### PR TITLE
chore(flake/nixpkgs): `08b9151e` -> `fd281bd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712122226,
-        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`1484678e`](https://github.com/NixOS/nixpkgs/commit/1484678e2fffc3abc1689eeacffefca2cbc9a51a) | `` _64gram: fix uppercase letter in pname ``                                                       |
| [`fab46df7`](https://github.com/NixOS/nixpkgs/commit/fab46df7639328c77c575e55bf18a5c54374d4a0) | `` gh-f: package as standalone command ``                                                          |
| [`1a1bfe08`](https://github.com/NixOS/nixpkgs/commit/1a1bfe0857813661d51eee402c88b5a4f0189c21) | `` gh-notify: init at 0-unstable-2024-03-19 ``                                                     |
| [`24af99ca`](https://github.com/NixOS/nixpkgs/commit/24af99ca711e60bdddf54dc84ab722e36607d088) | `` linux-rt_5_15: 5.15.148-rt74 -> 5.15.153-rt75 ``                                                |
| [`505b96c9`](https://github.com/NixOS/nixpkgs/commit/505b96c94c6370c929d779bf3b3622f83c876875) | `` linux_6_1: 6.1.83 -> 6.1.84 ``                                                                  |
| [`26b1b707`](https://github.com/NixOS/nixpkgs/commit/26b1b707e8d40a148876d84c6195fed366adaefa) | `` linux_6_6: 6.6.23 -> 6.6.24 ``                                                                  |
| [`073a26ea`](https://github.com/NixOS/nixpkgs/commit/073a26ea454df46ae180207c752ef8c6f6e6ea85) | `` linux_6_7: 6.7.11 -> 6.7.12 ``                                                                  |
| [`b1a006e8`](https://github.com/NixOS/nixpkgs/commit/b1a006e80e93486fed50c51ea5c212dfffd306fe) | `` linux_6_8: 6.8.2 -> 6.8.3 ``                                                                    |
| [`deef0a9d`](https://github.com/NixOS/nixpkgs/commit/deef0a9d5fc96b7f0e4f9d0506712ba524b05507) | `` vimPlugins.cmp_yanky: Added homepage ``                                                         |
| [`b4c207c4`](https://github.com/NixOS/nixpkgs/commit/b4c207c41de6c31e9b303534814c9b652db65b98) | `` vimPlugins.cmp_yanky: init at 2023-11-16 ``                                                     |
| [`e113e819`](https://github.com/NixOS/nixpkgs/commit/e113e8197a68b0a7500a30b28da4277b6c529ca9) | `` vimPlugins.competitest-nvim: init at 2024-01-23 ``                                              |
| [`8d385d2b`](https://github.com/NixOS/nixpkgs/commit/8d385d2b5aec2da14c411f9be5be8f9014e04f57) | `` gopatch: 0.3.0 -> 0.4.0 ``                                                                      |
| [`84419346`](https://github.com/NixOS/nixpkgs/commit/84419346a958d1478cfb2ab5691fa926509f7f3a) | `` firefox-bin-unwrapped: 124.0.1 -> 124.0.2 ``                                                    |
| [`014a603d`](https://github.com/NixOS/nixpkgs/commit/014a603d23c57b6fcd9c6f7a47f8745a07d442a1) | `` firefox-unwrapped: 124.0.1 -> 124.0.2 ``                                                        |
| [`3532edfb`](https://github.com/NixOS/nixpkgs/commit/3532edfb2b68b5be70037713cdee6f52358d0ff7) | `` bitcoin: 26.0 -> 26.1 ``                                                                        |
| [`bc4802a7`](https://github.com/NixOS/nixpkgs/commit/bc4802a7d67d5f5cb2bf4eee7f51601ecfc3f8c8) | `` kstars: 3.6.9 -> 3.7.0 + fixing build failure ``                                                |
| [`853a4402`](https://github.com/NixOS/nixpkgs/commit/853a440235bb8c02488935aa454aaec34976b9a5) | `` neocmakelsp: 0.6.20 -> 0.6.22 ``                                                                |
| [`b33c8f42`](https://github.com/NixOS/nixpkgs/commit/b33c8f42af0a58984c76832da577ec2e937b1626) | `` parquet-tools: 0.2.14 -> 0.2.16 ``                                                              |
| [`51912b15`](https://github.com/NixOS/nixpkgs/commit/51912b15f834ad07536783f4eea62fb50341d0f8) | `` parquet-tools: support Moto 5.x ``                                                              |
| [`0eed0f13`](https://github.com/NixOS/nixpkgs/commit/0eed0f1309446e65bdedb3495a16befe06b926ba) | `` libvirt: Use valid runstatedir for Darwin ``                                                    |
| [`f3a9c375`](https://github.com/NixOS/nixpkgs/commit/f3a9c375cc9a550fd5b8160542da629cc2a63b66) | `` epub-thumbnailer: 0-unstable-2024-03-16 -> 0-unstable-2024-03-26 ``                             |
| [`1597810a`](https://github.com/NixOS/nixpkgs/commit/1597810a9ea03ba8407f1f45ae70cbbe0642970f) | `` st: remove andsild as maintainer (#301201) ``                                                   |
| [`8352227f`](https://github.com/NixOS/nixpkgs/commit/8352227f58e76cf53262633cda6b06924a4c86f6) | `` python311Packages.oslo-log: 5.5.0 -> 5.5.1 ``                                                   |
| [`912d84a6`](https://github.com/NixOS/nixpkgs/commit/912d84a6d84aaab59bf5e4da4050abea6a7be00b) | `` makeFontsConf: refactor for readibility (#299220) ``                                            |
| [`cd467b60`](https://github.com/NixOS/nixpkgs/commit/cd467b6063fd8d16dd0e2912dc2f30c9cc5e5c3d) | `` rwpspread: 0.2.4 -> 0.2.5 ``                                                                    |
| [`30edf658`](https://github.com/NixOS/nixpkgs/commit/30edf65874e2e87871afdd0f1c37263fe8c3acf2) | `` risor: 1.5.1 -> 1.5.2 ``                                                                        |
| [`b1288490`](https://github.com/NixOS/nixpkgs/commit/b1288490f7ca908825002b8983a8e884d31387b5) | `` ddns-go: 6.3.0 -> 6.3.1 ``                                                                      |
| [`ffa73a66`](https://github.com/NixOS/nixpkgs/commit/ffa73a6608ed1b218b030d537b26c57c3edd398d) | `` phpactor: 2023.12.03.0 -> 2024.03.09.0 ``                                                       |
| [`7ab1a0dd`](https://github.com/NixOS/nixpkgs/commit/7ab1a0dd456218b8ed5322e0d079354fd4c3d494) | `` vscode-extensions.hbenl.vscode-test-explorer: init at 2.21.1 ``                                 |
| [`0d7427ea`](https://github.com/NixOS/nixpkgs/commit/0d7427ea73375adabcff66a895fd50863ccdfcc7) | `` python312Packages.google-ai-generativelanguage: use nixfmt ``                                   |
| [`f060f646`](https://github.com/NixOS/nixpkgs/commit/f060f64619f304dc42cb35cc21c7f73495ccdd9f) | `` python312Packages.google-ai-generativelanguage: 0.6.0 -> 0.6.1 ``                               |
| [`eb903959`](https://github.com/NixOS/nixpkgs/commit/eb903959af7fb6b1ce9f91cb59f1cb3934e3986a) | `` kubeshark: 52.1.77 -> 52.2.1 ``                                                                 |
| [`c0ce798d`](https://github.com/NixOS/nixpkgs/commit/c0ce798d8114d958b622f32055f4582e85c88855) | `` python3Packages.numba: fix: make free again ``                                                  |
| [`ee457b8b`](https://github.com/NixOS/nixpkgs/commit/ee457b8b080168886039694a61ce098750fb1b79) | `` Avoid top-level `with ...;` in pkgs/development/lua-modules/aliases.nix ``                      |
| [`0e83dd50`](https://github.com/NixOS/nixpkgs/commit/0e83dd50eac2964453c5ec3c85c61c820fe84108) | `` deepin.deepin-picker: 6.0.0 -> 6.0.1 ``                                                         |
| [`1616ab21`](https://github.com/NixOS/nixpkgs/commit/1616ab211b88b5a4f0cea12d3ba2ef34d8d4701c) | `` diffutils: disable tests in diffutils on riscv64 ``                                             |
| [`fcae6f8d`](https://github.com/NixOS/nixpkgs/commit/fcae6f8db8315a87e5dd4a3d817b98d56c020529) | `` mystmd: 1.1.48 -> 1.1.50 ``                                                                     |
| [`2275d54d`](https://github.com/NixOS/nixpkgs/commit/2275d54d337d89724276ede52167530d404545f0) | `` ripes: 2.2.6-unstable-2024-03-03 -> 2.2.6-unstable-2024-04-02 ``                                |
| [`fe01395d`](https://github.com/NixOS/nixpkgs/commit/fe01395de21d2e28fbaa9933cfbdc453643c76ea) | `` qolibri: 2.1.4 -> 2.1.5-unstable-2024-03-17 ``                                                  |
| [`c8497682`](https://github.com/NixOS/nixpkgs/commit/c8497682546f35861bbfc89453b59c247b5ddaf3) | `` xgboost: use pkgs.autoAddDriverRunpath ``                                                       |
| [`eef06fe9`](https://github.com/NixOS/nixpkgs/commit/eef06fe93ea548dc7b84e8bafa9399fbcbbe2ce7) | `` foot: 1.16.2 -> 1.17.0 ``                                                                       |
| [`865f976d`](https://github.com/NixOS/nixpkgs/commit/865f976ddd33b90c47e72299030f492cc746e2e5) | `` nixos/v2raya: fix nftables support ``                                                           |
| [`efd45198`](https://github.com/NixOS/nixpkgs/commit/efd4519818ebc4bb24fcdf907a2ff1f2a10b15be) | `` python311Packages.peaqevcore: refactor ``                                                       |
| [`b213b627`](https://github.com/NixOS/nixpkgs/commit/b213b627a9c9db6a9610566ffb03eae08837b7da) | `` vulnix: 1.10.1 -> 1.10.1-unstable-2024-04-02 ``                                                 |
| [`b385c0ea`](https://github.com/NixOS/nixpkgs/commit/b385c0ea8ead5613694606de0755e39b051ae00f) | `` gotestwaf: 0.4.17 -> 0.4.18 ``                                                                  |
| [`768747ee`](https://github.com/NixOS/nixpkgs/commit/768747ee572409e107be01daa1b266866fb825f0) | `` rain: 1.8.2 -> 1.8.3 ``                                                                         |
| [`381e517d`](https://github.com/NixOS/nixpkgs/commit/381e517d36e45b9097b0f46b390821c5ef7deb3d) | `` python312Packages.boto3-stubs: 1.34.74 -> 1.34.76 ``                                            |
| [`8a0bef62`](https://github.com/NixOS/nixpkgs/commit/8a0bef6221295f723cbccdac4535a477ec5df57a) | `` python312Packages.edk2-pytool-library: refactor ``                                              |
| [`45b46c84`](https://github.com/NixOS/nixpkgs/commit/45b46c84c44adca69ee596c552760691c6a4d0bb) | `` python312Packages.google-cloud-firestore: refactor ``                                           |
| [`f191c7b0`](https://github.com/NixOS/nixpkgs/commit/f191c7b0d4df45febde1785074c6303ec4ab96d4) | `` python312Packages.mkdocstrings: refactor ``                                                     |
| [`51152898`](https://github.com/NixOS/nixpkgs/commit/51152898b908c958c0d2481a5ddf784edb3b21a0) | `` python312Packages.tencentcloud-sdk-python: 3.0.1121 -> 3.0.1122 ``                              |
| [`9f191da5`](https://github.com/NixOS/nixpkgs/commit/9f191da5da0f687da8114d8c6f66d0e6ebe2434f) | `` python312Packages.dploot: refactor ``                                                           |
| [`9c793508`](https://github.com/NixOS/nixpkgs/commit/9c79350876e8248c3c4f01fc64f962b008d8d9a2) | `` python312Packages.whenever: refactor ``                                                         |
| [`b9d24bbf`](https://github.com/NixOS/nixpkgs/commit/b9d24bbfecd031813a3c68b7841c94cf3b6f813a) | `` exploitdb: 2024-03-29 -> 2024-04-03 ``                                                          |
| [`695a027c`](https://github.com/NixOS/nixpkgs/commit/695a027cb548efb99779b4d35839c7118fd40ef0) | `` checkov: 3.2.50 -> 3.2.51 ``                                                                    |
| [`ad30c640`](https://github.com/NixOS/nixpkgs/commit/ad30c640d625f9e5dde9843989b7eac57d305375) | `` civo: 1.0.77 -> 1.0.80 ``                                                                       |
| [`4192bbbd`](https://github.com/NixOS/nixpkgs/commit/4192bbbdcf58001eae1efc0c72846210004eaed4) | `` algolia-cli: 1.6.5 -> 1.6.6 ``                                                                  |
| [`0decb324`](https://github.com/NixOS/nixpkgs/commit/0decb324b3459e2ff78db4b424dbce8946290726) | `` doc: improve fetchers overview, deduplicate readme content, follow doc conventions (#297654) `` |
| [`3b2fe1c8`](https://github.com/NixOS/nixpkgs/commit/3b2fe1c824627a895583167d41f86b7a03fcfa97) | `` shopware-cli: 0.4.30 -> 0.4.33 ``                                                               |
| [`dddb92b8`](https://github.com/NixOS/nixpkgs/commit/dddb92b891fedf13ccec114c295bee1968e39f55) | `` overmind: 2.5.0 -> 2.5.1 ``                                                                     |
| [`f86158cd`](https://github.com/NixOS/nixpkgs/commit/f86158cd9a0cf41edb2b99e9615495c7fedff318) | `` Revert "swift: don't pass -march to swiftc" ``                                                  |
| [`9fd2efac`](https://github.com/NixOS/nixpkgs/commit/9fd2efac08231b9a13459eafb597820b1023e23c) | `` swiftc: pass -Xcc before -march ``                                                              |
| [`6330a2b8`](https://github.com/NixOS/nixpkgs/commit/6330a2b8c45ea4ad9fe9c653220832216898b442) | `` gnuradio3_9Packages.osmosdr: 0.2.4 -> 0.2.5 ``                                                  |
| [`f67c0d9b`](https://github.com/NixOS/nixpkgs/commit/f67c0d9bd09f46e7cd9ffb75abc56ad5265a52ab) | `` minijinja: 1.0.15 -> 1.0.16 ``                                                                  |
| [`deb0873d`](https://github.com/NixOS/nixpkgs/commit/deb0873db7ce9caf6d6fc7dfe3b046a94e1700ee) | `` typos: 1.20.1 -> 1.20.3 ``                                                                      |
| [`844106fc`](https://github.com/NixOS/nixpkgs/commit/844106fc86ba7d9cbea2b1f8be7c300581e668a7) | `` python312Packages.dploot: 2.6.2 -> 2.7.0 ``                                                     |
| [`22558083`](https://github.com/NixOS/nixpkgs/commit/22558083a10bf9aba88ab772f5daf73e64c601e4) | `` python312Packages.whenever: 0.5.0 -> 0.5.1 ``                                                   |
| [`29ed8e30`](https://github.com/NixOS/nixpkgs/commit/29ed8e3015d163e8660fc567f95039b4892f3ab3) | `` python312Packages.mkdocstrings: 0.24.1 -> 0.24.2 ``                                             |
| [`2ab9fbb1`](https://github.com/NixOS/nixpkgs/commit/2ab9fbb1e5ee65aca7c9cc5ccd38c5f34d7c91b5) | `` python312Packages.google-cloud-firestore: 2.15.0 -> 2.16.0 ``                                   |
| [`b4945ec1`](https://github.com/NixOS/nixpkgs/commit/b4945ec190b15994815854ffbb36cb10779ea0c8) | `` python312Packages.edk2-pytool-library: 0.21.4 -> 0.21.5 ``                                      |
| [`25a5f227`](https://github.com/NixOS/nixpkgs/commit/25a5f227f7ef8ba9cf90cdc22a67b2b2288b51ce) | `` postgresql15JitPackages.pg_partman: 5.0.1 -> 5.1.0 ``                                           |
| [`bb2278e4`](https://github.com/NixOS/nixpkgs/commit/bb2278e4a0955e17066c76c98fe64541904591c5) | `` opensearch: 2.12.0 -> 2.13.0 ``                                                                 |
| [`a779399a`](https://github.com/NixOS/nixpkgs/commit/a779399a8bd9dbafa53edbf9b44c7d3c92681b27) | `` kubedock: 0.15.5 -> 0.16.0 ``                                                                   |
| [`d0469c6f`](https://github.com/NixOS/nixpkgs/commit/d0469c6f6298fe368c75583ed18435434c09138a) | `` kubergrunt: 0.14.2 -> 0.15.0 ``                                                                 |
| [`2b76e669`](https://github.com/NixOS/nixpkgs/commit/2b76e669fb742966a3fa020256feada8e6abd233) | `` qownnotes: 24.3.5 -> 24.4.0 ``                                                                  |
| [`45e30693`](https://github.com/NixOS/nixpkgs/commit/45e306931244be6a0aef1b94a7e74204a0d406cd) | `` gitsign: 0.9.0 -> 0.10.1 ``                                                                     |
| [`663be2fb`](https://github.com/NixOS/nixpkgs/commit/663be2fbd716ebc2a9a812d4ad72bdbfa899e30e) | `` atmos: 1.66.0 -> 1.67.0 ``                                                                      |
| [`511009ad`](https://github.com/NixOS/nixpkgs/commit/511009ada7a9c2c7855201bc871e61b9e03ad790) | `` qmplay2: 24.03.16 -> 24.04.02 ``                                                                |
| [`f2966a41`](https://github.com/NixOS/nixpkgs/commit/f2966a41550c45b6b9f2630c601df65726078e22) | `` cargo-leptos: 0.2.16 -> 0.2.17 ``                                                               |
| [`a0c1ca99`](https://github.com/NixOS/nixpkgs/commit/a0c1ca99ca4ee9033b3c34761e876ea6043dbb92) | `` syncthingtray: 1.5.0 -> 1.5.1 ``                                                                |
| [`03f4397c`](https://github.com/NixOS/nixpkgs/commit/03f4397c369c18ab280fdcd578c89afb397b8420) | `` mongoc: 1.26.1 -> 1.26.2 ``                                                                     |
| [`f626720e`](https://github.com/NixOS/nixpkgs/commit/f626720e677de9b25df443fd84ed3b7905d19fe9) | `` arti: 1.2.0 -> 1.2.1 ``                                                                         |
| [`ec7e7712`](https://github.com/NixOS/nixpkgs/commit/ec7e7712b59e4c6427ec3e6717824e6f99e71b90) | `` kdePackages.qtutilities: 6.13.5 -> 6.14.0 ``                                                    |
| [`ecf98f67`](https://github.com/NixOS/nixpkgs/commit/ecf98f67308207ce6effaeb6c9f259171a80efef) | `` stubby: update homepage ``                                                                      |
| [`ebee574f`](https://github.com/NixOS/nixpkgs/commit/ebee574f0a46ab079da2c24ddde8553ac6898ee9) | `` davix: 0.8.5 -> 0.8.6 ``                                                                        |
| [`fca0124a`](https://github.com/NixOS/nixpkgs/commit/fca0124a51afa047a15cd96cea5d164f83dee154) | `` cargo-pgo: 0.2.6 -> 0.2.8 ``                                                                    |
| [`030a74ba`](https://github.com/NixOS/nixpkgs/commit/030a74ba22daad338a856666418cf97fdc9c709e) | `` pscale: 0.186.0 -> 0.191.0 ``                                                                   |
| [`466e57cb`](https://github.com/NixOS/nixpkgs/commit/466e57cb4764d0863202853ad7caa5f1a18c409e) | `` pagefind: 1.0.4 -> 1.1.0 ``                                                                     |
| [`45e8a573`](https://github.com/NixOS/nixpkgs/commit/45e8a5734f3a6d42f5a5057f1796de802b2f47be) | `` oh-my-posh: 19.18.1 -> 19.19.0 ``                                                               |
| [`604a145e`](https://github.com/NixOS/nixpkgs/commit/604a145e25cce41f683eeaa4e10d9888e72cc71f) | `` xpipe: 8.5 -> 8.6 ``                                                                            |
| [`766f3e85`](https://github.com/NixOS/nixpkgs/commit/766f3e85e1f4cc83ef4e6fed06cd3d08cb0231ef) | `` python311Packages.orbax-checkpoint: 0.5.5 -> 0.5.7 ``                                           |
| [`63a5fb91`](https://github.com/NixOS/nixpkgs/commit/63a5fb914a37b086f0d95a1b39ab8a232cad08ba) | `` python311Packages.trimesh: 4.2.2 -> 4.2.4 ``                                                    |
| [`6e41227f`](https://github.com/NixOS/nixpkgs/commit/6e41227f1efb472607bcc7238330a518696e2654) | `` marimo: 0.3.5 -> 0.3.8 ``                                                                       |
| [`b41a6498`](https://github.com/NixOS/nixpkgs/commit/b41a6498fb5734d9d826f3018a889a9660e26eff) | `` python312Packages.iceportal: refactor ``                                                        |
| [`428661dd`](https://github.com/NixOS/nixpkgs/commit/428661dd5a53c5cc0f30361e640981b13d6a554f) | `` python312Packages.iceportal: 1.1.2 -> 1.2.0 ``                                                  |
| [`ab59037e`](https://github.com/NixOS/nixpkgs/commit/ab59037ef4470934205ab968847de2f91a8dc22b) | `` kns: allow building on any unix platform ``                                                     |
| [`e92fdc7d`](https://github.com/NixOS/nixpkgs/commit/e92fdc7daec598cbe9b469068d8cc721244d8d6f) | `` python312Packages.volkszaehler: refactor ``                                                     |
| [`526e7d9d`](https://github.com/NixOS/nixpkgs/commit/526e7d9df79de1bf2f2c0cc711e86c87b9e0bf54) | `` python312Packages.volkszaehler: 0.4.0 -> 0.5.0 ``                                               |
| [`1b84906c`](https://github.com/NixOS/nixpkgs/commit/1b84906c6fbe7d2d47848821d8c324a1045c8b4d) | `` python311Packages.dploot: 2.6.2 -> 2.7.0 ``                                                     |
| [`30feff92`](https://github.com/NixOS/nixpkgs/commit/30feff921b22b3e22274246d178e2be81bda353c) | `` python312Packages.netdata: 1.1.0 -> 1.2.0 ``                                                    |
| [`ff249bd5`](https://github.com/NixOS/nixpkgs/commit/ff249bd530eee842c53c4ef06e793965d3f62f58) | `` nextcloud-client: 3.12.2 -> 3.12.3 ``                                                           |
| [`4a0b0055`](https://github.com/NixOS/nixpkgs/commit/4a0b0055eb64047aa178f388d62d9d917c841d11) | `` python312Packages.aiounifi: 73 -> 74 ``                                                         |
| [`92fa58c2`](https://github.com/NixOS/nixpkgs/commit/92fa58c20372f6b699e9ce43c049ed45d71186d6) | `` zfs-replicate: 3.2.11 -> 3.2.12 ``                                                              |
| [`6d4078e7`](https://github.com/NixOS/nixpkgs/commit/6d4078e7f4cf2f1e30a7edf17d408d28eb02c8a4) | `` miriway: unstable-2024-03-15 -> unstable-2024-04-02 ``                                          |
| [`86258a59`](https://github.com/NixOS/nixpkgs/commit/86258a598932eed7efdbfdbd800b879e9321de23) | `` stirling-pdf: init at 0.22.3 ``                                                                 |
| [`97cec92c`](https://github.com/NixOS/nixpkgs/commit/97cec92c51184ed53ea4d59325f057b9af402b69) | `` luaPackages.sqlite: fix build ``                                                                |
| [`461df534`](https://github.com/NixOS/nixpkgs/commit/461df53427b1a8879ea14d2aede14a882ba4005f) | `` luaPackages.ldbus: make override more robust ``                                                 |
| [`88328bcf`](https://github.com/NixOS/nixpkgs/commit/88328bcf2fd153862d8fa0a5f145acc0a04970fb) | `` lua overrides, limit the scope of the with; ``                                                  |
| [`613c2ddc`](https://github.com/NixOS/nixpkgs/commit/613c2ddc6f3e35ed296b3bcb7898591ac6a19f7c) | `` tailscale-nginx-auth: 1.62.0 -> 1.62.1 ``                                                       |