### PR TITLE
chore(flake/nixvim): `4f6e9021` -> `4530a35b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710156081,
-        "narHash": "sha256-4PMY6aumJi5dLFjBzF5O4flKXmadMNq3AGUHKYfchh0=",
+        "lastModified": 1713532798,
+        "narHash": "sha256-wtBhsdMJA3Wa32Wtm1eeo84GejtI43pMrFrmwLXrsEc=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "bc68b058dc7e6d4d6befc4ec6c60082b6e844b7d",
+        "rev": "12e914740a25ea1891ec619bb53cf5e6ca922e40",
         "type": "github"
       },
       "original": {
@@ -94,16 +94,31 @@
         ]
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1713493429,
+        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
         "type": "github"
       }
     },
@@ -212,11 +227,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710820906,
-        "narHash": "sha256-2bNMraoRB4pdw/HtxgYTFeMhEekBZeQ53/a8xkqpbZc=",
+        "lastModified": 1715486357,
+        "narHash": "sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "022464438a85450abb23d93b91aa82e0addd71fb",
+        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
         "type": "github"
       },
       "original": {
@@ -233,11 +248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710717205,
-        "narHash": "sha256-Wf3gHh5uV6W1TV/A8X8QJf99a5ypDSugY4sNtdJDe0A=",
+        "lastModified": 1713946171,
+        "narHash": "sha256-lc75rgRQLdp4Dzogv5cfqOg6qYc5Rp83oedF2t0kDp8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "bcc8afd06e237df060c85bad6af7128e05fd61a3",
+        "rev": "230a197063de9287128e2c68a7a4b0cd7d0b50a7",
         "type": "github"
       },
       "original": {
@@ -295,19 +310,21 @@
         "devshell": "devshell",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts_2",
+        "flake-root": "flake-root",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1710936779,
-        "narHash": "sha256-ecYnUzSWqRae10pp7J6ZE2BznTPJ9f8sLiIoDBQtRBw=",
+        "lastModified": 1715582453,
+        "narHash": "sha256-pW8a12PHt/PUphG8Tn0nb+mfbTS7JS4YbThGPepCcb0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4f6e90212c7ec56d7c03611fb86befa313e7f61f",
+        "rev": "4530a35bad28a0e8b21905b0817a225e6387811c",
         "type": "github"
       },
       "original": {
@@ -331,11 +348,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710843117,
-        "narHash": "sha256-b6iKQeHegzpc697rxTPA3bpwGN3m50eLCgdQOmceFuE=",
+        "lastModified": 1714478972,
+        "narHash": "sha256-q//cgb52vv81uOuwz1LaXElp3XAe1TqrABXODAEF6Sk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e8dc1b4fe80c6fcededde7700e6a23bcdf7f3347",
+        "rev": "2849da033884f54822af194400f8dff435ada242",
         "type": "github"
       },
       "original": {
@@ -418,6 +435,27 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1714058656,
+        "narHash": "sha256-Qv4RBm4LKuO4fNOfx9wl40W2rBbv5u5m+whxRYUMiaA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`4530a35b`](https://github.com/nix-community/nixvim/commit/4530a35bad28a0e8b21905b0817a225e6387811c) | `` plugins/lspkind: undefined variable ``                                             |
| [`a2a558d1`](https://github.com/nix-community/nixvim/commit/a2a558d15ee85ea07291d172310e54ebadd6b221) | `` flake.lock: Update ``                                                              |
| [`908932b5`](https://github.com/nix-community/nixvim/commit/908932b53c8e501eb7b56d35476754fbdb126f5e) | `` plugins/nixd: Adapt to new options ``                                              |
| [`2fd3a049`](https://github.com/nix-community/nixvim/commit/2fd3a0493c7a62fa5449d6c400c6f2b33d4d5e56) | `` flake.lock: Update ``                                                              |
| [`8eeefad9`](https://github.com/nix-community/nixvim/commit/8eeefad9ddf4c6196cdc821f4f84341f6afb50e0) | `` build_documentation: update workflow actions ``                                    |
| [`f7f255af`](https://github.com/nix-community/nixvim/commit/f7f255afe22fcca0c07177c3707fd61fa0c85835) | `` flake-modules: add treefmt to fix the 'nix fmt' command ``                         |
| [`ba545ded`](https://github.com/nix-community/nixvim/commit/ba545ded79057faf866005acd15c1b03bb6d3bf8) | `` tests/pugins/rest: set dontRun for test because the plugin is broken in nixpkgs `` |
| [`5dca76a2`](https://github.com/nix-community/nixvim/commit/5dca76a21e88efb847c808e1bd5c72ad35a3f1af) | `` flake.lock: Update ``                                                              |
| [`b731bedf`](https://github.com/nix-community/nixvim/commit/b731bedfb9a75f9d25da4d8e97a95f03eb863274) | `` expose withRuby option ``                                                          |
| [`62f32bfc`](https://github.com/nix-community/nixvim/commit/62f32bfc711f0a3c8a52af4c0790345b4b3d2346) | `` treewide: Reformat with nixfmt ``                                                  |
| [`c6281260`](https://github.com/nix-community/nixvim/commit/c6281260dc074012b54f22f6dba7d6bef72813b6) | `` flake-modules: Use nixfmt instead of alejandra ``                                  |
| [`c05fba47`](https://github.com/nix-community/nixvim/commit/c05fba47c733445098847399b61ddfd81ecbde55) | `` plugins/cmp-git: add settings option ``                                            |
| [`fd134f84`](https://github.com/nix-community/nixvim/commit/fd134f84dd22389e98c3a18e8f2f7a7bdcf83040) | `` plugins/lsp/dartls: add test ``                                                    |
| [`20aea5cd`](https://github.com/nix-community/nixvim/commit/20aea5cd7a81d0b7952f31408285ed5cdbd46e3c) | `` plugins/lsp: move dartls options in a dedicated file ``                            |
| [`d57c962d`](https://github.com/nix-community/nixvim/commit/d57c962d6eea50795427f4cad103ea401c37b2a6) | `` tests/lsp: move language server tests to separate folder ``                        |
| [`0a294ad9`](https://github.com/nix-community/nixvim/commit/0a294ad931ca74903765915821876273bc10aedd) | `` Revert "tests/lsp: temporarily disable test for pylyzer" ``                        |
| [`317da7bb`](https://github.com/nix-community/nixvim/commit/317da7bbbaac56b1d9a97b959ed0518fc0ea4a4d) | `` flake.lock: Update ``                                                              |
| [`82a19581`](https://github.com/nix-community/nixvim/commit/82a19581defe682ff9ca7cb8b1b980b6dc297cf2) | `` colorschemes/cyberdream: init ``                                                   |
| [`afa64f35`](https://github.com/nix-community/nixvim/commit/afa64f35eefa388ca897656f7b3928a6e9e09e4d) | `` plugins/lsp/helpers/mkLsp: add extraConfig argument ``                             |
| [`b5dbe0bb`](https://github.com/nix-community/nixvim/commit/b5dbe0bb69681f3d203f322eb1a085fe537f211e) | `` plugins/lsp: make plugins.lsp.servers.*.settings RFC-42 compliant ``               |
| [`2483dff0`](https://github.com/nix-community/nixvim/commit/2483dff03dd326296278213a8e051d375b56d3df) | `` plugins/cmp-async-path: init ``                                                    |
| [`91e3bb05`](https://github.com/nix-community/nixvim/commit/91e3bb0523c37ebe432e2639853149a2af6dd48a) | `` tests/cmp: add a test that enables all sources ``                                  |
| [`dc038244`](https://github.com/nix-community/nixvim/commit/dc038244f8c5cd76025b4ea0163446985a8bd8ec) | `` plugins/cmp: refactor source-plugin internal mechanics ``                          |
| [`892caa9b`](https://github.com/nix-community/nixvim/commit/892caa9b40793bf1a1648d76d89a92ffa0693248) | `` tests/pylsp: change test name ``                                                   |
| [`35c0f714`](https://github.com/nix-community/nixvim/commit/35c0f714578fad139426dbf720725db45c8b170b) | `` plugins/cmp-fish: add fishPackage option ``                                        |
| [`4dea1478`](https://github.com/nix-community/nixvim/commit/4dea1478eb493d756cba0aae62d1cfbd8116bb47) | `` plugins/lazygit: init ``                                                           |
| [`62cf01df`](https://github.com/nix-community/nixvim/commit/62cf01df74cb68853448de80f3e772d096295392) | `` plugins/hydra: init ``                                                             |
| [`bf23dfdb`](https://github.com/nix-community/nixvim/commit/bf23dfdb0f15d55120a8073f6f518f7ef1e30419) | `` plugins/lsp: add nginx-language-server ``                                          |
| [`3fe60dbe`](https://github.com/nix-community/nixvim/commit/3fe60dbed04447dc7025a918250e78123dece601) | `` plugins/spectre: init ``                                                           |
| [`823c701e`](https://github.com/nix-community/nixvim/commit/823c701ee3028a014e4b33f73ed81ace21b10fd0) | `` tests/multicursors: disable while waiting for upstream fix ``                      |
| [`bea35897`](https://github.com/nix-community/nixvim/commit/bea358979810d57c038b4cfdfc65078818a89b13) | `` flake.lock: Update ``                                                              |
| [`b12d81c6`](https://github.com/nix-community/nixvim/commit/b12d81c69a7328256ce52eb640b5682bc108df78) | `` plugins/lsp: add ast-grep language server ``                                       |
| [`e2e72582`](https://github.com/nix-community/nixvim/commit/e2e7258267ba4ec81bd6503e968b6cf52cbd3f2a) | `` plugins/competitest: init ``                                                       |
| [`8f9e3548`](https://github.com/nix-community/nixvim/commit/8f9e35481fb6e44e7b1e7f8d82faa47bac150655) | `` helpers/maintainers: add svl ``                                                    |
| [`e521e37f`](https://github.com/nix-community/nixvim/commit/e521e37f51f50a91e26b44779cd402fdaa426fbd) | `` plugins/dressing: init ``                                                          |
| [`b4a30dd1`](https://github.com/nix-community/nixvim/commit/b4a30dd1d67d78d166a58b9807cb51dc93039f93) | `` lib/maintainers: add AndresBermeoMarinelli ``                                      |
| [`0fc19014`](https://github.com/nix-community/nixvim/commit/0fc190144f9acf72ae8705ea304577e90389da20) | `` plugins/lsp/ccls: fix initOptions ``                                               |
| [`e95f8e9c`](https://github.com/nix-community/nixvim/commit/e95f8e9ce4c126e323bd4e82c3399d43c92185cd) | `` plugins/texpresso: init ``                                                         |
| [`77efb038`](https://github.com/nix-community/nixvim/commit/77efb038df92ea1f42bf87a3428fef55aac73eef) | `` plugins/cloak: init ``                                                             |
| [`3981a314`](https://github.com/nix-community/nixvim/commit/3981a31464bdd50fcfea7ae3176c37e33dac07da) | `` flake.lock: Update ``                                                              |
| [`f2f97d84`](https://github.com/nix-community/nixvim/commit/f2f97d844bb39559f3356e209b49c92900d860b8) | `` misc: allow null in extraPackages ``                                               |
| [`c826d146`](https://github.com/nix-community/nixvim/commit/c826d146c65bfa8164f31931cf54278b99f5a3a0) | `` plugins/godot: init ``                                                             |
| [`84d7453e`](https://github.com/nix-community/nixvim/commit/84d7453e44730ec2b6bfb71d109e376d6590a818) | `` plugins/gitignore: init ``                                                         |
| [`6ebd538e`](https://github.com/nix-community/nixvim/commit/6ebd538ede5a0de49253620828ba28dc57988305) | `` plugins/treesitter-context: switch to mkNeovimPlugin ``                            |
| [`c1ae78cd`](https://github.com/nix-community/nixvim/commit/c1ae78cd8c8f8ef85ca98d1c6445789f3915f973) | `` plugins/rest: add keybinds option ``                                               |
| [`6f7b236f`](https://github.com/nix-community/nixvim/commit/6f7b236f65d1751788c4ab50b78fdae7dd20ef49) | `` plugins/none-ls: update tools ``                                                   |
| [`1b7ff66d`](https://github.com/nix-community/nixvim/commit/1b7ff66de9129489c96ae4cb77db3d459fc8658f) | `` flake.lock: Update ``                                                              |
| [`9a24838a`](https://github.com/nix-community/nixvim/commit/9a24838aac6b55a865dd30f1b5885ac4f62c78e1) | `` flake.lock: Update ``                                                              |
| [`83a7ce98`](https://github.com/nix-community/nixvim/commit/83a7ce9846b1b01a34b3e6b25077c1a5044ad7b3) | `` plugins/lsp: add ruff language server ``                                           |
| [`514a5187`](https://github.com/nix-community/nixvim/commit/514a51877df9fe41ffc38c5237e3c4e5327e7607) | `` plugins/statuscol: init ``                                                         |
| [`987c204b`](https://github.com/nix-community/nixvim/commit/987c204b498f4f77dad23c9515864dc978812e76) | `` plugins/lsp: add docker-compose-language-service language server ``                |
| [`4662a06f`](https://github.com/nix-community/nixvim/commit/4662a06f4e405987cff5c7745ea98c044daabf87) | `` colorschemes/tokyonight: switch to mkNeovimPlugin ``                               |
| [`d5a30928`](https://github.com/nix-community/nixvim/commit/d5a309286db2bca02166d9267852ea5d36b70ba8) | `` colorschemes/rose-pine: switch to mkNeovimPlugin ``                                |
| [`16272920`](https://github.com/nix-community/nixvim/commit/16272920e23bd47b53eace5e479e3f0200933978) | `` colorschemes/poimandres: switch to mkNeovimPlugin ``                               |
| [`6440f4af`](https://github.com/nix-community/nixvim/commit/6440f4af878150b501befdb91a73ef7e92a52bee) | `` plugins/qmk: init ``                                                               |
| [`99068dab`](https://github.com/nix-community/nixvim/commit/99068dab4b6d6dc55fb50cfaf807b156115e8d89) | `` plugins/filetrees/neo-tree: remove deprecated lib.mdDoc call (#1415) ``            |
| [`ad6a08b6`](https://github.com/nix-community/nixvim/commit/ad6a08b69528fdaf7e12c90da06f9a34f32d7ea6) | `` plugins/improved-search: init ``                                                   |
| [`a88a282a`](https://github.com/nix-community/nixvim/commit/a88a282a110a53011d1524a7547e57dfaccc14d0) | `` plugins/lsp/pylsp: replace "--replace" to remove warnings ``                       |
| [`1da2087d`](https://github.com/nix-community/nixvim/commit/1da2087d9b8a89c310d093207afd41114d6727e1) | `` flake.lock: Update ``                                                              |
| [`21c23391`](https://github.com/nix-community/nixvim/commit/21c233919d747d3375e3a173b65f7f26ccf01256) | `` output: format init.lua ``                                                         |
| [`3a4de0bb`](https://github.com/nix-community/nixvim/commit/3a4de0bb2fd19313a9e89c6387cba60e8acf6b90) | `` plugins/coq-nvim: fix settings not being set when lsp is not enabled (#1408) ``    |
| [`f4018967`](https://github.com/nix-community/nixvim/commit/f4018967d40ccab752c1898cc3d81330368eb7a4) | `` plugins/telescope/extensions/media-files: add rename warnings ``                   |
| [`37b14144`](https://github.com/nix-community/nixvim/commit/37b14144a34b8ea0dae09b991e02eec0b341633d) | `` flake.lock: Update ``                                                              |
| [`ad046c97`](https://github.com/nix-community/nixvim/commit/ad046c976d0a52512f75cae6154c39dac84dbc65) | `` colorschemes/catpuccin: switch to mkNeovimPlugin ``                                |
| [`c068f78d`](https://github.com/nix-community/nixvim/commit/c068f78dcde4856deab31bc6dcf5802d6da1c088) | `` plugins/toggleterm: switch to mkNeovimPlugin ``                                    |
| [`776cc84a`](https://github.com/nix-community/nixvim/commit/776cc84ad1b67618c24f740b6d71a4fc3f87ed1c) | `` helpers/types: allow highlight.ctypes to accept a string ``                        |
| [`38a4fc77`](https://github.com/nix-community/nixvim/commit/38a4fc7709343eb6e15ebb483e141fd95be28122) | `` plugins/nvim-autopairs: switch to mkNeovimPlugin ``                                |
| [`ffa30205`](https://github.com/nix-community/nixvim/commit/ffa3020522e210fcae934f10440c24ea1d46f6ea) | `` plugins/cmp_yanky: init ``                                                         |
| [`c86a0aca`](https://github.com/nix-community/nixvim/commit/c86a0aca63ce91c482b1b86242e0959ceb882667) | `` plugins/hop: init ``                                                               |
| [`f1df1548`](https://github.com/nix-community/nixvim/commit/f1df1548346a2c1f5bb7983a92bf817d76c45c13) | `` plugins/lsp: Add tinymist language server ``                                       |
| [`512ac70e`](https://github.com/nix-community/nixvim/commit/512ac70ec96ee774867f5a6ae494b12f0d4ddcb9) | `` plugins/lsp: add lexical language server ``                                        |
| [`30bddf7d`](https://github.com/nix-community/nixvim/commit/30bddf7da11d8cbf14e4f96c24d8af981334ff4f) | `` plugins/which-key: fix typo in package option description ``                       |
| [`6e828d38`](https://github.com/nix-community/nixvim/commit/6e828d38a3b191429c17d0ee0ae91f194a1ddfed) | `` tests/plugins/neorg: temporarily disable tests ``                                  |
| [`e1b7b4e5`](https://github.com/nix-community/nixvim/commit/e1b7b4e52d5656de1e9f90d0b83319af66cd3209) | `` plugins/lsp/pylsp: fix python-lsp-server derivation ``                             |
| [`b9f211bb`](https://github.com/nix-community/nixvim/commit/b9f211bbee6acab257c7c47458e7b1373c56e382) | `` plugins/debugprint: switch to mkNeovimPlugin ``                                    |
| [`192b404e`](https://github.com/nix-community/nixvim/commit/192b404e413e297d0d28431cd42fb20a1c557621) | `` plugins/rest: switch to mkNeovimPlugin ``                                          |
| [`3a161eae`](https://github.com/nix-community/nixvim/commit/3a161eaec0fe367e314ca9410beb393280731042) | `` tests/plugins/codeium-vim: set dontRun to true as tests are now hanging ``         |
| [`2742dc09`](https://github.com/nix-community/nixvim/commit/2742dc091a2432827b9b18fa07e9176402fd47c2) | `` plugins/none-ls: rename package nixfmt to nixfmt-classic ``                        |
| [`dadf9b19`](https://github.com/nix-community/nixvim/commit/dadf9b192d851a0895fc7cb273d1902ffc53efdb) | `` plugins/efmls-configs: rename package nixfmt to nixfmt-classic ``                  |
| [`f05d5aaf`](https://github.com/nix-community/nixvim/commit/f05d5aaf3b80aae724d1cd9f26b0386c4cb3dc19) | `` plugins/none-ls: add new server htmlbeautifier ``                                  |
| [`22982bd7`](https://github.com/nix-community/nixvim/commit/22982bd708088d7399639474b0665d7c97585e6e) | `` tests/lsp: disable test for vala-ls as pkgs.vala-language-server is broken ``      |
| [`5c5f95bc`](https://github.com/nix-community/nixvim/commit/5c5f95bc3f040d139f3c702c959343e982c58973) | `` flake.lock: Update ``                                                              |
| [`0d85838d`](https://github.com/nix-community/nixvim/commit/0d85838d204d0f3d1cda22059d3fed0cd757d0ab) | `` colorschemes/melange: switch to mkVimPlugin ``                                     |
| [`48acee7d`](https://github.com/nix-community/nixvim/commit/48acee7dcabe88ab25b44bd8fbeeba251d96baea) | `` colorschemes/oxocarbon: switch to mkVimPlugin ``                                   |
| [`b38f24f3`](https://github.com/nix-community/nixvim/commit/b38f24f3482aeb59fa55f9fb2fd6269f978b7b9f) | `` plugins/telescope: refactor extensions ``                                          |
| [`3c0951eb`](https://github.com/nix-community/nixvim/commit/3c0951ebc84988b1f175c73dcb8cb01f6c5fe491) | `` plugins/telescope: switch to mkNeovimPlugin ``                                     |
| [`07de1fe9`](https://github.com/nix-community/nixvim/commit/07de1fe92e5354079aa2690584596af62b457852) | `` colorschemes/palette: switch to mkNeovimPlugin ``                                  |
| [`d348bb3e`](https://github.com/nix-community/nixvim/commit/d348bb3e036cb151c152cccaaa2c02892af6b642) | `` lib/types: factor out logLevel enum for standalone use ``                          |
| [`f285a958`](https://github.com/nix-community/nixvim/commit/f285a958c089ccbca9c5710d4a075683fa1af654) | `` plugins/jdtls: fix binary name ``                                                  |
| [`2c99cefa`](https://github.com/nix-community/nixvim/commit/2c99cefa913c8afb8fa08e53608c6f8bd5a2e5c4) | `` plugins/lsp: add nimls language server ``                                          |
| [`052012d2`](https://github.com/nix-community/nixvim/commit/052012d2d98d0e97f488111380c28cc53812ea48) | `` plugins/lsp: Improved docs for keymaps ``                                          |
| [`e229e3ad`](https://github.com/nix-community/nixvim/commit/e229e3ad446666af30c12c375f5fc3770e30f9b4) | `` plugins/lsp: Reduce indent on attr set and use `helpers.mkRaw` ``                  |
| [`03009d0b`](https://github.com/nix-community/nixvim/commit/03009d0b999f98dbea4a766c3cdf6263c6b7c2c9) | `` LSP: Register keymaps on `LspAttach` ``                                            |
| [`7baefc8a`](https://github.com/nix-community/nixvim/commit/7baefc8aa587931827797db7fbd55a733179dc79) | `` plugins: Add ccc (new PR) (#1365) ``                                               |
| [`bd1794e8`](https://github.com/nix-community/nixvim/commit/bd1794e89d705776dac393675c93f7ebb6f74e94) | `` docs: hotfix module guide links ``                                                 |
| [`3f7e6ce8`](https://github.com/nix-community/nixvim/commit/3f7e6ce8501ebdaa839f75426446ab82701f76dd) | `` wrappers: expose `config` in standalone output (#1356) ``                          |
| [`14fca449`](https://github.com/nix-community/nixvim/commit/14fca449b7dabc94096c0d55dc68b9a7cc511d8f) | `` docs: add usage tldr ``                                                            |
| [`226c555d`](https://github.com/nix-community/nixvim/commit/226c555d8ff451cced577904d6fbf657460187ea) | `` docs: move standalone example to platform usage ``                                 |
| [`87df94dc`](https://github.com/nix-community/nixvim/commit/87df94dcbddc9a34658191e7645da1b13c66af31) | `` docs: Move standalone usage to modules section ``                                  |
| [`db6b61f1`](https://github.com/nix-community/nixvim/commit/db6b61f117c83943f15289ced03674f81d08256a) | `` Fix typo ``                                                                        |
| [`0c16f592`](https://github.com/nix-community/nixvim/commit/0c16f59202c5062d12ef9cd4560cc9fca9d99f9a) | `` plugins/headlines: init ``                                                         |
| [`6d1ef586`](https://github.com/nix-community/nixvim/commit/6d1ef5864b6b3f7244f50847b6355b13ad8de3fd) | `` docs: Add a section on module specific options (#1355) ``                          |
| [`c7062070`](https://github.com/nix-community/nixvim/commit/c706207007033c2cba8a4d8a55b53a66eb0d1e78) | `` tests: fix occurences of deprecated "options" option ``                            |
| [`0f6d4450`](https://github.com/nix-community/nixvim/commit/0f6d44503b69e34093325b70778b9cc89c2fa658) | `` tests: remove useless comments in test files ``                                    |
| [`cc296ddb`](https://github.com/nix-community/nixvim/commit/cc296ddb8bbdaa7dae6e88c0a6531d5939125cc9) | `` flake.lock: Update ``                                                              |
| [`4f83bcf2`](https://github.com/nix-community/nixvim/commit/4f83bcf2906c1c933316396221024f3482a7b086) | `` Rename `options` to avoid confusion with module options (#1324) ``                 |
| [`acb917fb`](https://github.com/nix-community/nixvim/commit/acb917fbf2bc9ce9c556516d8a1f257709b3cf1e) | `` plugins/zen-mode: init ``                                                          |
| [`b658169f`](https://github.com/nix-community/nixvim/commit/b658169f114bd38d29617f01e1fe4dd587a31199) | `` plugins/jupytext: init ``                                                          |
| [`a9442524`](https://github.com/nix-community/nixvim/commit/a94425245b9b125c356edc819c7d3f232b2798b7) | `` plugins/sandwich: init ``                                                          |
| [`d7667dd0`](https://github.com/nix-community/nixvim/commit/d7667dd083fccc063de8e17dd5146e2ab3a35175) | `` flake.lock: Update ``                                                              |
| [`5fb9f0bb`](https://github.com/nix-community/nixvim/commit/5fb9f0bb86edf08043ebf1cc3d16388469390c0a) | `` plugins/vim-css-color: init (#1335) ``                                             |
| [`d248bf58`](https://github.com/nix-community/nixvim/commit/d248bf587cdb86b661ca54f16fe2f3263018b985) | `` plugins/neotest: add neotest-gtest ``                                              |
| [`4012cdbb`](https://github.com/nix-community/nixvim/commit/4012cdbbf13bab4793a11617261d6fdc15c7fc4f) | `` plugins/zellij: init ``                                                            |
| [`f1cb9f07`](https://github.com/nix-community/nixvim/commit/f1cb9f07463136e635cceb055bd367f4f72115b8) | `` tests: disable tests using broken pkgs.clj-kondo ``                                |
| [`26e37367`](https://github.com/nix-community/nixvim/commit/26e373671fad5d8e39365ba3b377e86be687c4bb) | `` flake.lock: Update ``                                                              |
| [`a1d97bf1`](https://github.com/nix-community/nixvim/commit/a1d97bf1999c2b5083c3ac2a485665607bbdf4d9) | `` colorschemes/one: switch to mkVimPlugin ``                                         |
| [`b8b0c1d5`](https://github.com/nix-community/nixvim/commit/b8b0c1d58f3259dd0236a5844897aeec3b36b73d) | `` plugins/oil: switch to mkNeovimPlugin + update options ``                          |
| [`d1d7fb1f`](https://github.com/nix-community/nixvim/commit/d1d7fb1f4a336ab509c1503153f7107c1d87838a) | `` plugins/gitsigns: switch to mkNeovimPlugin ``                                      |
| [`c6d45054`](https://github.com/nix-community/nixvim/commit/c6d45054389d47c3b54bedf31c4473dfed8e4bef) | `` colorschemes/kanagawa: switch to mkNeovimPlugin ``                                 |
| [`ce87283d`](https://github.com/nix-community/nixvim/commit/ce87283dd6f6660b199af174e60f4a0cec0e2c5b) | `` docs: Add a more verbose example on adding the standalone flake (#1323) ``         |
| [`2799e830`](https://github.com/nix-community/nixvim/commit/2799e830b2be8cdc5a6be141dbbdeed6c2c45f9d) | `` plugins/indent-blankline: swith to mkNeovimPlugin ``                               |
| [`83ca6756`](https://github.com/nix-community/nixvim/commit/83ca67566d77b8ce2b605b99216f5c40cf38f7f1) | `` plugins/indent-blankline: remove deprecation warnings ``                           |
| [`ddac6db1`](https://github.com/nix-community/nixvim/commit/ddac6db152e5c86aa5af4ee0269e8e79333c1c54) | `` plugins/sleuth: init ``                                                            |
| [`d261b39e`](https://github.com/nix-community/nixvim/commit/d261b39e7c086b5eff2527dd289f1ebed01e754d) | `` plugins/neotest: add hardhat.nvim ``                                               |
| [`4d471f04`](https://github.com/nix-community/nixvim/commit/4d471f04a56fc357df0a4e7446f9c908fc06ae05) | `` helpers/vim-plugin/mkVimPlugin: remove useless 'options' argument ``               |
| [`2b2e9f96`](https://github.com/nix-community/nixvim/commit/2b2e9f962a309323a2fb44589eee482a58629741) | `` plugins/lsp: add vhdl-ls ``                                                        |
| [`b4b64125`](https://github.com/nix-community/nixvim/commit/b4b64125057491aa4cba2e7d9506959b3238adbc) | `` plugins/comment: add tests ``                                                      |
| [`546e6ea6`](https://github.com/nix-community/nixvim/commit/546e6ea68a6ef9c39a97ebfaaa9c6029a2bd5569) | `` plugins/comment: swith to mkNeovimPlugin + rename ``                               |
| [`e7a3461f`](https://github.com/nix-community/nixvim/commit/e7a3461fefd983ae3443e9aa849e9d1566ab47e4) | `` plugins/neoscroll: minor formatting ``                                             |
| [`7170aad2`](https://github.com/nix-community/nixvim/commit/7170aad28139cd3629b2b6ce4c9272bf41c2ad45) | `` flake.lock: Update ``                                                              |
| [`7dae5228`](https://github.com/nix-community/nixvim/commit/7dae5228f10959e8e5420280beb413b9bcc570a1) | `` ci/update: update actions to latest versions ``                                    |
| [`97131789`](https://github.com/nix-community/nixvim/commit/97131789aeef1ef4e27ea3e75511292b299db981) | `` plugins/lsp: add sqls language server ``                                           |
| [`d45c30f1`](https://github.com/nix-community/nixvim/commit/d45c30f160a93cf3dc67d6a3d9ddcc1870eae5de) | `` docs: fix moduleDoc being interpreted by bash ``                                   |
| [`fd5ef727`](https://github.com/nix-community/nixvim/commit/fd5ef727256c44aadd1014f8b869e175a64b4b5c) | `` plugins/tmux-navigator: use un-aliased package ``                                  |
| [`9dc09448`](https://github.com/nix-community/nixvim/commit/9dc094489ac853f0fcbb4ef9242c4e9bf07b9b84) | `` plugins/tmux-navigator: port to mkVimPlugin ``                                     |
| [`822ec156`](https://github.com/nix-community/nixvim/commit/822ec15646b8f7b621468b503118921d644acf39) | `` tests/none-ls: disable test for broken d2_fmt ``                                   |
| [`3ae3a293`](https://github.com/nix-community/nixvim/commit/3ae3a293b6dcec7a18a7a73612b56b046af005c4) | `` flake.lock: Update ``                                                              |
| [`9c2c0d20`](https://github.com/nix-community/nixvim/commit/9c2c0d20df7bf89be0b65474de7bf1e66a744864) | `` plugins/cmp: fix examples for snippet.expand ``                                    |
| [`04091a13`](https://github.com/nix-community/nixvim/commit/04091a13ec544be1e95eb5de4123300ee40ac29c) | `` plugins/neoscroll: init ``                                                         |
| [`40a4f5ef`](https://github.com/nix-community/nixvim/commit/40a4f5ef6707db2a082fb1ac28e2a7962160ea3a) | `` plugins/codeium-vim: fix keymaps ``                                                |
| [`848543d5`](https://github.com/nix-community/nixvim/commit/848543d527cdaa3d708dbb69db94dd8e91859ab1) | `` docs: optionally add a description to plugins ``                                   |
| [`2d4ebda2`](https://github.com/nix-community/nixvim/commit/2d4ebda245f765772db0f19bb9c26784e3890877) | `` docs: swap "url" and "maintainers" in documentation ``                             |
| [`a89c8a9a`](https://github.com/nix-community/nixvim/commit/a89c8a9a97e3e6d715b402011e2bb247624b9de6) | `` feat: allow custom formatting for status components (#1018) ``                     |
| [`7a952a4e`](https://github.com/nix-community/nixvim/commit/7a952a4e32b67933f2ec1301bd9a8611a716491c) | `` docs: Add an FAQ entry for keymap aliases (#1301) ``                               |
| [`da7c6c41`](https://github.com/nix-community/nixvim/commit/da7c6c41eff8aadbdeadb9cefa9515b764aa1598) | `` docs: fix github link branch (#1300) ``                                            |
| [`80a2244a`](https://github.com/nix-community/nixvim/commit/80a2244afcfab2c7e662a1fb839397ef75875f35) | `` docs: remove misleading `_` after `globalPrefix` ``                                |