### PR TITLE
chore(flake/nixpkgs): `44d0940e` -> `57e6b3a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711163522,
-        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
+        "lastModified": 1711333969,
+        "narHash": "sha256-5PiWGn10DQjMZee5NXzeA6ccsv60iLu+Xtw+mfvkUAs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
+        "rev": "57e6b3a9e4ebec5aa121188301f04a6b8c354c9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`fbbf99cd`](https://github.com/NixOS/nixpkgs/commit/fbbf99cd0f31683aaf60333962c5b14886e6bbba) | `` firefox: update warning about nativeMessagingHosts ``                        |
| [`2e805456`](https://github.com/NixOS/nixpkgs/commit/2e8054564245e4df8a9d3ccda41fd98a4b0f497f) | `` clifm: format with nixfmt-rfc-style ``                                       |
| [`bf4b84df`](https://github.com/NixOS/nixpkgs/commit/bf4b84df02105d5927f64eb31807244acc0f0efc) | `` hyprcursor: 0.1.4 -> 0.1.5 ``                                                |
| [`cd781012`](https://github.com/NixOS/nixpkgs/commit/cd7810121f722fc6a755309855848094ca289103) | `` atari800: 5.1.0 -> 5.2.0 ``                                                  |
| [`5f640fb0`](https://github.com/NixOS/nixpkgs/commit/5f640fb0042090fd06c2d5658d5f3eed1177341c) | `` vscode-extensions.jdinhlife.gruvbox: 1.8.0 -> 1.18.0 ``                      |
| [`a5e78c3d`](https://github.com/NixOS/nixpkgs/commit/a5e78c3ddc59ffcfad69374ae9728e5ec181ae7a) | `` python311Packages.fido2: 1.1.2 -> 1.1.3 ``                                   |
| [`e6b9a285`](https://github.com/NixOS/nixpkgs/commit/e6b9a28514019ca9651b76882db1af8c38a336e3) | `` Revert "appium-inspector: init at 2024.3.1" ``                               |
| [`8aa915fe`](https://github.com/NixOS/nixpkgs/commit/8aa915fe5efb8be48685cab7b5cfd979dbfd7bb5) | `` maintainers: fix eymeric maintainer email ``                                 |
| [`83a2696d`](https://github.com/NixOS/nixpkgs/commit/83a2696de8a93dea32b8d5ba63602f8e3b2edf28) | `` texlive.bin.core: patch ttfdump buffer overflow, CVE 2024-25262 (#298721) `` |
| [`5ff608b2`](https://github.com/NixOS/nixpkgs/commit/5ff608b21a07251b5ce5d6c357bca37bdc76828e) | `` vimPlugins.zellij-nvim: init at 2024-02-06 (#291238) ``                      |
| [`483547e5`](https://github.com/NixOS/nixpkgs/commit/483547e5398c52d486ae56df608eca53f8c13742) | `` stats: 2.10.3 -> 2.10.5 ``                                                   |
| [`7f6fd46a`](https://github.com/NixOS/nixpkgs/commit/7f6fd46ab697081bca68f79bcd8d0db69b2fdf2e) | `` raycast: 1.66.2 -> 1.70.2 ``                                                 |
| [`ffb9150b`](https://github.com/NixOS/nixpkgs/commit/ffb9150bdb539f424c1bbe4deece8482fa9463fa) | `` lndmanage: 0.15.0 -> 0.16.0 ``                                               |
| [`9c16c79d`](https://github.com/NixOS/nixpkgs/commit/9c16c79d661f908faf80227faaeb6b989615751e) | `` nwg-drawer: 0.4.5 -> 0.4.7 ``                                                |
| [`c4459a8a`](https://github.com/NixOS/nixpkgs/commit/c4459a8adff4829f127410d7f8642b7a5de13398) | `` eclairevoyant: update maintainer email ``                                    |
| [`c844a523`](https://github.com/NixOS/nixpkgs/commit/c844a5236e6de0f79caf2ce76f74315b122d9e49) | `` alire: 2.0.0 -> 2.0.1 ``                                                     |
| [`b1bffe2f`](https://github.com/NixOS/nixpkgs/commit/b1bffe2fe8f4769871aefde4f37e7313359ad83b) | `` blueutil: init at 2.9.1 ``                                                   |
| [`a5be355d`](https://github.com/NixOS/nixpkgs/commit/a5be355ddc9c877bc4f4ecfb74831a4359a3a6de) | `` wesnoth: 1.16.11 -> 1.18.0 ``                                                |
| [`f0a72af5`](https://github.com/NixOS/nixpkgs/commit/f0a72af5fc9c9ae89dac844aad655371507eac77) | `` dex-oidc: 2.38.0 -> 2.39.0 (#298222) ``                                      |
| [`a029ee17`](https://github.com/NixOS/nixpkgs/commit/a029ee17621d03451d17b798482afd2a742cf5fb) | `` supabase-cli: 1.144.2 -> 1.151.1 ``                                          |
| [`fdab275c`](https://github.com/NixOS/nixpkgs/commit/fdab275c089a847eda5da99ea595817b0d95897f) | `` flutter: move flutter-tools' Gradle build files out of Nix Store ``          |
| [`432f7488`](https://github.com/NixOS/nixpkgs/commit/432f7488def86c53c5064268f5d09fa3c8271aa7) | `` go-judge: 1.8.1 -> 1.8.2 ``                                                  |
| [`40bef96f`](https://github.com/NixOS/nixpkgs/commit/40bef96f3c43403d2cd218fde515a2d7db2a4ec9) | `` deepin.deepin-album: 6.0.2 -> 6.0.4 ``                                       |
| [`5fbc0943`](https://github.com/NixOS/nixpkgs/commit/5fbc09439396aa896995b99342985efc4715154d) | `` nixos/profile/all-hardware: remove simplefb ``                               |
| [`b10f0b93`](https://github.com/NixOS/nixpkgs/commit/b10f0b93e22b8a51384f7e283e5003be0bc1972a) | `` python311Packages.litellm: refactor ``                                       |
| [`e92d9adb`](https://github.com/NixOS/nixpkgs/commit/e92d9adba1b39a1369079b5b62abdedf2e88cb2a) | `` vscode-extensions.catppuccin.catppuccin-vsc-icons: 0.30.0 -> 1.10.0 ``       |
| [`3c4fdc7f`](https://github.com/NixOS/nixpkgs/commit/3c4fdc7fb3bd915e1453e08a87bd1b90c4c96ced) | `` fdroidserver: set mainProgram ``                                             |
| [`49d9251c`](https://github.com/NixOS/nixpkgs/commit/49d9251c1af6fa49124a8f310433cdd244ac3613) | `` clifm: 1.17 -> 1.18 ``                                                       |
| [`2cee7b9a`](https://github.com/NixOS/nixpkgs/commit/2cee7b9ab1461bd84cc9ebd638df70bc3a962f47) | `` python311Packages.litellm: 1.33.7 -> 1.34.0 ``                               |
| [`74c99ac8`](https://github.com/NixOS/nixpkgs/commit/74c99ac81d0fb06c2a2e87f691c2024ed2051891) | `` shellharden: 4.3.0 -> 4.3.1 ``                                               |
| [`a07ef204`](https://github.com/NixOS/nixpkgs/commit/a07ef204c5fd245c8cdc3e5f678b2e9eb5a10bfd) | `` bun: add meta.mainProgram ``                                                 |
| [`d495f7b6`](https://github.com/NixOS/nixpkgs/commit/d495f7b63355c851c9643bed423eb64d663194c1) | `` sttr: 0.2.18 -> 0.2.19 ``                                                    |
| [`64d0ec49`](https://github.com/NixOS/nixpkgs/commit/64d0ec491fabdf17219e4985b5f57657aed4794d) | `` cargo-tally: 1.0.41 -> 1.0.42 ``                                             |
| [`39f5882e`](https://github.com/NixOS/nixpkgs/commit/39f5882e1af13e691a5fe35d62d4df1230c4e626) | `` python312Packages.pyngrok: 7.1.5 -> 7.1.6 ``                                 |
| [`d03e5b7c`](https://github.com/NixOS/nixpkgs/commit/d03e5b7c1a176e0fa08c5dbcdb14b1322486e020) | `` varnish60: 6.0.12 -> 6.0.13 ``                                               |
| [`f3ddb905`](https://github.com/NixOS/nixpkgs/commit/f3ddb90555d053d0861d990a5eea4f10d355c049) | `` varnish: 7.4.2 -> 7.4.3 ``                                                   |
| [`0b605e08`](https://github.com/NixOS/nixpkgs/commit/0b605e08da6f98b3e61b56243e0e493eeeb3d882) | `` hyperrogue: 13.0c -> 13.0d ``                                                |
| [`f71f613d`](https://github.com/NixOS/nixpkgs/commit/f71f613d1e0d3783a33ee7198391118e700e018a) | `` consul-template: 0.37.2 -> 0.37.3 ``                                         |
| [`df755634`](https://github.com/NixOS/nixpkgs/commit/df7556345844ffbaa225ef78618857a0e4a2be4d) | `` hysteria: 2.3.0 -> 2.4.0 ``                                                  |
| [`bb2b1e83`](https://github.com/NixOS/nixpkgs/commit/bb2b1e8312b758cc48151f65d5e2db570c8e04a4) | `` go-jet: 2.11.0 -> 2.11.1 ``                                                  |
| [`7cadc175`](https://github.com/NixOS/nixpkgs/commit/7cadc175919016d329c868915f1f1c42fc8fb817) | `` skawarePackages: add manpages to their respective packages ``                |
| [`2ce1f2b0`](https://github.com/NixOS/nixpkgs/commit/2ce1f2b04b317d7640190319ac75b57688da9cf9) | `` goflow2: 2.1.2 -> 2.1.3 ``                                                   |
| [`9de9c904`](https://github.com/NixOS/nixpkgs/commit/9de9c90422910825aa3482e1b7e3d22730e6efd7) | `` wayland-pipewire-idle-inhibit: 0.4.5 -> 0.5.0 ``                             |
| [`661cb5e8`](https://github.com/NixOS/nixpkgs/commit/661cb5e80d93e5a0788767423027460badbdb7c4) | `` jnv: 0.1.2 -> 0.1.3 ``                                                       |
| [`d2118f51`](https://github.com/NixOS/nixpkgs/commit/d2118f51d996060335e22bc9cbdd4d8ee2c82abd) | `` overskride: 0.5.6 -> 0.5.7 ``                                                |
| [`982e8ef1`](https://github.com/NixOS/nixpkgs/commit/982e8ef140fc9c18adcd16a5d71284f508b689d4) | `` fdroidserver: fix metadata ``                                                |
| [`5cf15d4f`](https://github.com/NixOS/nixpkgs/commit/5cf15d4f4d8ed837540b48d86dbf655f76596cfe) | `` tlrc: 1.8.0 -> 1.9.0 ``                                                      |
| [`42592a7c`](https://github.com/NixOS/nixpkgs/commit/42592a7c7856c4edf4076192b01a8adf455b0a4c) | `` vscode-extensions.ms-dotnettools.csdevkit: init at 1.4.28 ``                 |
| [`e26df615`](https://github.com/NixOS/nixpkgs/commit/e26df6159a323887af97794668b2c738069516cc) | `` nmrpflash: refactor ``                                                       |
| [`b0da52a0`](https://github.com/NixOS/nixpkgs/commit/b0da52a02fd0dbd90733c2089d4b12b3900dde61) | `` scion: use buildGo121Module ``                                               |
| [`acb30190`](https://github.com/NixOS/nixpkgs/commit/acb30190d1df721720b7e8ba405e66e1f4fa8042) | `` uutils-coreutils 0.0.22 -> 0.0.25 ``                                         |
| [`1400a12f`](https://github.com/NixOS/nixpkgs/commit/1400a12fc358b5cc95e1a0ab5d78cf34629ecfc6) | `` gtkmm3: 3.24.8 -> 3.24.9 ``                                                  |
| [`d6c5284a`](https://github.com/NixOS/nixpkgs/commit/d6c5284a53bae60d2f663b98ca01d7156d94e93a) | `` crawley: 1.7.2 -> 1.7.3 ``                                                   |
| [`b7de695b`](https://github.com/NixOS/nixpkgs/commit/b7de695b7de27a1bf33d76039d2c72306cf52775) | `` owmods-cli: 0.13.0 -> 0.13.1 ``                                              |
| [`1922cfff`](https://github.com/NixOS/nixpkgs/commit/1922cfffe288709c4ce1c0877419178959cefe23) | `` pocketbase: 0.22.4 -> 0.22.6 ``                                              |
| [`22c49eb9`](https://github.com/NixOS/nixpkgs/commit/22c49eb9058da9ea0f2886f4a754f1276409489b) | `` keymapper: 3.0.0 -> 3.5.3 ``                                                 |
| [`db9099eb`](https://github.com/NixOS/nixpkgs/commit/db9099eb19ab351c13ab9a9b431b18e4bcbcd270) | `` maintainers: add spitulax ``                                                 |
| [`fe758cbb`](https://github.com/NixOS/nixpkgs/commit/fe758cbb5fd5ad92a590a0eade982b30cf3875a2) | `` pest: 2.34.4 -> 2.34.5 ``                                                    |
| [`d3ef7664`](https://github.com/NixOS/nixpkgs/commit/d3ef766498a6c07a9563c1d1932cc1ac209e4590) | `` phpPackages.phpinsights: init at 2.11.0 ``                                   |