### PR TITLE
chore(flake/nixpkgs): `c75037bb` -> `b06025f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710631334,
-        "narHash": "sha256-rL5LSYd85kplL5othxK5lmAtjyMOBg390sGBTb3LRMM=",
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c75037bbf9093a2acb617804ee46320d6d1fea5a",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`c2f60aea`](https://github.com/NixOS/nixpkgs/commit/c2f60aeadc7af3f832c1ffa86bae06518d227fbf) | `` nawk: 20230911 -> 20240311 ``                                                  |
| [`8b8cfec9`](https://github.com/NixOS/nixpkgs/commit/8b8cfec92eaaad160fc9244966916601749641f1) | `` python311Packages.vector: 1.3.0 -> 1.3.1 (#296881) ``                          |
| [`85f6b7ab`](https://github.com/NixOS/nixpkgs/commit/85f6b7ab502c8e60482b777bd27e2fb1c2f0ee95) | `` python312Packages.energyflow: normalize pname (#297022) ``                     |
| [`f83d7ac1`](https://github.com/NixOS/nixpkgs/commit/f83d7ac16d4d9f466a5bc97d1facc064a90c7d25) | `` qt6.qtsvg: add mingw support ``                                                |
| [`55bf0219`](https://github.com/NixOS/nixpkgs/commit/55bf02190ee57fcf83490fd7b6bf7834e28c9c86) | `` cockroachdb: point to cockroachdb-bin ``                                       |
| [`9ec0e31f`](https://github.com/NixOS/nixpkgs/commit/9ec0e31f79d676288278a92c105f11121f694d01) | `` nixos/garage: add env-var wrapper for admin cli ``                             |
| [`a72afcbc`](https://github.com/NixOS/nixpkgs/commit/a72afcbc4896f1bff362cd65d0656f6f0207cdb6) | `` nixos.luksroot: fix assertion message to name correct option ``                |
| [`5ce6ec0a`](https://github.com/NixOS/nixpkgs/commit/5ce6ec0ae5e36491b371a5ad6dbe94b18d4c92af) | `` python312Packages.macfsevents: normalize pname ``                              |
| [`3cfa7b5c`](https://github.com/NixOS/nixpkgs/commit/3cfa7b5c58d0d0d701ff62b2ce27402f90076fdd) | `` python312Packages.coapthon3: normalize pname ``                                |
| [`f2ac6240`](https://github.com/NixOS/nixpkgs/commit/f2ac62404a9ba9f9cf7cb885ebab80f50de73a47) | `` texlive.bin.core-big: LuaTeX 1.16.0 -> 1.17.0 (#296742) ``                     |
| [`5fc8e8d7`](https://github.com/NixOS/nixpkgs/commit/5fc8e8d7c46a506f149908b9d9fc381a48d2e65e) | `` luaPackages.argparse: enable tests ``                                          |
| [`4813658e`](https://github.com/NixOS/nixpkgs/commit/4813658ef74b159c0e507cb4ec6cc6ae1b2b3981) | `` clash-verge-rev: 1.5.8 -> 1.5.9 ``                                             |
| [`81bd4ee8`](https://github.com/NixOS/nixpkgs/commit/81bd4ee813fababaa306168c6fc1f1e9cfbeeb21) | `` python312Packages.cyclonedx-python-lib: 6.4.3 -> 6.4.4 ``                      |
| [`37a41870`](https://github.com/NixOS/nixpkgs/commit/37a41870f131dd825d93da1e7ff481deb0c82147) | `` python311Packages.oracledb: 2.0.1 -> 2.1.0 ``                                  |
| [`28a46fa3`](https://github.com/NixOS/nixpkgs/commit/28a46fa3df4159a136ae861ac4c426c80fad0cec) | `` libretro.gambatte: unstable-2024-03-08 -> unstable-2024-03-15 ``               |
| [`b7c9261b`](https://github.com/NixOS/nixpkgs/commit/b7c9261b0291a851874ae8b59618c987d379e155) | `` libretro.vecx: unstable-2024-02-10 -> unstable-2024-03-17 ``                   |
| [`1f620b39`](https://github.com/NixOS/nixpkgs/commit/1f620b3988db4ef6a62c4b0a88e47c42890cb4f7) | `` libretro.genesis-plus-gx: unstable-2024-03-09 -> unstable-2024-03-15 ``        |
| [`d12836a9`](https://github.com/NixOS/nixpkgs/commit/d12836a90052106826bcda85a77bd63db25c325a) | `` libretro.flycast: unstable-2024-03-14 -> unstable-2024-03-17 ``                |
| [`0cf0db25`](https://github.com/NixOS/nixpkgs/commit/0cf0db258be979cf4f9fe45c3c1bbd9c5679330e) | `` libretro.bsnes: unstable-2024-03-09 -> unstable-2024-03-15 ``                  |
| [`6869cba1`](https://github.com/NixOS/nixpkgs/commit/6869cba134a102695ac02f2d1653b46f530f4433) | `` libretro.fbneo: unstable-2024-03-14 -> unstable-2024-03-17 ``                  |
| [`6ed6d864`](https://github.com/NixOS/nixpkgs/commit/6ed6d864d82ee849443f990fad8440e092228e13) | `` moar: 1.23.7 -> 1.23.8 ``                                                      |
| [`240c39ef`](https://github.com/NixOS/nixpkgs/commit/240c39ef2e49115919a96faed41e14fb19ed6721) | `` nixos/xmonad: add slotThe as a maintainer ``                                   |
| [`c98506fa`](https://github.com/NixOS/nixpkgs/commit/c98506fa103493ac6a038703136ebdf483e6acfb) | `` haskellPackages: add slotThe as a maintainer ``                                |
| [`e6921fe1`](https://github.com/NixOS/nixpkgs/commit/e6921fe12bb62dac36b6a5bf21c4523456a3e082) | `` libretro.ppsspp: unstable-2024-03-13 -> unstable-2024-03-17 ``                 |
| [`96df16fb`](https://github.com/NixOS/nixpkgs/commit/96df16fbd374aa621797505ea5a74244711b0670) | `` coqPackages_8_19.itauto: init at 8.19.0 ``                                     |
| [`fd888537`](https://github.com/NixOS/nixpkgs/commit/fd888537715ddc780b0ee74d952fe361067f1a7f) | `` coqPackages_8_19.equations: init at 1.3+8.19 ``                                |
| [`9c145232`](https://github.com/NixOS/nixpkgs/commit/9c145232020d542f7c11f94aa5fdaf97f5542b37) | `` coqPackages_8_19.aac-tactics: init at 8.19.0 ``                                |
| [`72daa174`](https://github.com/NixOS/nixpkgs/commit/72daa1740ce28f1cca5e5d9e998444d668edce47) | `` libretro.beetle-pce-fast: unstable-2024-03-08 -> unstable-2024-03-15 ``        |
| [`00df1593`](https://github.com/NixOS/nixpkgs/commit/00df15937b346dc31db6529f055e87363bade9de) | `` libretro.beetle-psx-hw: unstable-2024-03-08 -> unstable-2024-03-15 ``          |
| [`3e8f7301`](https://github.com/NixOS/nixpkgs/commit/3e8f7301a019a233e92f605f30fcfc01bc4f7961) | `` libretro.play: unstable-2024-03-11 -> unstable-2024-03-15 ``                   |
| [`90309b16`](https://github.com/NixOS/nixpkgs/commit/90309b160cd98a592fadefa0827bcab5579422cb) | `` python311Packages.aioautomower: 2024.3.0 -> 2024.3.3 ``                        |
| [`55b023c5`](https://github.com/NixOS/nixpkgs/commit/55b023c5893fcb0385d9f75f606112df26b0efa9) | `` firefox-esr-115-unwrapped: 115.8.0esr -> 115.9.0esr ``                         |
| [`013cda86`](https://github.com/NixOS/nixpkgs/commit/013cda86f80def87784c5e41902f58231710af8a) | `` firefox-bin-unwrapped: 123.0.1 -> 124.0 ``                                     |
| [`f2b067a0`](https://github.com/NixOS/nixpkgs/commit/f2b067a09a910cfa29cb8abf6c994281d7c32330) | `` firefox-unwrapped: 123.0.1 -> 124.0 ``                                         |
| [`0ce12029`](https://github.com/NixOS/nixpkgs/commit/0ce12029c8e52979c53f89327c3fafd8919c580f) | `` element-desktop: add libnotify runtime dependency ``                           |
| [`3fc32ecb`](https://github.com/NixOS/nixpkgs/commit/3fc32ecbd1fe9afbd2f781f774bef0c7187459aa) | `` signalbackup-tools: 20240314 -> 20240318 ``                                    |
| [`3d231621`](https://github.com/NixOS/nixpkgs/commit/3d23162141a4e84e33293a6f9133e6bd4be5e7c7) | `` cargo-nextest: 0.9.67 -> 0.9.68 (#296629) ``                                   |
| [`d3014281`](https://github.com/NixOS/nixpkgs/commit/d30142819e1b54ee0e1216dadc18549777e5757e) | `` python311Packages.pydeps: 1.12.19 -> 1.12.20 ``                                |
| [`c62cb2fc`](https://github.com/NixOS/nixpkgs/commit/c62cb2fc875379c8c0e680cf818368828328eda9) | `` vimPlugins.hardhat-nvim: add plenary-nvim dependency ``                        |
| [`28afcb73`](https://github.com/NixOS/nixpkgs/commit/28afcb73d227d8373d8af7f6a015215672560d58) | `` ginkgo: 2.16.0 -> 2.17.0 ``                                                    |
| [`a21d4e02`](https://github.com/NixOS/nixpkgs/commit/a21d4e02c361ba8d3783cb69355b6d608d959d0d) | `` cloud-nuke: 0.33.0 -> 0.34.0 ``                                                |
| [`9448d982`](https://github.com/NixOS/nixpkgs/commit/9448d982b6ff72637a1662aa754c6e67bcee013e) | `` flannel: 0.24.3 -> 0.24.4 ``                                                   |
| [`46c8b682`](https://github.com/NixOS/nixpkgs/commit/46c8b6821e7fecfea1879ccf0ff0116e3554b8dd) | `` popeye: 0.21.0 -> 0.21.1 ``                                                    |
| [`8531144e`](https://github.com/NixOS/nixpkgs/commit/8531144e3e8b0287a0c3490b8afd6596b8ec7936) | `` maintainer: update email address of @sinanmohd ``                              |
| [`f33f019b`](https://github.com/NixOS/nixpkgs/commit/f33f019bb22c837dd301b7aa04aa987ac41070fb) | `` pacu: init at 1.5.2 ``                                                         |
| [`d9bcada5`](https://github.com/NixOS/nixpkgs/commit/d9bcada50ef21bbc707103e40c738510067e59d0) | `` wleave: 0.4.0 -> 0.4.1 ``                                                      |
| [`b8933407`](https://github.com/NixOS/nixpkgs/commit/b8933407af2ecf271468394b484de8648731d298) | `` arkade: 0.11.5 -> 0.11.6 ``                                                    |
| [`bc205b24`](https://github.com/NixOS/nixpkgs/commit/bc205b24df12d90a83395c15d6aa7b5eb6b1f464) | `` radicale: 3.1.8 -> 3.1.9 ``                                                    |
| [`bae081c6`](https://github.com/NixOS/nixpkgs/commit/bae081c666a852581e03f628185dcaed645dceef) | `` typst-preview: 0.10.8 -> 0.11.1 ``                                             |
| [`7d61bb19`](https://github.com/NixOS/nixpkgs/commit/7d61bb198f715c133e5221b6307b2b569a0f06b2) | `` doc: document makeDesktopItem ``                                               |
| [`93aba53a`](https://github.com/NixOS/nixpkgs/commit/93aba53a08418eba4ce60dfd907326fdf9c28c87) | `` engelsystem: cleanup ``                                                        |
| [`91d4f204`](https://github.com/NixOS/nixpkgs/commit/91d4f204591ce9a05bbc73f896656ff966705d92) | `` corectrl: 1.3.11 -> 1.4.0 ``                                                   |
| [`823897dd`](https://github.com/NixOS/nixpkgs/commit/823897dde8c9ed8ae8f6080efa2d416ea3cb33d0) | `` wireplumber: 0.4.17 -> 0.5.0 ``                                                |
| [`e20b0b19`](https://github.com/NixOS/nixpkgs/commit/e20b0b19abff20997822c39f9561ac226696dd9c) | `` python312Packages.prayer-times-calculator: refactor ``                         |
| [`fc288f25`](https://github.com/NixOS/nixpkgs/commit/fc288f2582d6313a3408636818d7295cc1e191db) | `` python312Packages.aioapns: 3.1 -> 3.2 ``                                       |
| [`9d384c35`](https://github.com/NixOS/nixpkgs/commit/9d384c350b29e8d59a55d35582ff06309721e9a0) | `` nixos/scrutiny: Order scrutiny-collector after scrutiny ``                     |
| [`21ca99d8`](https://github.com/NixOS/nixpkgs/commit/21ca99d882653f897d165649ccf2624ef5c142d8) | `` python312Packages.azure-mgmt-batch: 17.2.0 -> 17.3.0 ``                        |
| [`8068282e`](https://github.com/NixOS/nixpkgs/commit/8068282e68cbc40adac6d89b0108c5fe09b6636b) | `` python312Packages.azure-mgmt-compute: 30.5.0 -> 30.6.0 ``                      |
| [`7b52191a`](https://github.com/NixOS/nixpkgs/commit/7b52191a56712353e14b7adcb74d343df553008d) | `` python312Packages.azure-mgmt-datafactory: 6.0.0 -> 6.1.0 ``                    |
| [`78d8e2ca`](https://github.com/NixOS/nixpkgs/commit/78d8e2ca119e4019415006ac5ea553e62c8e70c4) | `` nixos/timesyncd: further document services.timesyncd.servers ``                |
| [`a67eba88`](https://github.com/NixOS/nixpkgs/commit/a67eba88cadf0dd9b6cac8614441a62b27d64625) | `` bun: 1.0.32 -> 1.0.33 ``                                                       |
| [`e5bcc0a2`](https://github.com/NixOS/nixpkgs/commit/e5bcc0a201ac518e54a582ac23a6289f8875d1a4) | `` okteto: 2.25.2 -> 2.25.3 ``                                                    |
| [`1422ad9a`](https://github.com/NixOS/nixpkgs/commit/1422ad9a5e7095154039bff5474ab23b2c891f14) | `` xeol: init at 0.9.13 ``                                                        |
| [`7927f0f8`](https://github.com/NixOS/nixpkgs/commit/7927f0f89c7fcc25085c338e417b812fd98d2940) | `` vscode-extensions.mgt19937.typst-preview: 0.10.8 -> 0.11.1 ``                  |
| [`83a41502`](https://github.com/NixOS/nixpkgs/commit/83a41502b402e6965ab70df70366a5e65f615261) | `` maintainers: slotThe ``                                                        |
| [`aa306996`](https://github.com/NixOS/nixpkgs/commit/aa306996877168b297e6a87210adb75801e85eba) | `` efm-langserver: 0.0.50 -> 0.0.53 ``                                            |
| [`9d8efb86`](https://github.com/NixOS/nixpkgs/commit/9d8efb86edb3967dd9e9737e42b07dd4c18c35a7) | `` ddns-go: 6.2.1 -> 6.2.2 ``                                                     |
| [`d007e76f`](https://github.com/NixOS/nixpkgs/commit/d007e76ff390a1a7dd3923b507acbf45d3af8e89) | `` vimPlugins.neotest-gradle: add plenary-nvim dependency ``                      |
| [`6563fa50`](https://github.com/NixOS/nixpkgs/commit/6563fa504adb72e9657023772083fbe8bee9784b) | `` ngtcp2-gnutls: 1.3.0 -> 1.4.0 ``                                               |
| [`4084ca6c`](https://github.com/NixOS/nixpkgs/commit/4084ca6c21bd7e19a7d054f3c705c8029a973f17) | `` linuxPackages.vhba: 20211218 -> 20240202 (#285972) ``                          |
| [`33f3c988`](https://github.com/NixOS/nixpkgs/commit/33f3c988220217dad6325f1945b25d516fcec7f1) | `` surrealdb: migrate to by-name ``                                               |
| [`f4235345`](https://github.com/NixOS/nixpkgs/commit/f4235345e44e35af00dfa0fd30a3288a0b4ab853) | `` surrealdb: 1.2.1 → 1.3.1 ``                                                    |
| [`b449ae39`](https://github.com/NixOS/nixpkgs/commit/b449ae3987e68a8b6ba1b0e90fe662526c410057) | `` python311Packages.axis: 55 -> 56 ``                                            |
| [`1c2a0b6d`](https://github.com/NixOS/nixpkgs/commit/1c2a0b6df96b09b929fd177a91e401a8d546f282) | `` llama-cpp: 2424 -> 2454 ``                                                     |
| [`614f9b40`](https://github.com/NixOS/nixpkgs/commit/614f9b40d226b8e82bacd986fe142bbe3da885e2) | `` slint-lsp: 1.4.1 -> 1.5.0 ``                                                   |
| [`bce86182`](https://github.com/NixOS/nixpkgs/commit/bce861827894453b57ce56e638f55b431dcaec3d) | `` python312Packages.ring-doorbell: 0.8.7 -> 0.8.8 ``                             |
| [`1f8af4f3`](https://github.com/NixOS/nixpkgs/commit/1f8af4f3573a9282a9c4dd4cd5553f383210a4b8) | `` python312Packages.oras: 0.1.27 -> 0.1.28 ``                                    |
| [`b6ed496a`](https://github.com/NixOS/nixpkgs/commit/b6ed496a0aa7b45bdf728b97ce4c007dc63ee3cc) | `` build(deps): bump peter-evans/create-pull-request from 6.0.1 to 6.0.2 ``       |
| [`677b0f82`](https://github.com/NixOS/nixpkgs/commit/677b0f82c7d69d45f2a00a112cf79f2780a565ba) | `` build(deps): bump actions/checkout from 4.1.1 to 4.1.2 ``                      |
| [`fc104b59`](https://github.com/NixOS/nixpkgs/commit/fc104b59ceed3a0f8581b19f6110eab211ee4300) | `` donpapi: init at 1.2.0 ``                                                      |
| [`5cd749fa`](https://github.com/NixOS/nixpkgs/commit/5cd749fa56c2ee496bc71f35524ff4629d899981) | `` vscode-extensions.13xforever.language-x86-64-assembly: add alias ``            |
| [`10c5fdbb`](https://github.com/NixOS/nixpkgs/commit/10c5fdbb32bf11453e9e7f202cee28844ab9189f) | `` python311Packages.lnkparse3: init at 1.3.3 ``                                  |
| [`1f155ddb`](https://github.com/NixOS/nixpkgs/commit/1f155ddb2843611aebbf4db822205191583c2884) | `` dark-mode-notify: sync clang with swift itself ``                              |
| [`40351beb`](https://github.com/NixOS/nixpkgs/commit/40351bebc34ebb56239181f0efde8bf1424e5498) | `` renode-unstable: 1.14.0+20240314git7ff57f373 -> 1.14.0+20240315gita7bdc1e0e `` |
| [`cb382fec`](https://github.com/NixOS/nixpkgs/commit/cb382fec42f9c094747b3db04df9cd1e4e0442d0) | `` chromium-codecs-ffmpeg-extra 111306 -> 114023 ``                               |
| [`853e0c29`](https://github.com/NixOS/nixpkgs/commit/853e0c2992e35675a7405213edc9790eed454bb6) | `` linux/generic: make output of buildLinux overrideable again ``                 |
| [`ee92e0bd`](https://github.com/NixOS/nixpkgs/commit/ee92e0bdf8ed80d21dda45474c88e5c23f24c239) | `` certi: init at 0.1.0-unstable-2023-01-27 ``                                    |
| [`e5b3215a`](https://github.com/NixOS/nixpkgs/commit/e5b3215afdc02a676590789eacd50a5a118e4d03) | `` gotosocial: skip more flakey tests ``                                          |
| [`f9ab7d77`](https://github.com/NixOS/nixpkgs/commit/f9ab7d7753391bdc3e67aa422de710aeddc4791a) | `` ferretdb: add changelog link ``                                                |
| [`4504d0d6`](https://github.com/NixOS/nixpkgs/commit/4504d0d64668d7eaeef1e091030c2ed735cdfe39) | `` melt: 0.6.0 -> 0.6.1 ``                                                        |
| [`636d8a7b`](https://github.com/NixOS/nixpkgs/commit/636d8a7bbb068ed240a5c4f1faeb7391911b7d89) | `` sslstrip: init at 2.0 ``                                                       |
| [`2a52c47f`](https://github.com/NixOS/nixpkgs/commit/2a52c47fdf1065c81b7c6cc4334f8299645522c6) | `` tf-summarize: 0.3.8 -> 0.3.9 ``                                                |
| [`8fec083b`](https://github.com/NixOS/nixpkgs/commit/8fec083b833146eba481d7f4175f8d386e5b056a) | `` tenki: 1.4.0 -> 1.5.0 ``                                                       |
| [`0a80980f`](https://github.com/NixOS/nixpkgs/commit/0a80980fbf4edadb28a365682920e8be4253145b) | `` python311Packages.extract-msg: init at 0.48.2 ``                               |
| [`290c1653`](https://github.com/NixOS/nixpkgs/commit/290c16532c5e11f357cd48da7bfd072d5cbd0e0f) | `` doc/mkYarnPackage: document better distPhase and doDist ``                     |
| [`df0fae23`](https://github.com/NixOS/nixpkgs/commit/df0fae235fbd943fb77fed357f59513eb80d1b51) | `` python312Packages.prayer-times-calculator: 0.0.10 -> 0.0.12 ``                 |
| [`d0fe4b5f`](https://github.com/NixOS/nixpkgs/commit/d0fe4b5f5fd5e1aca70e06503e8c4649fd755813) | `` python312Packages.bthome-ble: 3.8.0 -> 3.8.1 ``                                |
| [`6a611883`](https://github.com/NixOS/nixpkgs/commit/6a611883d6ce5764963e9a40ddf1316b8d445821) | `` python311Packages.rtfde: init at 0.1.1 ``                                      |
| [`6a493df2`](https://github.com/NixOS/nixpkgs/commit/6a493df296f10bb22dd9686a2c7591fe09d1419e) | `` python312Packages.asysocks: 0.2.11 -> 0.2.12 ``                                |
| [`d2ee191a`](https://github.com/NixOS/nixpkgs/commit/d2ee191a7db8bb7dc438e36e8236e0f4ead53e7b) | `` python312Packages.aioapns: 3.1 -> 3.2 ``                                       |