### PR TITLE
chore(flake/nixpkgs): `2726f127` -> `d8fe5e6c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711523803,
-        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                          |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
| [`b2832010`](https://github.com/NixOS/nixpkgs/commit/b28320100bc5ae95de0abee748c3d89aadd065ad) | `` open-policy-agent: 0.62.1 -> 0.63.0 ``                                                                        |
| [`e9c98c68`](https://github.com/NixOS/nixpkgs/commit/e9c98c68d37ea1de7e776ea6b0ea154da1e4ccdc) | `` pgmoneta: 0.9.0 -> 0.10.0 ``                                                                                  |
| [`a06a03ed`](https://github.com/NixOS/nixpkgs/commit/a06a03ed7c92c5482f6d260c596a4b593f201318) | `` llama-cpp: update from b2481 to b2568 ``                                                                      |
| [`1ab78293`](https://github.com/NixOS/nixpkgs/commit/1ab78293f2bce42f3bb9a16ce0d4e46179e10456) | `` python312Packages.aioraven: refactor ``                                                                       |
| [`b403964b`](https://github.com/NixOS/nixpkgs/commit/b403964bb9806bbc09125ca09b97adc9d432cf23) | `` python312Packages.aioraven: 0.5.2 -> 0.5.3 ``                                                                 |
| [`b086f140`](https://github.com/NixOS/nixpkgs/commit/b086f1406d7da6bb90ce256d1e8b0160f3e20c19) | `` python311Packages.angrop: refactor ``                                                                         |
| [`c0b4ed84`](https://github.com/NixOS/nixpkgs/commit/c0b4ed846ee8f5941549ba2467816add05997e62) | `` python311Packages.angr: 9.2.84 -> 9.2.96 ``                                                                   |
| [`112fdbb2`](https://github.com/NixOS/nixpkgs/commit/112fdbb2c1986fa58f00e8b6af292f2c57b3d8d3) | `` python311Packages.pyformlang: refactor ``                                                                     |
| [`917ccf98`](https://github.com/NixOS/nixpkgs/commit/917ccf988fe713a65d5b9d29f66f23b477baf912) | `` python311Packages.unique-log-filter: refactor ``                                                              |
| [`aa3de91b`](https://github.com/NixOS/nixpkgs/commit/aa3de91b56004496fc47f1b4569ccd56d2ec65c1) | `` python311Packages.angrcli: refactor ``                                                                        |
| [`735f815f`](https://github.com/NixOS/nixpkgs/commit/735f815f29de2e4873fd15f7f88b1f60682408ba) | `` python311Packages.angr: refactor ``                                                                           |
| [`e74a30a7`](https://github.com/NixOS/nixpkgs/commit/e74a30a73775c05df668c4e15d76800f88f3bc06) | `` python311Packages.nampa: refactor ``                                                                          |
| [`350d7713`](https://github.com/NixOS/nixpkgs/commit/350d7713be81ffe12e56ca84f334a40f7d0fd387) | `` files-cli: 2.12.44 -> 2.12.46 ``                                                                              |
| [`c2706010`](https://github.com/NixOS/nixpkgs/commit/c2706010acdbb4962e8b48a3d18c817d8447aae7) | `` python311Packages.cle: 9.2.84 -> 9.2.96 ``                                                                    |
| [`b3922bf9`](https://github.com/NixOS/nixpkgs/commit/b3922bf9a89cdfd6811e3285cf292f8a7ce7acbe) | `` python311Packages.pyvex: 9.2.93 -> 9.2.96 ``                                                                  |
| [`49adc35e`](https://github.com/NixOS/nixpkgs/commit/49adc35edc6af66d789c1399cd9c6452a4761fd2) | `` nodejs_18: Add comment to warn about ffi-napi compatibility problem to prevent updating to newer versions. `` |
| [`61c9c6cd`](https://github.com/NixOS/nixpkgs/commit/61c9c6cd03cbb22919b68c7556349f74df55d118) | `` remind: 04.03.03 -> 04.03.04 ``                                                                               |
| [`e4daa765`](https://github.com/NixOS/nixpkgs/commit/e4daa76528288450144d0389631b04103dd75921) | `` python311Packages.pyvex: refactor ``                                                                          |
| [`8c93cec3`](https://github.com/NixOS/nixpkgs/commit/8c93cec3778908e0d3295c31da6fa62f315dd71c) | `` python311Packages.cle: refactor ``                                                                            |
| [`1f6ac2ec`](https://github.com/NixOS/nixpkgs/commit/1f6ac2ecebfd6a65eadccd0bbca573288ce36e94) | `` python311Packages.archinfo: 9.2.84 -> 9.2.96 ``                                                               |
| [`208705bd`](https://github.com/NixOS/nixpkgs/commit/208705bdd638af7d8f85c63bcbf435756e8cd3ef) | `` python311Packages.archinfo: refactor ``                                                                       |
| [`1e430af6`](https://github.com/NixOS/nixpkgs/commit/1e430af6e4bf50dd78243fb9f8c4e1dc88f987b4) | `` python311Packages.ailment: refactor ``                                                                        |
| [`bb920bf9`](https://github.com/NixOS/nixpkgs/commit/bb920bf9ff05bab7c77669b6d2768e6f951e2f8e) | `` python311Packages.claripy: 9.2.84 -> 9.2.96 ``                                                                |
| [`316633a6`](https://github.com/NixOS/nixpkgs/commit/316633a60f6be22e04759537ccefaf70e6b22ebf) | `` python311Packages.ailment: 9.2.84 -> 9.2.96 ``                                                                |
| [`e27adc40`](https://github.com/NixOS/nixpkgs/commit/e27adc4072288593b20f1c520494ca2d694fd47c) | `` python312Packages.claripy: fix z3-solver issue ``                                                             |
| [`db70cf28`](https://github.com/NixOS/nixpkgs/commit/db70cf2859e587bb1fd3a02819a415f76d189099) | `` team-list: drop from LLVM team ``                                                                             |
| [`432180da`](https://github.com/NixOS/nixpkgs/commit/432180dade654a0bfacc4922f71f0e82dedb2b99) | `` authelia: drop myself from maintenance ``                                                                     |
| [`9b324f1e`](https://github.com/NixOS/nixpkgs/commit/9b324f1e7209217bb5a7f7fb2ca94fd91a6f6ad4) | `` CODEOWNERS: drop myself from LLVM & Linux Kernel ``                                                           |
| [`db2e5df9`](https://github.com/NixOS/nixpkgs/commit/db2e5df9e6b7233ca8f18b789df9e4e0c3e22fd6) | `` python311Packages.dbt-semantic-interfaces: refactor ``                                                        |
| [`7a9688b8`](https://github.com/NixOS/nixpkgs/commit/7a9688b8c31c02d42b9eec7f42d52eb6aab937ef) | `` python311Packages.dbt-snowflake: 1.7.2 -> 1.7.3 ``                                                            |
| [`8449be91`](https://github.com/NixOS/nixpkgs/commit/8449be91d0de86ae07562f779f6aeafc6a7a46cf) | `` python311Packages.dbt-snowflake: refactor ``                                                                  |
| [`1c38ccb9`](https://github.com/NixOS/nixpkgs/commit/1c38ccb9a46eca4926f1bf2ac38bf676e0b12a84) | `` python311Packages.dbt-postgres: refactor ``                                                                   |
| [`948d7e3c`](https://github.com/NixOS/nixpkgs/commit/948d7e3c0859a4df522729d2b6edeeda5fa54384) | `` python311Packages.dbt-bigquery: 1.7.6 -> 1.7.7 ``                                                             |
| [`1bb92ab2`](https://github.com/NixOS/nixpkgs/commit/1bb92ab2c5f2b922032de2039c0db12973b838f7) | `` python311Packages.dbt-core: 1.7.10 -> 1.7.11 ``                                                               |
| [`35c9135d`](https://github.com/NixOS/nixpkgs/commit/35c9135d0aa827dd3f05428027281cc2e2a8dca1) | `` python311Packages.dbt-core: refactor ``                                                                       |
| [`a60c7cff`](https://github.com/NixOS/nixpkgs/commit/a60c7cff874bccffe28a0ec420ce4ed914b65b16) | `` linuxKernel.kernels.linux_lqx: 6.7.9-lqx1 -> 6.7.11-lqx1 ``                                                   |
| [`0d86c16f`](https://github.com/NixOS/nixpkgs/commit/0d86c16ff087a7e1d3b860bbf1134b02965d84b2) | `` linuxKernel.kernels.linux_zen: 6.8-zen1 -> 6.8.2-zen2 ``                                                      |
| [`56231b95`](https://github.com/NixOS/nixpkgs/commit/56231b9522a1e2dbe13d744ca570c5c8b857ba71) | `` python312Packages.pyecoforest: refactor ``                                                                    |
| [`488c293c`](https://github.com/NixOS/nixpkgs/commit/488c293cbdc1135b4cd0248189226ee7989dd3ed) | `` invidious-router: 1.0 -> 1.1 ``                                                                               |
| [`179a5ac3`](https://github.com/NixOS/nixpkgs/commit/179a5ac3c36dbc706fbfc373ac3aeda7ac84c702) | `` invidious-router: init at 1.0 ``                                                                              |
| [`10865ad4`](https://github.com/NixOS/nixpkgs/commit/10865ad4c1d38f5ff02bf60c747842c0904b52ed) | `` python312Packages.pyinsteon: disable all handlers tests on Python 3.12 ``                                     |
| [`091b8328`](https://github.com/NixOS/nixpkgs/commit/091b832816afb7f5c5896cc40bc83e50845ea934) | `` maintainers: add sils ``                                                                                      |
| [`a3615c2e`](https://github.com/NixOS/nixpkgs/commit/a3615c2e41b5588c00c395c0339cd902d766c7bc) | `` python312Packages.pyinsteon: refactor ``                                                                      |
| [`3c9cdd29`](https://github.com/NixOS/nixpkgs/commit/3c9cdd296561bc6b9ae49586ca4c293b17d6dda1) | `` Avoid top-level `with ...;` in pkgs/tools/virtualization/awsebcli/default.nix ``                              |
| [`4ede2c36`](https://github.com/NixOS/nixpkgs/commit/4ede2c365781a036c4710188cd4cd168c6cdf5c5) | `` Avoid top-level `with ...;` in pkgs/tools/misc/bepasty/default.nix ``                                         |
| [`28164c64`](https://github.com/NixOS/nixpkgs/commit/28164c6434380425fa4d9b8e6ab3c26698226eb2) | `` Avoid top-level `with ...;` in pkgs/tools/backup/ugarit-manifest-maker/default.nix ``                         |
| [`623a58e4`](https://github.com/NixOS/nixpkgs/commit/623a58e4c9d6c1dc48d4a22ef48fd3a8ad730c69) | `` Avoid top-level `with ...;` in pkgs/tools/networking/dd-agent/integrations-core.nix ``                        |
| [`2c495214`](https://github.com/NixOS/nixpkgs/commit/2c49521491f6d2a8e2059eafccd452f3643b8e8d) | `` Avoid top-level `with ...;` in pkgs/tools/backup/ugarit/default.nix ``                                        |
| [`6aa0a471`](https://github.com/NixOS/nixpkgs/commit/6aa0a4712e4d0042b0a58e5aff8f90485f4ba76b) | `` Avoid top-level `with ...;` in pkgs/tools/security/pass/extensions/default.nix ``                             |
| [`ac39e45b`](https://github.com/NixOS/nixpkgs/commit/ac39e45b0448bd6dc593b68f66c4d6cfa0ae2399) | `` Avoid top-level `with ...;` in pkgs/tools/misc/graylog/plugins.nix ``                                         |
| [`5b0905b8`](https://github.com/NixOS/nixpkgs/commit/5b0905b8eaf258dcd5c0d4c04c132ad7296c0023) | `` Avoid top-level `with ...;` in pkgs/tools/graphics/astc-encoder/default.nix ``                                |
| [`c0666485`](https://github.com/NixOS/nixpkgs/commit/c0666485e5e29d07401c30f29c70be36e6e3abbb) | `` python312Packages.manifest-ml: disable failing tests ``                                                       |
| [`673b5545`](https://github.com/NixOS/nixpkgs/commit/673b5545c10bb19336b4fed4adb846f061045b63) | `` python312Packages.manifest-ml: refactor ``                                                                    |
| [`e1fd64f4`](https://github.com/NixOS/nixpkgs/commit/e1fd64f4e8a7d149972b31d09b20b0bad4de82ea) | `` python312Packages.llama-index-graph-stores-nebula: init at 0.1.2 ``                                           |
| [`49c1c82f`](https://github.com/NixOS/nixpkgs/commit/49c1c82fd8ca32975eb553acc8d7ca25608c6955) | `` python312Packages.nebula3-python: init at 3.5.0 ``                                                            |
| [`5e0f3e5e`](https://github.com/NixOS/nixpkgs/commit/5e0f3e5e36ce0a7a6ddb25ef9faf698c91250b3a) | `` python312Packages.llama-index-graph-stores-neptune: init at 0.1.3 ``                                          |
| [`445c570f`](https://github.com/NixOS/nixpkgs/commit/445c570f5e9826d180f965038b09899373e814ab) | `` python312Packages.llama-index-graph-stores-neo4j: init at 0.1.3 ``                                            |
| [`7f1aead8`](https://github.com/NixOS/nixpkgs/commit/7f1aead8b38d0e9e6120d299597a4343c22faf29) | `` python312Packages.llama-index-vector-stores-google: init at 0.1.4 ``                                          |
| [`c921298c`](https://github.com/NixOS/nixpkgs/commit/c921298cc6be5c049bd46aaa046d5eaaac42d42c) | `` python312Packages.llama-index-vector-stores-qdrant: init at 0.1.4 ``                                          |
| [`655a2864`](https://github.com/NixOS/nixpkgs/commit/655a28646eefbf37b01d0bfa52d5f887f903b34d) | `` python312Packages.llama-index-vector-stores-postgres: init at 0.1.3 ``                                        |
| [`84193256`](https://github.com/NixOS/nixpkgs/commit/84193256b53f6ebae225edc4086effeae1c3929c) | `` python312Packages.starlette-context: init at 0.3.6 ``                                                         |
| [`e21763ec`](https://github.com/NixOS/nixpkgs/commit/e21763ec29c66c974f343047b4102689c3a67063) | `` python312Packages.sse-starlette: init at 2.0.0 ``                                                             |
| [`e9fc5be0`](https://github.com/NixOS/nixpkgs/commit/e9fc5be0c783e9b6c2a87f095773fd2b42851503) | `` python312Packages.asgi-lifespan: init at 2.1.0 ``                                                             |
| [`4efe4831`](https://github.com/NixOS/nixpkgs/commit/4efe48318b9799bb8084914a61f79858f60deeb2) | `` python312Packages.llama-index-llms-openai-like: init at 0.1.3 ``                                              |
| [`d622e6ab`](https://github.com/NixOS/nixpkgs/commit/d622e6abcb59de616900a00fd275fb48f7423614) | `` python312Packages.llama-index-llms-ollama: init at 0.1.2 ``                                                   |
| [`67fccb8c`](https://github.com/NixOS/nixpkgs/commit/67fccb8c48b5501690b856e2837e1972b3412456) | `` python312Packages.llama-index-embeddings-huggingface: init at 0.2.0 ``                                        |
| [`c0456ddd`](https://github.com/NixOS/nixpkgs/commit/c0456dddc9843750c3f4fbb8a79d2b662c38973f) | `` python312Packages.sentence-transformers: 2.5.1 -> 2.6.1 ``                                                    |
| [`900b45b9`](https://github.com/NixOS/nixpkgs/commit/900b45b96a7fdd2bff751d3928142dcf40f0f671) | `` python312Packages.sentence-transformers: refactor ``                                                          |
| [`0c0a1ee5`](https://github.com/NixOS/nixpkgs/commit/0c0a1ee5f0564d30e5e3476934824429cded4af5) | `` python312Packages.llama-index-embeddings-ollama: init at 0.1.2 ``                                             |
| [`9fb68677`](https://github.com/NixOS/nixpkgs/commit/9fb68677e40ad2bfec0cc6cbdbecdf1523c9430a) | `` forgejo: fix applying of our `STATIC_ROOT_PATH` patch ``                                                      |
| [`aeae82eb`](https://github.com/NixOS/nixpkgs/commit/aeae82eb6b4e2e423791eb2b15618383a5a11264) | `` Revert "nodejs_18: 18.19.1 -> 18.20.0" ``                                                                     |
| [`8a74441f`](https://github.com/NixOS/nixpkgs/commit/8a74441fc09539b80985c1704530ebbd85390d4a) | `` lmstudio: init at 0.2.18 ``                                                                                   |
| [`8ec91d2a`](https://github.com/NixOS/nixpkgs/commit/8ec91d2a1cdd04f7c92b3337167369a4a7559da8) | `` python311Packages.transformers: 4.39.1 -> 4.39.2 ``                                                           |
| [`c70699a1`](https://github.com/NixOS/nixpkgs/commit/c70699a11bab28319311c5daf984a52ff2a16d6a) | `` ungoogled-chromium: 123.0.6312.58-1 -> 123.0.6312.86-1 ``                                                     |
| [`c7faa543`](https://github.com/NixOS/nixpkgs/commit/c7faa543a3d2a54d8c8436e64413d4958e7e8594) | `` python312Packages.pathtools: disable ``                                                                       |
| [`d546502c`](https://github.com/NixOS/nixpkgs/commit/d546502c7ccdedcb0c51dcdc9aa7ef8727d3d83e) | `` elmPackages: move adjusts from cabal2nix-generated files to overrides ``                                      |
| [`07899424`](https://github.com/NixOS/nixpkgs/commit/078994248a1e52d95de7c32c0a642f00abf881aa) | `` nixos/mollysocket: init ``                                                                                    |
| [`03a76c27`](https://github.com/NixOS/nixpkgs/commit/03a76c271eb522369bc6b364797914c72902655e) | `` python311Packages.spacy: relax smart-open constraint ``                                                       |
| [`13b12a92`](https://github.com/NixOS/nixpkgs/commit/13b12a92814bf411906620ffcd1d26e5c30017cc) | `` elm: include all cabal2nix in update script ``                                                                |
| [`9b795711`](https://github.com/NixOS/nixpkgs/commit/9b795711fa45f8b7e205e8510b1a20f8df8080fa) | `` wslay: fix package ``                                                                                         |
| [`06361473`](https://github.com/NixOS/nixpkgs/commit/06361473d2e535c0cf8224578a62209840683d6f) | `` python312Packages.langchain: 0.1.11 -> 0.1.13 ``                                                              |
| [`eef78a0b`](https://github.com/NixOS/nixpkgs/commit/eef78a0b536c1f4e2d0776bebe6e41cff60faa6b) | `` python312Packages.langsmith: 0.1.33 -> 0.1.36 ``                                                              |
| [`7b27f7fb`](https://github.com/NixOS/nixpkgs/commit/7b27f7fbc5e787ce2b67dbdd5f6d323d13f0473b) | `` python312Packages.langchain-community: 0.0.27 -> 0.0.29 ``                                                    |
| [`7ce2a9dc`](https://github.com/NixOS/nixpkgs/commit/7ce2a9dc5267cf3ad8f54bca6fe9a12453bb2a98) | `` python312Packages.langchain-core: 0.1.32 -> 0.1.36 ``                                                         |
| [`629cd944`](https://github.com/NixOS/nixpkgs/commit/629cd9446904551106e13ddc495442c9160d46ed) | `` docs/nrd: remove docbook rendering support ``                                                                 |
| [`ec71d0da`](https://github.com/NixOS/nixpkgs/commit/ec71d0da98aa4e9fab4e84701512ef3e2930b884) | `` docs/nrd: move make_xml_id to manual_structure ``                                                             |
| [`02aff756`](https://github.com/NixOS/nixpkgs/commit/02aff756c3d4c8abaea56d716ba8ff017cb2dd9b) | `` nixos/doc: remove optionsDocBook ``                                                                           |
| [`4f625228`](https://github.com/NixOS/nixpkgs/commit/4f625228627e0edc3de588c384bfb3997c23c98a) | `` vector: 0.36.1 → 0.37.0 ``                                                                                    |
| [`47f877d4`](https://github.com/NixOS/nixpkgs/commit/47f877d41e92d1d3418a0250aad08a5988157025) | `` Revert "python311Packages.pathlib-abc: 0.1.1 -> 0.2.0" ``                                                     |
| [`d05f19f5`](https://github.com/NixOS/nixpkgs/commit/d05f19f5c298f33707c033863d131bfbd0af7ec5) | `` elmPackages.makeDotElm: modernize ``                                                                          |
| [`ae5eab1b`](https://github.com/NixOS/nixpkgs/commit/ae5eab1bf17d71ab2e7c467aa13ccd3811d73fff) | `` elm: refactor file structure ``                                                                               |
| [`de9db9a2`](https://github.com/NixOS/nixpkgs/commit/de9db9a27ba038099b0412562f85e7a35ca23a5c) | `` brscan5: fix sane config path ``                                                                              |
| [`74839cc4`](https://github.com/NixOS/nixpkgs/commit/74839cc49be16d43249fa788179865832d64c1ed) | `` redpanda-client: 23.3.9 -> 23.3.10 ``                                                                         |
| [`8ccea5a5`](https://github.com/NixOS/nixpkgs/commit/8ccea5a5473e58416acfc7898a34d9b4b349f69e) | `` k0sctl: 0.17.4 -> 0.17.5 ``                                                                                   |
| [`db7df7bf`](https://github.com/NixOS/nixpkgs/commit/db7df7bf66064de89e6f56637853c7cfe254d2f4) | `` roon-server: 2.0-1382 -> 2.0-1388 ``                                                                          |
| [`6955b374`](https://github.com/NixOS/nixpkgs/commit/6955b3743c86b032cb15108ad3b522f40ee4b451) | `` nixos/roon-server: add package option ``                                                                      |
| [`a5b7a0ff`](https://github.com/NixOS/nixpkgs/commit/a5b7a0ff37bfed61f6b015228da6f212c683797c) | `` elmPackages: sync node version ``                                                                             |
| [`b6cb4ebc`](https://github.com/NixOS/nixpkgs/commit/b6cb4ebcc04820d0e34ac1dd39f5dd37f447241a) | `` retroarch-joypad-autoconfig: 1.17.0 -> 1.18.0 ``                                                              |
| [`df334cc9`](https://github.com/NixOS/nixpkgs/commit/df334cc96409b7d1313e8707153d950ee5065507) | `` libretro.gambatte: unstable-2024-03-15 -> unstable-2024-03-22 ``                                              |
| [`7cf7c9c6`](https://github.com/NixOS/nixpkgs/commit/7cf7c9c63b869bd25766dd305b5b90f41dfe5b9f) | `` python311Packages.tilequant: refactor ``                                                                      |
| [`1139d41d`](https://github.com/NixOS/nixpkgs/commit/1139d41d5fcec605851a83c34f00fcf327cbc0ea) | `` libretro.flycast: unstable-2024-03-19 -> unstable-2024-03-26 ``                                               |
| [`cf96eb52`](https://github.com/NixOS/nixpkgs/commit/cf96eb52fd3a659818ab33414344d46d62db39e9) | `` python312Packages.mypy-boto3: set exec permission for update script ``                                        |
| [`dc8a9737`](https://github.com/NixOS/nixpkgs/commit/dc8a9737edd7ac63bf7814e47bfdf3ca23489de7) | `` python311Packages.mypy-boto3-secretsmanager: 1.34.63 -> 1.34.72 ``                                            |
| [`d928fa22`](https://github.com/NixOS/nixpkgs/commit/d928fa229e6634d77126c6d94fbbc3428c30e999) | `` python311Packages.mypy-boto3-sagemaker: 1.34.64 -> 1.34.70 ``                                                 |
| [`45217c44`](https://github.com/NixOS/nixpkgs/commit/45217c4474046c4410a4a1606ac9370cba5b1b3d) | `` python311Packages.mypy-boto3-medialive: 1.34.47 -> 1.34.70 ``                                                 |
| [`5e136869`](https://github.com/NixOS/nixpkgs/commit/5e1368690fecfc8fa54c60775b177c2275019190) | `` python311Packages.mypy-boto3-globalaccelerator: 1.34.0 -> 1.34.70 ``                                          |
| [`7a830bb8`](https://github.com/NixOS/nixpkgs/commit/7a830bb8139d044a4b02dc4cbaf0c973c893d1ab) | `` python311Packages.mypy-boto3-finspace: 1.34.66 -> 1.34.71 ``                                                  |
| [`9a41ca54`](https://github.com/NixOS/nixpkgs/commit/9a41ca54f7b2d74b913ea53a037f24081f2b8aee) | `` python311Packages.mypy-boto3-emr-containers: 1.34.0 -> 1.34.70 ``                                             |
| [`07f5d331`](https://github.com/NixOS/nixpkgs/commit/07f5d331f29a1c217bcbcfd17746abf738216a36) | `` python311Packages.mypy-boto3-elasticache: 1.34.60 -> 1.34.72 ``                                               |
| [`655740df`](https://github.com/NixOS/nixpkgs/commit/655740dfc35235f8039f2b43129a5fb0b01e2e13) | `` python311Packages.mypy-boto3-ecs: 1.34.39 -> 1.34.71 ``                                                       |
| [`227c394e`](https://github.com/NixOS/nixpkgs/commit/227c394e32b5a0273d52443f62c0f52176b12048) | `` python311Packages.mypy-boto3-ec2: 1.34.66 -> 1.34.71 ``                                                       |
| [`7a81c73e`](https://github.com/NixOS/nixpkgs/commit/7a81c73ec789176cdcf7bd843361542d3cfb9bf3) | `` python311Packages.mypy-boto3-codebuild: 1.34.67 -> 1.34.70 ``                                                 |
| [`0d14c526`](https://github.com/NixOS/nixpkgs/commit/0d14c526c30680514779f22598d6187698745969) | `` python311Packages.mypy-boto3-ce: 1.34.52 -> 1.34.71 ``                                                        |
| [`91818b15`](https://github.com/NixOS/nixpkgs/commit/91818b154f17947796dcc9f22c97d878e60f2421) | `` python311Packages.mypy-boto3-batch: 1.34.59 -> 1.34.72 ``                                                     |
| [`b82bcbdb`](https://github.com/NixOS/nixpkgs/commit/b82bcbdb356ad5811d2702dff0b7a1d96308cb30) | `` gopls: set correct version (#299690) ``                                                                       |
| [`d9ef35f1`](https://github.com/NixOS/nixpkgs/commit/d9ef35f1928f0b36369e6f94804fd4e9726c4442) | `` python311Packages.fjaraskupan: add changelog to meta ``                                                       |
| [`12935503`](https://github.com/NixOS/nixpkgs/commit/12935503a74166d1ab0d7bbc4b2002c2044ea5fd) | `` python311Packages.fjaraskupan: refactor ``                                                                    |
| [`0d66ff03`](https://github.com/NixOS/nixpkgs/commit/0d66ff03de1620596a1a0f87128c200f27748b50) | `` python311Packages.fjaraskupan: 2.2.0 -> 2.3.0 ``                                                              |
| [`136e5d4b`](https://github.com/NixOS/nixpkgs/commit/136e5d4b8e21133973e5301e055f7f0fef632743) | `` python311Packages.ollama: refactor ``                                                                         |
| [`0cb341b4`](https://github.com/NixOS/nixpkgs/commit/0cb341b478dfb68e480756d94466446543fb0903) | `` python311Packages.ollama: 0.1.7 -> 0.1.8 ``                                                                   |
| [`861a7977`](https://github.com/NixOS/nixpkgs/commit/861a797763a0cfc739abe0a78235ab9ccdfab5a8) | `` python311Packages.pyunifiprotect: 5.0.2 -> 5.1.1 ``                                                           |
| [`27b02170`](https://github.com/NixOS/nixpkgs/commit/27b0217072b50ad3ee3b5313aacdadd87d553afe) | `` libretro.bsnes: unstable-2024-03-15 -> unstable-2024-03-22 ``                                                 |
| [`00ec049c`](https://github.com/NixOS/nixpkgs/commit/00ec049cfca8cf4614ab0dd33aeb8f5c726c4bb0) | `` tf-summarize: 0.3.9 -> 0.3.10 ``                                                                              |
| [`e211fda2`](https://github.com/NixOS/nixpkgs/commit/e211fda228470d789f701d05e926b542ed15cef8) | `` wit-bindgen: 0.22.0 -> 0.23.0 ``                                                                              |
| [`6a10a5f5`](https://github.com/NixOS/nixpkgs/commit/6a10a5f509ce97b96e4a599cef0ae26ecf64b133) | `` platformsh: add spk as maintainer ``                                                                          |
| [`ba6a6b54`](https://github.com/NixOS/nixpkgs/commit/ba6a6b548d05ad45339817bd76383328ed074a83) | `` platformsh: 4.11.4 -> 4.17.0 ``                                                                               |
| [`306fe97c`](https://github.com/NixOS/nixpkgs/commit/306fe97cef91a07ea9466e2aa160597dfe983f90) | `` maintainers: add spk ``                                                                                       |
| [`0c39588c`](https://github.com/NixOS/nixpkgs/commit/0c39588cff2377e24655c252456673ca8a2a2f0f) | `` python312Packages.extract-msg: 0.48.3 -> 0.48.4 ``                                                            |