### PR TITLE
chore(flake/nixvim): `53697141` -> `7c4fe30f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -302,11 +302,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1715947282,
-        "narHash": "sha256-BFrcAf1MU2s3PRRSqoe8aFqwVxErLGYsSKO4z+PLOiw=",
+        "lastModified": 1715976947,
+        "narHash": "sha256-cfU0THstf6phd6vpzIzsew89Ns5JdPq7CyeiLRajE1g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "53697141b59b66598a18cbdb003103f775c976e4",
+        "rev": "7c4fe30f814595bc617d6b1b682ab9cbfe535d33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`7c4fe30f`](https://github.com/nix-community/nixvim/commit/7c4fe30f814595bc617d6b1b682ab9cbfe535d33) | `` lib/options: introduce new mkPackageOption for dependencies ``  |
| [`26367692`](https://github.com/nix-community/nixvim/commit/26367692daabb924c627a9f3a7af80c21f276afe) | `` lib/options: rename mkPackageOption to mkPluginPackageOption `` |
| [`40598fc1`](https://github.com/nix-community/nixvim/commit/40598fc1bd8c93adc3759aff5d5a39d4e66790e5) | `` Test statuscol segment without text ``                          |
| [`a9682e28`](https://github.com/nix-community/nixvim/commit/a9682e28ec9b5cb62a170b62f9ca03ff42cd40e0) | `` Allow statuscol segment text to be null ``                      |
| [`3766e363`](https://github.com/nix-community/nixvim/commit/3766e3633586ef9fac02f0347509171f0a4794b9) | `` lib/options: change "default: ..." to "Plugin default: ..." ``  |
| [`7697a1cc`](https://github.com/nix-community/nixvim/commit/7697a1cc5a0d08df7339d5a9e8a49d27f6438c01) | `` lib/options: refactor ``                                        |