### PR TITLE
chore(flake/nixpkgs): `9099616b` -> `1536926e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -208,11 +208,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709150264,
-        "narHash": "sha256-HofykKuisObPUfj0E9CJVfaMhawXkYx3G8UIFR/XQ38=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9099616b93301d5cf84274b184a3a5ec69e94e08",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`c90d5b6f`](https://github.com/NixOS/nixpkgs/commit/c90d5b6f2cbd4227b567ea1f3b1d54f102907d49) | `` python311Packages.google-cloud-kms: 2.20.0 -> 2.21.2 ``                       |
| [`47f5ac28`](https://github.com/NixOS/nixpkgs/commit/47f5ac28cf6a9b9876741a2cb4021f869996cd5d) | `` python311Packages.google-cloud-kms: 2.19.2 -> 2.20.0 ``                       |
| [`e433a5be`](https://github.com/NixOS/nixpkgs/commit/e433a5be1a7da3b15d45bcff62118ce2b4db5f2f) | `` python311Packages.google-cloud-bigquery-datatransfer: 3.14.1 -> 3.15.0 ``     |
| [`bf9da701`](https://github.com/NixOS/nixpkgs/commit/bf9da7015bba5490eeec987e2be5c35dd9ddc01c) | `` python311Packages.google-cloud-pubsub: 2.19.6 -> 2.19.7 ``                    |
| [`39805fbd`](https://github.com/NixOS/nixpkgs/commit/39805fbd8843201df0a112e2842bb8112c4240b3) | `` python311Packages.google-cloud-secret-manager: 2.18.1 -> 2.18.2 ``            |
| [`44c70a37`](https://github.com/NixOS/nixpkgs/commit/44c70a37071aff4360ff5453fb04e107680d1f70) | `` libgit2_1_5: drop ``                                                          |
| [`92c43b63`](https://github.com/NixOS/nixpkgs/commit/92c43b6345eb326c4ef203c054a70ce5adb7963c) | `` cargo-update: unpin libgit2 ``                                                |
| [`03351c06`](https://github.com/NixOS/nixpkgs/commit/03351c06983a1987f2d03122bcface55da67933d) | `` cargo-codspeed: unpin libgit2 ``                                              |
| [`2e25909a`](https://github.com/NixOS/nixpkgs/commit/2e25909a4961c1db831151fecc6b15613a4d7745) | `` cargo-audit: drop unused libgit2 dependency ``                                |
| [`ec23a91d`](https://github.com/NixOS/nixpkgs/commit/ec23a91dfce1879745ecc10a10bbacc241f9b37b) | `` git-mit: unpin libgit2 ``                                                     |
| [`bb82aa1c`](https://github.com/NixOS/nixpkgs/commit/bb82aa1c0cb619f89a7a66924797de1652d217e3) | `` git-dive: unpin libgit2 ``                                                    |
| [`4f428752`](https://github.com/NixOS/nixpkgs/commit/4f4287521b83d236c0ae6c6032220c22c8a96bdd) | `` projectable: unpin libgit2 ``                                                 |
| [`e2c7a97f`](https://github.com/NixOS/nixpkgs/commit/e2c7a97fac1dbd550173587a74510ca9d86fc1f9) | `` cargo-ui: unpin libgit2 ``                                                    |
| [`2159ca14`](https://github.com/NixOS/nixpkgs/commit/2159ca14d82e5b7992370a4155f007710b61cf96) | `` cargo-unused-features: unpin libgit2 ``                                       |
| [`49bb96ed`](https://github.com/NixOS/nixpkgs/commit/49bb96edf1804bb928345c976ee1e268f7fe9d26) | `` libgit2_1_3_0: drop ``                                                        |
| [`b9a613aa`](https://github.com/NixOS/nixpkgs/commit/b9a613aa8c020a423329df55e6a534068d7ec34c) | `` turbogit: make libgit2 override local to package ``                           |
| [`8042f624`](https://github.com/NixOS/nixpkgs/commit/8042f62417315a1a67c979c8495b73ee598b1046) | `` cargo-dephell: unpin libgit2 ``                                               |
| [`793ef7f7`](https://github.com/NixOS/nixpkgs/commit/793ef7f7fcf7cd2586847ccd31bc0db88cc6dce0) | `` libgit2_1_6: drop ``                                                          |
| [`0d974fc9`](https://github.com/NixOS/nixpkgs/commit/0d974fc94490be49c7909e897e35129ebfdd5a2a) | `` cargo-workspaces: drop unused libgit2 dependency ``                           |
| [`c46ca8c6`](https://github.com/NixOS/nixpkgs/commit/c46ca8c6bc6cb8256433b0cf9564900e8e7719ba) | `` cargo-generate: unpin libgit2 ``                                              |
| [`655cec4b`](https://github.com/NixOS/nixpkgs/commit/655cec4b6c40b3aa67c66472733e30c134c1e8c0) | `` biome: unpin libgit2 ``                                                       |
| [`2429bde8`](https://github.com/NixOS/nixpkgs/commit/2429bde882875d93c8461f2801879ef3fc668d20) | `` nix-init: unpin libgit2 ``                                                    |
| [`bc6d119b`](https://github.com/NixOS/nixpkgs/commit/bc6d119bd0615780470db760bc2cb24ee4583102) | `` libshumate: support cross compilation ``                                      |
| [`bf827773`](https://github.com/NixOS/nixpkgs/commit/bf82777340bcb9b01ebfc8e18994a67724ce78bb) | `` gopls: 0.15.0 -> 0.15.1, set meta.changelog (#292354) ``                      |
| [`c224745f`](https://github.com/NixOS/nixpkgs/commit/c224745fee0edaab5720e60aed52f4fba97aa74d) | `` python311Pakcages.griffe: refactor ``                                         |
| [`62552e36`](https://github.com/NixOS/nixpkgs/commit/62552e3683af9f67dd6cf7dc93c49c0e2a587550) | `` doc: update docs for portableService, follow doc conventions ``               |
| [`c73de6fa`](https://github.com/NixOS/nixpkgs/commit/c73de6fac35a264d7a95d0875c7d7075bcbfae0e) | `` doc: update docs in ociTools, follow doc conventions ``                       |
| [`9daae565`](https://github.com/NixOS/nixpkgs/commit/9daae56550c8883757d122c0fb1188f24ccfe7fd) | `` reptyr: disable tests ``                                                      |
| [`baae71c8`](https://github.com/NixOS/nixpkgs/commit/baae71c82109f67632911287bbc36252fe43eab1) | `` lib.fixedPoints: fix rendering of docs for `extends` ``                       |
| [`0a341999`](https://github.com/NixOS/nixpkgs/commit/0a3419997ef0fb9f26092a8b37a57547c8b3a908) | `` ffsubsync: refactor ``                                                        |
| [`9a2784c6`](https://github.com/NixOS/nixpkgs/commit/9a2784c65292ed59024b3b5c1e27cb70b44cd5fa) | `` outils: 0.10 -> 0.13 ``                                                       |
| [`50373904`](https://github.com/NixOS/nixpkgs/commit/50373904bc0e0784523b1ebf982d8e85f05fe1ba) | `` griffe: 0.40.1 -> 0.41.0 ``                                                   |
| [`c1a61df7`](https://github.com/NixOS/nixpkgs/commit/c1a61df7412184d0237eca3b02e9f2a14bbb2b78) | `` python312Packages.pydub: add patch to fix test assertions ``                  |
| [`b7da9254`](https://github.com/NixOS/nixpkgs/commit/b7da92542e26d5928a4eb06dd369ec2d41c02fbe) | `` python312Packages.types-aiobotocore: 2.11.2 -> 2.12.0 ``                      |
| [`36e51d7c`](https://github.com/NixOS/nixpkgs/commit/36e51d7cbfc920f3e51a5b234f0f35c4b03c8ba7) | `` sway: 1.8.1 -> 1.9.0 ``                                                       |
| [`2895734b`](https://github.com/NixOS/nixpkgs/commit/2895734ba7eda3f68f07b6c43c1747541dacd77b) | `` zcfan: 1.2.1 -> 1.3.0 ``                                                      |
| [`38eb9caf`](https://github.com/NixOS/nixpkgs/commit/38eb9caf24dc49fb1c5898632508b01b2868f3b1) | `` python311Packages.litellm: 1.27.4 -> 1.28.0 ``                                |
| [`95853731`](https://github.com/NixOS/nixpkgs/commit/95853731b24aad952dd0d0ac6b8539e53efe57aa) | `` python311Packages.pydub: refactor ``                                          |
| [`46581bb1`](https://github.com/NixOS/nixpkgs/commit/46581bb1b7fd65cfe7a6d44327f9799941ede45c) | `` ungoogled-chromium: 122.0.6261.69-1 -> 122.0.6261.94-1 ``                     |
| [`13c91f20`](https://github.com/NixOS/nixpkgs/commit/13c91f20396687dd94f73ec2f855ddb2c40449c9) | `` zim-tools: 3.3.0 -> 3.4.0 ``                                                  |
| [`5ff04ea7`](https://github.com/NixOS/nixpkgs/commit/5ff04ea7e143f411cdd4549509b641b1735f8291) | `` python311Packages.cssbeautifier: 1.14.11 -> 1.15.1 ``                         |
| [`7ef6e3a8`](https://github.com/NixOS/nixpkgs/commit/7ef6e3a859ae145b965e63864db3e31078157402) | `` python312Packages.snapcast: refactor ``                                       |
| [`28097f87`](https://github.com/NixOS/nixpkgs/commit/28097f87a250f6cf5806cd09600735a6173aa218) | `` dontgo403: refactor ``                                                        |
| [`c9352199`](https://github.com/NixOS/nixpkgs/commit/c93521999da29f2976aa88e41e98db91ee244ee1) | `` python311Packages.pymc: fix hash ``                                           |
| [`cf57c56b`](https://github.com/NixOS/nixpkgs/commit/cf57c56b881d5c81210584903399f33c92cf9f90) | `` alacritty-theme: unstable-2024-02-25 -> unstable-2024-02-28 ``                |
| [`8776076c`](https://github.com/NixOS/nixpkgs/commit/8776076cfa6863f2fd1305019eac2d43283946ad) | `` python311Packages.arviz: disable failing test ``                              |
| [`f4bbc00a`](https://github.com/NixOS/nixpkgs/commit/f4bbc00acbecd4cb97b5d074001c0cc48c4bcfdf) | `` python311Packages.aiounifi: 71 -> 72 ``                                       |
| [`da0b0fde`](https://github.com/NixOS/nixpkgs/commit/da0b0fdedd24dd0c65ff8ef3780b0ec3b0c38290) | `` pkgs/kde: set meta.platforms ``                                               |
| [`c34b1afc`](https://github.com/NixOS/nixpkgs/commit/c34b1afc6c47fdbbecc42472a38541c4db94a0ab) | `` python312Packages.opower: 0.3.1 -> 0.4.0 ``                                   |
| [`5674ac55`](https://github.com/NixOS/nixpkgs/commit/5674ac5599955691e834b1d94c1e697640d6ccd2) | `` python312Packages.mscerts: 2023.11.29 -> 2024.2.28 ``                         |
| [`77571191`](https://github.com/NixOS/nixpkgs/commit/7757119148dad39d640dd7c7868c62010854475f) | `` python312Packages.botocore-stubs: 1.34.50 -> 1.34.52 ``                       |
| [`9b9f8cc9`](https://github.com/NixOS/nixpkgs/commit/9b9f8cc9a1379eae4cc00c85faa95c0a4b2bc544) | `` python312Packages.boto3-stubs: 1.34.50 -> 1.34.52 ``                          |
| [`359cf2b2`](https://github.com/NixOS/nixpkgs/commit/359cf2b291087b49ead96a4131416ae924e116b8) | `` python312Packages.aioshelly: 8.0.2 -> 8.1.1 ``                                |
| [`7c2ed07a`](https://github.com/NixOS/nixpkgs/commit/7c2ed07aa66ebb1e0c977b32689a2d3c1476a2eb) | `` python312Packages.aiocsv: 1.3.0 -> 1.3.1 ``                                   |
| [`72af9e68`](https://github.com/NixOS/nixpkgs/commit/72af9e6863e93fb3904522c4525d44b8615a04f0) | `` python312Packages.adafruit-platformdetect: 3.60.0 -> 3.61.0 ``                |
| [`2918a03b`](https://github.com/NixOS/nixpkgs/commit/2918a03bc2cfc328399b53527e17c4bad5c94640) | `` python311Packages.yolink-api: refactor ``                                     |
| [`4a0d046d`](https://github.com/NixOS/nixpkgs/commit/4a0d046dba50b718c8610128e09939ad63a8a30f) | `` python311Packages.yolink-api: 0.3.8 -> 0.3.9 ``                               |
| [`f9601a89`](https://github.com/NixOS/nixpkgs/commit/f9601a89699eb4155f7212e0621a6fdc5c3cd45d) | `` python311Packages.types-html5lib: 1.1.11.20240222 -> 1.1.11.20240228 ``       |
| [`67e299d2`](https://github.com/NixOS/nixpkgs/commit/67e299d283d1ba7bb256833f836f1558fb7d8060) | `` python311Packages.types-beautifulsoup4: 4.12.0.20240106 -> 4.12.0.20240229 `` |
| [`e03caa7a`](https://github.com/NixOS/nixpkgs/commit/e03caa7a750afddf6df9e0f1a776f35f0635b65f) | `` python311Packages.dbt-redshift: 1.7.3 -> 1.7.4 ``                             |
| [`119fa58b`](https://github.com/NixOS/nixpkgs/commit/119fa58b0122e9fe77bb88b4cd581a35696dd61a) | `` nwg-panel: 0.9.24 -> 0.9.25 ``                                                |
| [`12f5d5fb`](https://github.com/NixOS/nixpkgs/commit/12f5d5fb107164d5c0daa95d9a2010457197e1c2) | `` vultr-cli: 3.0.0 -> 3.0.1 ``                                                  |
| [`08d19285`](https://github.com/NixOS/nixpkgs/commit/08d19285f6aec97f4857b4d0c8f55ee2bc5e1fda) | `` python311Packages.slack-sdk: 3.27.0 -> 3.27.1 ``                              |
| [`c623c418`](https://github.com/NixOS/nixpkgs/commit/c623c418da0b471587d9f616134f2ff0d45513d6) | `` python311Packages.twilio: 8.13.0 -> 9.0.0 ``                                  |
| [`d2fdc5ab`](https://github.com/NixOS/nixpkgs/commit/d2fdc5ab69278d89231d4f7de45cd98353901c8b) | `` trufflehog: 3.68.2 -> 3.68.3 ``                                               |
| [`035a438b`](https://github.com/NixOS/nixpkgs/commit/035a438bd80260aad2c343c4bee6080fccb8ee01) | `` python312Packages.pymicrobot: 0.0.18 -> 0.0.22 ``                             |
| [`452a974b`](https://github.com/NixOS/nixpkgs/commit/452a974bf4601ac141a5140018c6123944768cab) | `` python311Packages.cloudpathlib: 0.18.0 -> 0.18.1 ``                           |
| [`fd825615`](https://github.com/NixOS/nixpkgs/commit/fd825615991fe71912a0c5437fc60cde78c23733) | `` python311Packages.reptor: 0.9 -> 0.11 ``                                      |
| [`6244b6fc`](https://github.com/NixOS/nixpkgs/commit/6244b6fc47056621583e6e57af2fb46eb426d300) | `` eza: 0.18.4 -> 0.18.5 ``                                                      |
| [`086e6ed9`](https://github.com/NixOS/nixpkgs/commit/086e6ed9d9e204bd6e5254ccc29b28705efc7645) | `` suitesparse-graphblas: 9.0.1 -> 9.0.2 ``                                      |
| [`ea60665a`](https://github.com/NixOS/nixpkgs/commit/ea60665af57cd3d87444a4f0bf9b8ff75035d71c) | `` typeshare: 1.7.0 -> 1.8.0 ``                                                  |
| [`f80431b1`](https://github.com/NixOS/nixpkgs/commit/f80431b14717030da8ac76110ff7419d1161dafe) | `` nosql-workbench: unpack with 7zz ``                                           |
| [`94248807`](https://github.com/NixOS/nixpkgs/commit/942488076de27e968080a18d7ebad68a9609066a) | `` scitokens-cpp: 1.1.0 -> 1.1.1 ``                                              |
| [`89204b76`](https://github.com/NixOS/nixpkgs/commit/89204b76d5ff472fffac87f5ef070da970fa0c72) | `` signal-desktop: 6.48.1 -> 7.0.0 ``                                            |
| [`0b376ff6`](https://github.com/NixOS/nixpkgs/commit/0b376ff6e05a402fcad9a073725277784cc245e3) | `` python312Packages.snapcast: 2.3.3 -> 2.3.4 ``                                 |
| [`36533206`](https://github.com/NixOS/nixpkgs/commit/36533206c4acc663073bf5fbbca598070cdb91b4) | `` python311Packages.universal-silabs-flasher: 0.0.18 -> 0.0.19 ``               |
| [`9962afdd`](https://github.com/NixOS/nixpkgs/commit/9962afdd8c59a0f2c59725505f44bbea86286851) | `` qt6.qtbase: search PATH for plugins after search QT_PLUGIN_PATH ``            |
| [`57789e56`](https://github.com/NixOS/nixpkgs/commit/57789e56918f454069e7ed991276a184041cbd13) | `` prometheus-alertmanager: 0.26.0 -> 0.27.0 (#292230) ``                        |
| [`7f4946e1`](https://github.com/NixOS/nixpkgs/commit/7f4946e12588434a1f9ca52207ad8b79cf1103f7) | `` python312Packages.docstr-coverage: 2.3.0 -> 2.3.1 ``                          |
| [`6d1878e3`](https://github.com/NixOS/nixpkgs/commit/6d1878e3ebf7796cdb427e088546b126599bbc5f) | `` python312Packages.clickhouse-connect: 0.7.0 -> 0.7.1 ``                       |
| [`5d232458`](https://github.com/NixOS/nixpkgs/commit/5d232458f6712d09d5fb37006bd65ea2e7473f7e) | `` python312Packages.cheetah3: 3.3.3 -> 3.3.3.post1 ``                           |
| [`07d03a8a`](https://github.com/NixOS/nixpkgs/commit/07d03a8a4adea33ac9b3919902685ef7c9f8303a) | `` mpvScripts.mpv-playlistmanager: unstable-2023-11-28 -> unstable-2024-02-26 `` |
| [`dfbc49a5`](https://github.com/NixOS/nixpkgs/commit/dfbc49a58a64ab1386ff2e2d983ed84989688c4d) | `` fcitx5-with-addons: include both fcitx5-qt5 and fcitx5-qt6 ``                 |
| [`6479f63e`](https://github.com/NixOS/nixpkgs/commit/6479f63ecb8c8649f78e91b12c079b387686bc73) | `` qt6Packages.fcitx5-qt: init ``                                                |
| [`c29ae2c8`](https://github.com/NixOS/nixpkgs/commit/c29ae2c846e0d6dcfb2b8fc3699b2fa36e184f38) | `` ocamlPackages.caqti: 1.9.1 → 2.1.1 ``                                         |
| [`5a9fe45b`](https://github.com/NixOS/nixpkgs/commit/5a9fe45b5293bb3eefb3625394e93ba01118ef5a) | `` python311Packages.dbt-core: 1.7.8 -> 1.7.9 ``                                 |
| [`fa75f6e1`](https://github.com/NixOS/nixpkgs/commit/fa75f6e1a14035d63f0d7423fe8c7a642c1c91d5) | `` pure-prompt: 1.22.0 -> 1.23.0 ``                                              |
| [`672dc0d3`](https://github.com/NixOS/nixpkgs/commit/672dc0d3b5298c6b317d67c3e60b504cf76855f9) | `` lxgw-neoxihei: 1.110 -> 1.120 ``                                              |
| [`520909ab`](https://github.com/NixOS/nixpkgs/commit/520909ab4bad74101d061f1f312cfc4ac9b02100) | `` ibus-engines.anthy: 1.5.15 -> 1.5.16 ``                                       |
| [`9264ef15`](https://github.com/NixOS/nixpkgs/commit/9264ef15eb2cd9b6fcc3f30033516da2a6fbd55a) | `` goawk: 1.25.0 -> 1.26.0 ``                                                    |
| [`7a11e15a`](https://github.com/NixOS/nixpkgs/commit/7a11e15a39e2caec122cd7bed91f98c85d0874cb) | `` fulcio: 1.4.3 -> 1.4.4 ``                                                     |
| [`4de4c48b`](https://github.com/NixOS/nixpkgs/commit/4de4c48b392fb105f0ae4b5457ca4092a7c48dfc) | `` faketty: 1.0.15 -> 1.0.16 ``                                                  |
| [`e114f3d3`](https://github.com/NixOS/nixpkgs/commit/e114f3d3ce616ef75a8769cd7555886e7687bf6f) | `` exportarr: 1.6.1 -> 1.6.2 ``                                                  |
| [`121288e1`](https://github.com/NixOS/nixpkgs/commit/121288e133cf69930c82177abc89dd2cd9832ae2) | `` cirrus-cli: 0.112.0 -> 0.112.1 ``                                             |
| [`46573fb9`](https://github.com/NixOS/nixpkgs/commit/46573fb9317e7f7fa505586c2d1873f9a22fba80) | `` checkSSLCert: 2.79.0 -> 2.80.0 ``                                             |
| [`603c5af5`](https://github.com/NixOS/nixpkgs/commit/603c5af51927b04fede367b5edc03d7f3fea0d85) | `` nixos/tests/searx: use configured package for static content ``               |
| [`3330e3c9`](https://github.com/NixOS/nixpkgs/commit/3330e3c9c389ef5423ddae1eeff37d71b24f3efa) | `` nixos/searx: use lib.getExe ``                                                |
| [`cc745d76`](https://github.com/NixOS/nixpkgs/commit/cc745d76ca1ec63912047d85ec5acdf6eac56230) | `` brev-cli: 0.6.276 -> 0.6.277 ``                                               |
| [`4e0588db`](https://github.com/NixOS/nixpkgs/commit/4e0588db5cbf8981274529c98bc44e6d32c7674c) | `` python311Packages.ibm-cloud-sdk-core: 3.19.1 -> 3.19.2 ``                     |
| [`8f0ce838`](https://github.com/NixOS/nixpkgs/commit/8f0ce83807107efd3d483b816efa9b4336833556) | `` mfcj880dw: init at 1.0.0-1 ``                                                 |
| [`5c74739a`](https://github.com/NixOS/nixpkgs/commit/5c74739ab5d5e4745bdd4095fdc8e37766ba443b) | `` maintainers: add 6543 ``                                                      |
| [`03173009`](https://github.com/NixOS/nixpkgs/commit/03173009d5d54fa4899c947c8a65e19d338b51df) | `` llama-cpp: 2249 -> 2294; bring upstream flake ``                              |
| [`6aa4ed44`](https://github.com/NixOS/nixpkgs/commit/6aa4ed448704ab8acd5a57a607e3489710aa358a) | `` applyPatches: Fix a bug (#283887) ``                                          |
| [`34c5cc74`](https://github.com/NixOS/nixpkgs/commit/34c5cc74a18c10c04d55a67f916151c98337e6d0) | `` systemd: fix propagation of upheldBy option to units ``                       |
| [`b04dc42b`](https://github.com/NixOS/nixpkgs/commit/b04dc42ba8daee4651d5bdd4c8e0d1d91b5b435e) | `` uiua: add meta.updateScript ``                                                |
| [`c669777f`](https://github.com/NixOS/nixpkgs/commit/c669777f45c259472e20986ed61ef2dc38dce295) | `` vscode-extensions.uiua-lang.uiua-vscode: 0.0.27 -> 0.0.39 ``                  |
| [`240d588c`](https://github.com/NixOS/nixpkgs/commit/240d588cb33d05b8f01cd1e012b85be0d284ca96) | `` uiua: 0.8.0 -> 0.9.5 ``                                                       |
| [`cd5dc76d`](https://github.com/NixOS/nixpkgs/commit/cd5dc76d8340c38487d1b48a3ba090683fa35493) | `` substitute: Deprecate `replacements`, introduce `replacementsList` ``         |
| [`0822949d`](https://github.com/NixOS/nixpkgs/commit/0822949d9cc0fc7711baf11ae93479641eb2030c) | `` python311Packages.oslo-concurrency: 5.3.0 -> 6.0.0 ``                         |
| [`34d173ce`](https://github.com/NixOS/nixpkgs/commit/34d173ce85439b04e7ffb122c8d795f6c3a02788) | `` searxng: set meta.mainProgram ``                                              |