### PR TITLE
chore(flake/pre-commit-hooks): `e8dc1b4f` -> `c182c876`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -148,11 +148,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -355,11 +355,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710843117,
-        "narHash": "sha256-b6iKQeHegzpc697rxTPA3bpwGN3m50eLCgdQOmceFuE=",
+        "lastModified": 1715609711,
+        "narHash": "sha256-/5u29K0c+4jyQ8x7dUIEUWlz2BoTSZWUP2quPwFCE7M=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e8dc1b4fe80c6fcededde7700e6a23bcdf7f3347",
+        "rev": "c182c876690380f8d3b9557c4609472ebfa1b141",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`a741bc6e`](https://github.com/cachix/git-hooks.nix/commit/a741bc6e926abaf9d4dbd65b28a1f0a82d92078b) | `` flake-parts: add enabledPackages to shell ``                               |
| [`091eaa3a`](https://github.com/cachix/git-hooks.nix/commit/091eaa3a4130a2d447901e4f14a2b0f061fcd90e) | `` Fix and document lacheck hook ``                                           |
| [`f0dcdc1b`](https://github.com/cachix/git-hooks.nix/commit/f0dcdc1b204360250028d6496e265a73049b0e14) | `` Update modules/hooks.nix ``                                                |
| [`9052a48b`](https://github.com/cachix/git-hooks.nix/commit/9052a48b2ad895e0cb3d28d874fe1d423566bd54) | `` refactor: move `rec` keyword to minimize formatting impact ``              |
| [`bf98b7f1`](https://github.com/cachix/git-hooks.nix/commit/bf98b7f1d0983c091376d5191994d29927d51075) | `` feat: add deprecation warning for `rome` hook ``                           |
| [`f3a2deee`](https://github.com/cachix/git-hooks.nix/commit/f3a2deee819fe462affd678758c969ec4516923e) | `` Remove packageOverrides from the base hook module ``                       |
| [`c4e3cd4c`](https://github.com/cachix/git-hooks.nix/commit/c4e3cd4ca89d60be6c6e9b7338e9e3442266000b) | `` Add Flake Checker ``                                                       |
| [`bc5491d5`](https://github.com/cachix/git-hooks.nix/commit/bc5491d571291052763e34dde78155f59f70e0eb) | `` `config` -> `config.settings` ``                                           |
| [`8f2d990b`](https://github.com/cachix/git-hooks.nix/commit/8f2d990b994d242f53fd725b50ec8ef9a4d8c512) | `` refactor: deprecate `rome` with `mkRenamedOptionModule` ``                 |
| [`d2b7a5b4`](https://github.com/cachix/git-hooks.nix/commit/d2b7a5b4b8e1ecfd12cedd2e4a4de01bd5a7b5aa) | `` fix: alias rome to biome without formatting ``                             |
| [`ba2d5199`](https://github.com/cachix/git-hooks.nix/commit/ba2d51990f42e4c48e3390d138bb072ac29b5fa9) | `` revert: "fix: alias "rome" to "biome"" ``                                  |
| [`59d884a4`](https://github.com/cachix/git-hooks.nix/commit/59d884a4487bbf6347223977463b72e1cd3fb08c) | `` fix(alejandra): one `--exclude` flag per file ``                           |
| [`05c3a4ea`](https://github.com/cachix/git-hooks.nix/commit/05c3a4eaf1ac8f564b8c6aae34912996cd7c551b) | `` fix: alias "rome" to "biome" ``                                            |
| [`a6538a8d`](https://github.com/cachix/git-hooks.nix/commit/a6538a8d3d4cdde13a5b8d4a11c6db2262703596) | `` feat: create "biome" hook ``                                               |
| [`00a90e7b`](https://github.com/cachix/git-hooks.nix/commit/00a90e7bbaffeeecc05a1c8ba814d9edeec84701) | `` Add `extraPackages` for `clippy`, `rustfmt`, `dune-fmt` ``                 |
| [`dc1ffda6`](https://github.com/cachix/git-hooks.nix/commit/dc1ffda6986db8c2ef49e361a1dfb0e800f51083) | `` Add `extraPackages` option for packages propagated to `enabledPackages` `` |
| [`5069220c`](https://github.com/cachix/git-hooks.nix/commit/5069220c7f47ff139c7c1b01b6996684859d838b) | `` Add lacheck hook ``                                                        |
| [`6c2316d1`](https://github.com/cachix/git-hooks.nix/commit/6c2316d1b2903cecc3692b6b75fdf078e735ebcd) | `` Filter out nulls from enabledPackages ``                                   |
| [`eb9778d3`](https://github.com/cachix/git-hooks.nix/commit/eb9778d3a17b192708d2c8da2ce0f22be5e465b3) | `` Set the default hook package to null ``                                    |
| [`9715094e`](https://github.com/cachix/git-hooks.nix/commit/9715094e7af77f3090b11a43fa43c978a3f4d610) | `` Fix reference to renamed option ``                                         |
| [`649fb51d`](https://github.com/cachix/git-hooks.nix/commit/649fb51def9772b420737dae9cf7289af80f0a8b) | `` add installation test ``                                                   |
| [`f3bb9549`](https://github.com/cachix/git-hooks.nix/commit/f3bb95498eaaa49a93bacaf196cdb6cf8e872cdf) | `` Fix link to docs ``                                                        |
| [`8ae5bb63`](https://github.com/cachix/git-hooks.nix/commit/8ae5bb63f9bcd0472b67cf4ada414ae37f1f2bcc) | `` Update hook module import for default hooks ``                             |
| [`cc709e51`](https://github.com/cachix/git-hooks.nix/commit/cc709e51ce0dfaac452dbacbd4c5a9b40e89c79f) | `` refactor: DRY hookModule and upgrade to option ``                          |
| [`054c86ce`](https://github.com/cachix/git-hooks.nix/commit/054c86ce12e439240292d086a66a243c7d714fc7) | `` flake-module.nix: Update comment ``                                        |
| [`0d676ca9`](https://github.com/cachix/git-hooks.nix/commit/0d676ca9ca9df7f2d4d5fb0de511fed3a4b67fdf) | `` free up space on ci ``                                                     |
| [`5da7bab7`](https://github.com/cachix/git-hooks.nix/commit/5da7bab7c34586b8a0a8c397d8c6b257fcceb96e) | `` Fix `nix flake check` on macOS ``                                          |
| [`dc6812ea`](https://github.com/cachix/git-hooks.nix/commit/dc6812ea2c8a21cca091ecb9ae0433d89e03efe4) | `` Silence git commit summary ``                                              |
| [`6c48d19a`](https://github.com/cachix/git-hooks.nix/commit/6c48d19a93ed6891c6d99cdcc1f712917a763622) | `` Silence git default branch warning ``                                      |
| [`34fdf24f`](https://github.com/cachix/git-hooks.nix/commit/34fdf24f3e6b144c2dde7e7af605160cf477277e) | `` Add warnings for changed modules ``                                        |
| [`f94f8e27`](https://github.com/cachix/git-hooks.nix/commit/f94f8e27c38cacc906941063c66ac709014a7215) | `` Remove shadowing of `config` attribute in hooks ``                         |
| [`54189ae4`](https://github.com/cachix/git-hooks.nix/commit/54189ae45d1ced5bdc19c02ccdb36aacb67e6ef2) | `` Extend `yamllint` hook with more options ``                                |
| [`d2f6f937`](https://github.com/cachix/git-hooks.nix/commit/d2f6f9376c38fb0c48526720793a17f10cd3ac10) | `` Add `package` options for hooks ``                                         |
| [`6caf5b27`](https://github.com/cachix/git-hooks.nix/commit/6caf5b27b7ef4ce9746a8ec08592c609ccde34a2) | `` Fix sort-file-contents description ``                                      |
| [`c6189c3d`](https://github.com/cachix/git-hooks.nix/commit/c6189c3db3343985cdb5223b12b920172ee22b03) | `` Revert unintended changes ``                                               |
| [`73a4e8d7`](https://github.com/cachix/git-hooks.nix/commit/73a4e8d765e7ebfdd6ea1e2e18488012403093f0) | `` Fix `nix flake check`s ``                                                  |
| [`317fc48c`](https://github.com/cachix/git-hooks.nix/commit/317fc48c250158a80fc5844f69a4bf135c784f2c) | `` Fix Markdown formatting and sort hooks ``                                  |
| [`910b6db2`](https://github.com/cachix/git-hooks.nix/commit/910b6db22ec9b006b89f31d0cfa568ac4e171077) | `` Add default hooks to README ``                                             |
| [`754397c7`](https://github.com/cachix/git-hooks.nix/commit/754397c75a61707e20384b07e2c387778672a890) | `` Add pre-commit default hooks ``                                            |
| [`7d47a32e`](https://github.com/cachix/git-hooks.nix/commit/7d47a32e5cd1ea481fab33c516356ce27c8cef4a) | `` rename to git-hooks.nix ``                                                 |
| [`a130d70f`](https://github.com/cachix/git-hooks.nix/commit/a130d70f832e59799a2e86c1f8ff063b0fef9daa) | `` Fix typos and add pre-commit check ``                                      |
| [`1d744bb4`](https://github.com/cachix/git-hooks.nix/commit/1d744bb4e578c681b0c468924dc9a67ec52990e1) | `` Remove trailing new line ``                                                |
| [`fa4b9ef8`](https://github.com/cachix/git-hooks.nix/commit/fa4b9ef890fee95125163c1f7a1df39217b1c6c6) | `` Add Poetry hooks ``                                                        |
| [`b54aac8e`](https://github.com/cachix/git-hooks.nix/commit/b54aac8e39a0a0f2ccf8cd95aa747f4b3489bcf8) | `` Add ripsecrets hook ``                                                     |
| [`e611897d`](https://github.com/cachix/git-hooks.nix/commit/e611897ddfdde3ed3eaac4758635d7177ff78673) | `` fix flakes example for enabledPackages ``                                  |
| [`543d006f`](https://github.com/cachix/git-hooks.nix/commit/543d006fef3a86e0887d2f2a213bffa7afbf19d1) | `` fix option ``                                                              |
| [`cf361f56`](https://github.com/cachix/git-hooks.nix/commit/cf361f562612258d5f6272b0c567aaf2b5ff93df) | `` fix #356: provide a way to access all packages for enabled hooks ``        |
| [`21307b20`](https://github.com/cachix/git-hooks.nix/commit/21307b20b0f24ae8738e1771ac0b4a026756b85c) | `` Rename deprecated flake outputs ``                                         |
| [`8fc4dd7c`](https://github.com/cachix/git-hooks.nix/commit/8fc4dd7c1f12aeda9b1d001f18e243de563b357c) | `` feat: introduce black flags ``                                             |
| [`cbb3524c`](https://github.com/cachix/git-hooks.nix/commit/cbb3524cd65a4e71165c77842ac1c5827321cf64) | `` Remove treefmt package in the all-hooks check ``                           |
| [`8a980910`](https://github.com/cachix/git-hooks.nix/commit/8a9809104fbb6b8c829b95852fdce87a1f5c183a) | `` Fix treefmt flake-parts integration ``                                     |
| [`d43e4853`](https://github.com/cachix/git-hooks.nix/commit/d43e4853f578739ac2264eadcd18faa5aeb41889) | `` rustfmt: Support multi package projects ``                                 |