### PR TITLE
chore(flake/nixvim): `4530a35b` -> `e035d22b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1715582453,
-        "narHash": "sha256-pW8a12PHt/PUphG8Tn0nb+mfbTS7JS4YbThGPepCcb0=",
+        "lastModified": 1715758881,
+        "narHash": "sha256-0W9F2F9YnqMZPBrz68VrTALlhTyBBeuuh/xD8C0PEVg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4530a35bad28a0e8b21905b0817a225e6387811c",
+        "rev": "e035d22b64a9bd5f469664cbe42ea798d7c16b2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`e035d22b`](https://github.com/nix-community/nixvim/commit/e035d22b64a9bd5f469664cbe42ea798d7c16b2e) | `` standalone: Expose `options` ``                    |
| [`2705ce0e`](https://github.com/nix-community/nixvim/commit/2705ce0ec68361296d49c68fe0b63c3ba2f41d33) | `` plugins/lsp/language-servers: harmless refactor `` |