### PR TITLE
chore(flake/nixpkgs): `9df3e30c` -> `3030f185`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -208,11 +208,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709703039,
-        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
+        "lastModified": 1709961763,
+        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
+        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`1b7d1bd6`](https://github.com/NixOS/nixpkgs/commit/1b7d1bd6e1d6297d785f4c20a906a155be7b6ed3) | `` python311Packages.guidance: 0.1.6 -> 0.1.11 ``                                      |
| [`7a2394e7`](https://github.com/NixOS/nixpkgs/commit/7a2394e7926a16d9d3c43936734553827273ef8b) | `` python311Packages.anywidget: 0.9.2 -> 0.9.3 ``                                      |
| [`553e34df`](https://github.com/NixOS/nixpkgs/commit/553e34dfd6d63e576822c64266d2f4ffdacbe51e) | `` python311Packages.minio: 7.2.4 -> 7.2.5 ``                                          |
| [`6ca85622`](https://github.com/NixOS/nixpkgs/commit/6ca856220afde1fa658dbcd725340d4e9885abc9) | `` littlefs-fuse: 2.7.5 -> 2.7.6 ``                                                    |
| [`659b0549`](https://github.com/NixOS/nixpkgs/commit/659b05493104c056ef6b9ab5ac0ee9c55cc8adee) | `` grpc_cli: 1.62.0 -> 1.62.1 ``                                                       |
| [`d616b59f`](https://github.com/NixOS/nixpkgs/commit/d616b59f557388d6703d3b345b0cb52ca43172ef) | `` chamber: 2.14.0 -> 2.14.1 ``                                                        |
| [`82898955`](https://github.com/NixOS/nixpkgs/commit/82898955e2c88cce35022581df78ca223c406251) | `` python311Packages.chromedb: allow local networking on darwin ``                     |
| [`cfef06f5`](https://github.com/NixOS/nixpkgs/commit/cfef06f5c4db47c55ee4818ce02698209ef42609) | `` python311Packages.opentelemetry-util-http: 0.43b0 -> 0.44b0 ``                      |
| [`32b24345`](https://github.com/NixOS/nixpkgs/commit/32b24345277cdf77c0a060584cc1d7f0981756ed) | `` python311Packages.opentelemetry-instrumentation-wsgi: 0.43b0 -> 0.44b0 ``           |
| [`2dba2d7c`](https://github.com/NixOS/nixpkgs/commit/2dba2d7c21297abb1300a3150426b3527fd2c4f3) | `` python311Packages.opentelemetry-instrumentation-grpc: 0.43b0 -> 0.44b0 ``           |
| [`f242db71`](https://github.com/NixOS/nixpkgs/commit/f242db71c9fd8d04e9f937f4fc860dffaf7dd9a3) | `` python311Packages.opentelemetry-instrumentation-flask: 0.43b0 -> 0.44b0 ``          |
| [`cb4a763b`](https://github.com/NixOS/nixpkgs/commit/cb4a763b662c1e97f94b0e2c2dfcddf0a557c062) | `` python311Packages.opentelemetry-instrumentation-fastapi: 0.43b0 -> 0.44b0 ``        |
| [`76d6fa55`](https://github.com/NixOS/nixpkgs/commit/76d6fa55c84f56b007379a53f5ce63cd9191fd40) | `` python311Packages.opentelemetry-instrumentation-django: 0.43b0 -> 0.44b0 ``         |
| [`f3209f12`](https://github.com/NixOS/nixpkgs/commit/f3209f125f3f3aaf77d8f05333a82660d5471b2b) | `` python311Packages.opentelemetry-instrumentation-asgi: 0.43b0 -> 0.44b0 ``           |
| [`d83e6337`](https://github.com/NixOS/nixpkgs/commit/d83e6337d529cbd5f33fe13fd6f0aa150ed0da27) | `` python311Packages.opentelemetry-instrumentation-aiohttp-client: 0.43b0 -> 0.44b0 `` |
| [`4d988611`](https://github.com/NixOS/nixpkgs/commit/4d9886114f8ed2af9133ec1f6ee9701541c6f073) | `` python311Packages.opentelemetry-instrumentation: 0.43b0 -> 0.44b0 ``                |
| [`b1a9c453`](https://github.com/NixOS/nixpkgs/commit/b1a9c453103efc91b24c62363d427f7829ba5111) | `` agkozak-zsh-prompt: 3.11.2 -> 3.11.3 ``                                             |
| [`53841109`](https://github.com/NixOS/nixpkgs/commit/538411090b8595e63babade0cb4b966f188363e7) | `` python311Packages.opentelemetry-test-utils: 1.22.0 -> 0.44b0 ``                     |
| [`461f3c17`](https://github.com/NixOS/nixpkgs/commit/461f3c17156112e1b9b7a1f0c0da89b1ffdbb88a) | `` python311Packages.opentelemetry-semantic-conventions: 1.22.0 -> 0.44b0 ``           |
| [`b24a7f8b`](https://github.com/NixOS/nixpkgs/commit/b24a7f8b416a3d398efc5f6f7c9910f7697bad33) | `` python311Packages.opentelemetry-sdk: 1.22.0 -> 1.23.0 ``                            |
| [`2065c54c`](https://github.com/NixOS/nixpkgs/commit/2065c54ca3ebc65333fcf209b60ca5c99939204f) | `` python311Packages.opentelemetry-proto: 1.22.0 -> 1.23.0 ``                          |
| [`21fd95be`](https://github.com/NixOS/nixpkgs/commit/21fd95be7d5791c54cdf338d936351a2f65f317e) | `` python311Packages.opentelemetry-exporter-prometheus: 1.22.0 -> 0.44b0 ``            |
| [`c9eb088b`](https://github.com/NixOS/nixpkgs/commit/c9eb088b0e18f3e535668544a77693b6ebae1e8f) | `` python311Packages.opentelemetry-exporter-otlp-proto-http: 1.22.0 -> 1.23.0 ``       |
| [`7f821539`](https://github.com/NixOS/nixpkgs/commit/7f821539ac82c8dee431193105f420ac54bdc7f8) | `` python311Packages.opentelemetry-exporter-otlp-proto-grpc: 1.22.0 -> 1.23.0 ``       |
| [`65254c32`](https://github.com/NixOS/nixpkgs/commit/65254c32c608ebda29ad0a516f9e6c52f0bf69e4) | `` python311Packages.opentelemetry-exporter-otlp-proto-common: 1.22.0 -> 1.23.0 ``     |
| [`e6570c57`](https://github.com/NixOS/nixpkgs/commit/e6570c57c354d8a53ab56fe7260f9cb0245d4d0e) | `` python311Packages.opentelemetry-exporter-otlp: 1.22.0 -> 1.23.0 ``                  |
| [`cb103d5f`](https://github.com/NixOS/nixpkgs/commit/cb103d5f14009770fe4922c70d566a196692e162) | `` python311Packages.opentelemetry-api: 1.22.0 -> 1.23.0 ``                            |
| [`20acfe37`](https://github.com/NixOS/nixpkgs/commit/20acfe375abeac1d00d2be8862694ddffbf98ed3) | `` convco: 0.5.0 -> 0.5.1 ``                                                           |
| [`53d9101d`](https://github.com/NixOS/nixpkgs/commit/53d9101d8d75dafdb08971a694691a7bd589c6c7) | `` flexget: 3.11.21 -> 3.11.22 ``                                                      |
| [`69412ced`](https://github.com/NixOS/nixpkgs/commit/69412cedd728c81170ddbc6819eecc18a100df1f) | `` python311Packages.bless: refactor ``                                                |
| [`2f222445`](https://github.com/NixOS/nixpkgs/commit/2f2224456a3d498e92d9cb49738ed79b3b182f56) | `` zsync: migrate to by-name ``                                                        |
| [`8f41fb68`](https://github.com/NixOS/nixpkgs/commit/8f41fb68ff7443836f280323674a6a4a5e7fa0a3) | `` zsync: fix build with clang ``                                                      |
| [`eef817b5`](https://github.com/NixOS/nixpkgs/commit/eef817b55e176e0dcf00bfad1eefce766331e103) | `` python311Packages.bless: 0.2.5 -> 0.2.6 ``                                          |
| [`60145c2f`](https://github.com/NixOS/nixpkgs/commit/60145c2f12ffff5d88b3d3a981eefee1b7767c19) | `` git-releaser: 0.1.3 -> 0.1.6 ``                                                     |
| [`af147603`](https://github.com/NixOS/nixpkgs/commit/af147603cfd2096bb3c9e00e0106200d548d3c3f) | `` metasploit: 6.3.58 -> 6.3.59 ``                                                     |
| [`891ee492`](https://github.com/NixOS/nixpkgs/commit/891ee4927200605b1602ca0d946ef3f8d84fb56a) | `` python311Packages.google-cloud-container: 2.41.0 -> 2.43.0 ``                       |
| [`34093f4f`](https://github.com/NixOS/nixpkgs/commit/34093f4fa8b1b0ccb58f1f4f1532823c33c9d970) | `` beeper: 3.98.16 -> 3.99.22 ``                                                       |
| [`2038c77b`](https://github.com/NixOS/nixpkgs/commit/2038c77b0bcd6ebe35617ea05dee86a7ee98f3f6) | `` gpxsee: 13.16 -> 13.17 ``                                                           |
| [`9e53c1e8`](https://github.com/NixOS/nixpkgs/commit/9e53c1e876d8de692d92cb69b8d28f4910327e9b) | `` wttrbar: 0.8.2 -> 0.9.0 ``                                                          |
| [`2bbfc235`](https://github.com/NixOS/nixpkgs/commit/2bbfc235467466b195c755e2516305a83d1e2c11) | `` go-task: 3.35.0 -> 3.35.1 ``                                                        |
| [`921210c8`](https://github.com/NixOS/nixpkgs/commit/921210c8779364397f1cb5fda155c5b94cd9ebff) | `` sesh: init at 0.12.0 ``                                                             |
| [`c339d2e2`](https://github.com/NixOS/nixpkgs/commit/c339d2e256ae55d27ff677a93ef7451d9f589121) | `` evcc: 0.124.7 -> 0.124.8 ``                                                         |
| [`ff80a002`](https://github.com/NixOS/nixpkgs/commit/ff80a002ee244cb10e228bff214d2d52f2c6af41) | `` treewide: remove ThomasMader as maintainer from Dlang packages (#291338) ``         |
| [`95658590`](https://github.com/NixOS/nixpkgs/commit/95658590c6cf17be61adf44254f6a809c33c17e1) | `` cosmic-applibrary: unstable-2024-01-03 -> 0-unstable-2024-02-09 (#288987) ``        |
| [`3cb8ac5d`](https://github.com/NixOS/nixpkgs/commit/3cb8ac5dc461aa82c8e5704fa65ac0a63dc476b5) | `` scala-cli: 1.1.3 -> 1.2.0 ``                                                        |
| [`e0763a61`](https://github.com/NixOS/nixpkgs/commit/e0763a61ab0ec8b425ea35b0459a6555da9079d2) | `` abcmidi: 2024.03.02 -> 2024.03.05 ``                                                |
| [`11907c59`](https://github.com/NixOS/nixpkgs/commit/11907c593abc7eb4e2334692238cf916828fcb00) | `` hyprlang: 0.4.1 -> 0.5.0 ``                                                         |
| [`a9109b9c`](https://github.com/NixOS/nixpkgs/commit/a9109b9c1e1e3fa09096af562bf676cc1dd8a22f) | `` svdtools: 0.3.10 -> 0.3.11 ``                                                       |
| [`f2596237`](https://github.com/NixOS/nixpkgs/commit/f25962377f3d9259c7da9027b29617c8d867c697) | `` storj-uplink: 1.99.1 -> 1.99.3 ``                                                   |
| [`05b35434`](https://github.com/NixOS/nixpkgs/commit/05b354348e8b4f549e92b2ac0e5032d1a42e85a0) | `` ruplacer: 0.8.2 -> 0.8.3 ``                                                         |
| [`93aafcf1`](https://github.com/NixOS/nixpkgs/commit/93aafcf1fb86462cceabc57643cd4ba3bea75552) | `` linuxPackages.nvidiaPackages.vulkan_beta: 550.40.53 -> 550.40.55 ``                 |
| [`25f5537d`](https://github.com/NixOS/nixpkgs/commit/25f5537d622bc6cb71b75c023bc176f00c95a427) | `` python312Packages.recipe-scrapers: 14.54.0 -> 14.55.0 ``                            |
| [`4e3ae720`](https://github.com/NixOS/nixpkgs/commit/4e3ae720d088714b3b2952ee64ae7a42fdbe6d29) | `` python312Packages.linknlink: 0.1.9 -> 0.2.0 ``                                      |
| [`2337837b`](https://github.com/NixOS/nixpkgs/commit/2337837bfc863d8f51ed106edc1368d5eea4f22c) | `` python312Packages.keyring-pass: 0.9.2 -> 0.9.3 ``                                   |
| [`7c444ebc`](https://github.com/NixOS/nixpkgs/commit/7c444ebc5bea0c0dbee8097334c167355a31f5b3) | `` ton: 2024.01 -> 2024.02 ``                                                          |
| [`e27ddbd1`](https://github.com/NixOS/nixpkgs/commit/e27ddbd1cf7ddc8aaa034a508d239ad8b3e241a2) | `` python312Packages.clickhouse-connect: 0.7.1 -> 0.7.2 ``                             |
| [`fd35ba6c`](https://github.com/NixOS/nixpkgs/commit/fd35ba6cadbb06a95b0f21c82e6b98ca399a649e) | `` cmctl: 1.14.3 -> 1.14.4 ``                                                          |
| [`2876de89`](https://github.com/NixOS/nixpkgs/commit/2876de899173d3117e710fc5a8bf703176f5d427) | `` linuxKernel.kernels.linux_lqx: 6.7.6-lqx1 -> 6.7.9-lqx1 ``                          |
| [`a97c56c4`](https://github.com/NixOS/nixpkgs/commit/a97c56c47e29d6ff6fd8b5341ad3d0c4b6c3e909) | `` Revert "python311Packages.kubernetes: 28.1.0 -> 29.0.0" ``                          |
| [`349d8e0c`](https://github.com/NixOS/nixpkgs/commit/349d8e0c5c276d7d9a8ad1829465c8d532127538) | `` linuxKernel.kernels.linux_zen: 6.7.7-zen1 -> 6.7.9-zen1 ``                          |
| [`7e90be2a`](https://github.com/NixOS/nixpkgs/commit/7e90be2a25599dbb349661033c1a5bcc5dda96d2) | `` nom: 2.1.3 -> 2.1.4 ``                                                              |
| [`ff248e39`](https://github.com/NixOS/nixpkgs/commit/ff248e39167590597817f509347e9b7d506ef6f3) | `` infisical: 0.17.1 -> 0.18.0 ``                                                      |
| [`dfb956db`](https://github.com/NixOS/nixpkgs/commit/dfb956dbe903d851e5f2f70784f80d5051350de7) | `` maintainers: add daniel-fahey ``                                                    |
| [`fc88a67b`](https://github.com/NixOS/nixpkgs/commit/fc88a67b54bce990243d3dcd147e94c5d7a76636) | `` sentry-native: 0.6.7 -> 0.7.0 ``                                                    |
| [`f51256cc`](https://github.com/NixOS/nixpkgs/commit/f51256cc653ce13d174addbd032fbd014972a81f) | `` python311Packages.mlflow: use pyproject format ``                                   |
| [`6e2a59e5`](https://github.com/NixOS/nixpkgs/commit/6e2a59e5afe94ac0bdf61d2774072b9fbbd7d91b) | `` python311Packages.mlflow: 2.10.2 -> 2.11.1 ``                                       |
| [`2a1cd0b4`](https://github.com/NixOS/nixpkgs/commit/2a1cd0b439b113052b149bfa107980fec09906f4) | `` treewide: remove gst-plugins-good missing libsoup_3 workaround ``                   |
| [`a51e98b1`](https://github.com/NixOS/nixpkgs/commit/a51e98b174cdae3abc548b698abf162e655b7b47) | `` knock: init at 0.0.2 (#294140) ``                                                   |
| [`aa45bdd5`](https://github.com/NixOS/nixpkgs/commit/aa45bdd5d6e25d1d12670d9f9003f8ccbb6b5e00) | `` ytdownloader: init at 3.17.3 ``                                                     |
| [`ec6a140f`](https://github.com/NixOS/nixpkgs/commit/ec6a140f82d73b6ce9c9884ad07c8761e8e29452) | `` mokutil: 0.7.0 -> 0.7.1 ``                                                          |
| [`7b58179a`](https://github.com/NixOS/nixpkgs/commit/7b58179a77b34df648c31e4fec905d33229fe5da) | `` evcc: 0.124.6 -> 0.124.7 ``                                                         |
| [`17a79537`](https://github.com/NixOS/nixpkgs/commit/17a795370d0402b272d5d089054f0dd42e6c81dc) | `` python311Packages.aionotion: refactor ``                                            |
| [`7764fc53`](https://github.com/NixOS/nixpkgs/commit/7764fc53357084b8e9c4704a5559276488f22571) | `` nixos/lib/test-driver: fix mypy errors after staging-next merge ``                  |
| [`4c3ed8ae`](https://github.com/NixOS/nixpkgs/commit/4c3ed8aeba691c8491f6a25f51d484b0d769effe) | `` python311Packages.aionotion: 2024.02.2 -> 2024.03.0 ``                              |
| [`69aff002`](https://github.com/NixOS/nixpkgs/commit/69aff002d3b8da0f4e8fb73107ef1f46c96b9aa7) | `` python311Packages.pymodbus: 3.6.5 -> 3.6.6 ``                                       |
| [`b9d6b930`](https://github.com/NixOS/nixpkgs/commit/b9d6b9303b3ab9ed1ea526e8db485298afee8297) | `` bearer: 1.40.1 -> 1.41.0 ``                                                         |
| [`2a52e1df`](https://github.com/NixOS/nixpkgs/commit/2a52e1df8cf13b7da13da0e9fdc4e2fa9f57d7dc) | `` python311Packages.axis: refactor ``                                                 |
| [`9ad8af59`](https://github.com/NixOS/nixpkgs/commit/9ad8af59f5ad08ec16ec37b7a1cb9b6455c32131) | `` python311Packages.sagemaker: 2.210.0 -> 2.212.0 ``                                  |
| [`fd7454bd`](https://github.com/NixOS/nixpkgs/commit/fd7454bdde32e33c16d8a159e4d8e725a9fb546e) | `` home-manager: 0-unstable-2024-02-24 -> 0-unstable-2024-03-06 ``                     |
| [`7b8d88fa`](https://github.com/NixOS/nixpkgs/commit/7b8d88fa059d2a945e17c800d4f2bbc958755e5c) | `` nixos/steam: fix eval after #293564 ``                                              |
| [`26c09016`](https://github.com/NixOS/nixpkgs/commit/26c09016b9008a566042956530c03cfb27816a7d) | `` modules/steam: transfer maintainership to steam team ``                             |
| [`fc9de9a6`](https://github.com/NixOS/nixpkgs/commit/fc9de9a6f2396fccb7db25f7bff61cbcbc7990ed) | `` teams.steam: add - ref #289561 ``                                                   |
| [`e0008b48`](https://github.com/NixOS/nixpkgs/commit/e0008b48c915f3973d1785cf7166363680caedfe) | `` python3Packages.debugpy: disable tests on *-linux (for now) ``                      |
| [`ba38c5cc`](https://github.com/NixOS/nixpkgs/commit/ba38c5cc048c3fdba0fa7ae58426b86ff765f576) | `` cnspec: go set to 1.22 ``                                                           |
| [`46191f4b`](https://github.com/NixOS/nixpkgs/commit/46191f4b76e799d0fffd9e73f7e6de1bda30d1b9) | `` cnspec: 10.2.0 -> 10.6.1 ``                                                         |
| [`8bcf60e9`](https://github.com/NixOS/nixpkgs/commit/8bcf60e90f75607ff918f7b3159c7e96e2f97a0c) | `` trufflehog: 3.68.5 -> 3.69.0 ``                                                     |
| [`e4b660b6`](https://github.com/NixOS/nixpkgs/commit/e4b660b63cf41f05b53e9294ed5e0326e99e053f) | `` python311Packages.types-docutils: 0.20.0.20240304 -> 0.20.0.20240308 ``             |
| [`c14c2231`](https://github.com/NixOS/nixpkgs/commit/c14c22314075609b9e2395168f800aa6a162c9c8) | `` python311Packages.bc-detect-secrets: refactor ``                                    |
| [`459ac609`](https://github.com/NixOS/nixpkgs/commit/459ac609d575ebaa690a1bd56f8431311cc89bb1) | `` python311Packages.bc-detect-secrets: 1.5.1 -> 1.5.4 ``                              |