### PR TITLE
chore(flake/nixvim): `e035d22b` -> `6be28a94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -320,11 +320,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1715758881,
-        "narHash": "sha256-0W9F2F9YnqMZPBrz68VrTALlhTyBBeuuh/xD8C0PEVg=",
+        "lastModified": 1715807613,
+        "narHash": "sha256-3kL4E0Ff9TCvRNxwINzklupY7dcTpl89jTg0PGfBCJc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e035d22b64a9bd5f469664cbe42ea798d7c16b2e",
+        "rev": "6be28a941b39a7cbe4d34b577bd095548f5d1e15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`6be28a94`](https://github.com/nix-community/nixvim/commit/6be28a941b39a7cbe4d34b577bd095548f5d1e15) | `` plugins/lsp/nixd: refactor ``                                                 |
| [`f14aa756`](https://github.com/nix-community/nixvim/commit/f14aa756bad2df2264d84913cba4b27b9392fcfe) | `` plugins/lsp/vls: inline options and config in language-servers/default.nix `` |
| [`e97755be`](https://github.com/nix-community/nixvim/commit/e97755be47aee128fbd1ff0dac5e61037f45ffa0) | `` plugins/lsp/language-servers: add extraOptions argument to mkLsp ``           |