### PR TITLE
chore(flake/nixvim): `6be28a94` -> `53697141`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713946171,
-        "narHash": "sha256-lc75rgRQLdp4Dzogv5cfqOg6qYc5Rp83oedF2t0kDp8=",
+        "lastModified": 1715653378,
+        "narHash": "sha256-6kbg/PI3+SBP17f4T0js3CBsMLVtlD0JqJhDKgzk1mQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "230a197063de9287128e2c68a7a4b0cd7d0b50a7",
+        "rev": "de8b0d60d6fd34f35abffc46adc94ebaa6996ce2",
         "type": "github"
       },
       "original": {
@@ -320,11 +320,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1715807613,
-        "narHash": "sha256-3kL4E0Ff9TCvRNxwINzklupY7dcTpl89jTg0PGfBCJc=",
+        "lastModified": 1715947282,
+        "narHash": "sha256-BFrcAf1MU2s3PRRSqoe8aFqwVxErLGYsSKO4z+PLOiw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6be28a941b39a7cbe4d34b577bd095548f5d1e15",
+        "rev": "53697141b59b66598a18cbdb003103f775c976e4",
         "type": "github"
       },
       "original": {
@@ -348,11 +348,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714478972,
-        "narHash": "sha256-q//cgb52vv81uOuwz1LaXElp3XAe1TqrABXODAEF6Sk=",
+        "lastModified": 1715609711,
+        "narHash": "sha256-/5u29K0c+4jyQ8x7dUIEUWlz2BoTSZWUP2quPwFCE7M=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2849da033884f54822af194400f8dff435ada242",
+        "rev": "c182c876690380f8d3b9557c4609472ebfa1b141",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`53697141`](https://github.com/nix-community/nixvim/commit/53697141b59b66598a18cbdb003103f775c976e4) | `` plugins/rustaceanvim: update options ``                                    |
| [`d844ac1a`](https://github.com/nix-community/nixvim/commit/d844ac1a0656d64266c2c95aec7f529420915d68) | `` plugins/lsp/tinymist: add settings options ``                              |
| [`72ff1489`](https://github.com/nix-community/nixvim/commit/72ff1489c7f40dae829fafc689fb6a57099a9739) | `` lib/options: make use of previously unused mkNullableWithRaw internally `` |
| [`c5bb651d`](https://github.com/nix-community/nixvim/commit/c5bb651d01d96ccd1675a8cb273ed1e6514c6a67) | `` plugins/arrow: init ``                                                     |
| [`3c09f581`](https://github.com/nix-community/nixvim/commit/3c09f5810b470af46536bee5e33d4046b97c4e98) | `` flake.lock: Update ``                                                      |