### PR TITLE
chore(flake/nixpkgs): `33d1e753` -> `4a6b83b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715787315,
-        "narHash": "sha256-cYApT0NXJfqBkKcci7D9Kr4CBYZKOQKDYA23q8XNuWg=",
+        "lastModified": 1715961556,
+        "narHash": "sha256-+NpbZRCRisUHKQJZF3CT+xn14ZZQO+KjxIIanH3Pvn4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "33d1e753c82ffc557b4a585c77de43d4c922ebb5",
+        "rev": "4a6b83b05df1a8bd7d99095ec4b4d271f2956b64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`b0be8831`](https://github.com/NixOS/nixpkgs/commit/b0be883181e15007a95cb305451a9004d19e4fbd) | `` microcodeIntel: 20240312 -> 20240514 ``                                           |
| [`a4da2dc9`](https://github.com/NixOS/nixpkgs/commit/a4da2dc9ce227440ba9468f801d90ea7c6b98afe) | `` Add @ceedubs and @sellout as UCM maintainers. ``                                  |
| [`f8d5af45`](https://github.com/NixOS/nixpkgs/commit/f8d5af455807586848f5863b97cc7c57270fba42) | `` tracker-miners: move to pkgs/by-name ``                                           |
| [`e9a24f94`](https://github.com/NixOS/nixpkgs/commit/e9a24f94db47d2b9f78f552e5215dec4f01d2b98) | `` tracker-miners: 3.7.2 -> 3.7.3 ``                                                 |
| [`1d2460a6`](https://github.com/NixOS/nixpkgs/commit/1d2460a674fed0ca9813c5081b332acc4790bede) | `` audacious: link in Skins from audacious-plugins ``                                |
| [`4074fcd0`](https://github.com/NixOS/nixpkgs/commit/4074fcd0f27bbd0381eeb9b452a085ddbc37202d) | `` cachix: 1.7 -> 1.7.3 ``                                                           |
| [`671b0e58`](https://github.com/NixOS/nixpkgs/commit/671b0e58eb7ff4fd53a67042949160abe674c461) | `` home-assistant: pin plugwise at 0.37.3 ``                                         |
| [`bd90e5fd`](https://github.com/NixOS/nixpkgs/commit/bd90e5fd2866a57e791a51a9d03d74ccbd9e0944) | `` python312Packages.pyipp: format with nixfmt ``                                    |
| [`46faca71`](https://github.com/NixOS/nixpkgs/commit/46faca711b9e1565d0388bb1f295748053ec92f8) | `` python312Packages.pyipp: refactor ``                                              |
| [`e1c15567`](https://github.com/NixOS/nixpkgs/commit/e1c1556767aec96df88b4ce0f22cf926389d2126) | `` home-assistant-custom-components.midea_ac_lan: init at 0.3.22 ``                  |
| [`f2fbd4b4`](https://github.com/NixOS/nixpkgs/commit/f2fbd4b4110937b0d24cba294d94816f925cd3a4) | `` python312Packages.pyipp: 0.15.0 -> 0.16.0 ``                                      |
| [`2980f206`](https://github.com/NixOS/nixpkgs/commit/2980f2065fae619b0daf76fc248df685e5b4f581) | `` python3Packages.{str,willow}: drop python 2.7 check ``                            |
| [`05fa5917`](https://github.com/NixOS/nixpkgs/commit/05fa591701caed3c3211d0e9c7daac45a26fde48) | `` treewide: drop python 3.4 checks ``                                               |
| [`5d5c4baa`](https://github.com/NixOS/nixpkgs/commit/5d5c4baad83ea369ea10ec52bde7144c6eb14519) | `` treewide: drop python 3.3 checks ``                                               |
| [`9fb9a86f`](https://github.com/NixOS/nixpkgs/commit/9fb9a86ff8f8be8f72de58467fafe9fe83b9ad92) | `` python3Packages.{mock-open,pymarshal,qreactor}: drop python 3.0 checks ``         |
| [`b5bc9b45`](https://github.com/NixOS/nixpkgs/commit/b5bc9b45bf0c2973e17d98f9a2bb3f3697c22290) | `` python3Packages.functools32: drop ``                                              |
| [`f0884ae4`](https://github.com/NixOS/nixpkgs/commit/f0884ae466088fa5d5cc1e4e10318063104d1006) | `` python312Packages.hass-nabucasa: 0.80.0 -> 0.81.0 ``                              |
| [`08f4097b`](https://github.com/NixOS/nixpkgs/commit/08f4097b66ce60fe6df2ed7cafdc097113d0d274) | `` python312Packages.pycognito: format with nixfmt ``                                |
| [`b846431f`](https://github.com/NixOS/nixpkgs/commit/b846431fce5571077e1511d70c45ea6b426227d4) | `` python312Packages.pycognito: refactor ``                                          |
| [`aab74934`](https://github.com/NixOS/nixpkgs/commit/aab749341c7a6a498760f0de5e12a592ebe3b8f9) | `` python312Packages.pycognito: 2024.2.0 -> 2024.5.1 ``                              |
| [`3ff8c332`](https://github.com/NixOS/nixpkgs/commit/3ff8c33235d117a72fc97982f3d14b4c069bf751) | `` python312Packages.snitun: format with nixfmt ``                                   |
| [`e822a6b4`](https://github.com/NixOS/nixpkgs/commit/e822a6b4694df405175120b48ba69cb7a8202908) | `` linux-rt_6_6: 6.6.25-rt29 -> 6.6.30-rt30 ``                                       |
| [`8bf3203e`](https://github.com/NixOS/nixpkgs/commit/8bf3203e903089fd56ccbd98666ff3a474062084) | `` python312Packages.snitun: refactor ``                                             |
| [`6012dea4`](https://github.com/NixOS/nixpkgs/commit/6012dea46cccea5f594310c76475b79252805006) | `` linux-rt_6_1: 6.1.83-rt28 -> 6.1.90-rt30 ``                                       |
| [`81e70dec`](https://github.com/NixOS/nixpkgs/commit/81e70dec154c5b40b352a793b6ad82cdc061ace3) | `` linux-rt_5_15: 5.15.153-rt75 -> 5.15.158-rt76 ``                                  |
| [`91a19107`](https://github.com/NixOS/nixpkgs/commit/91a191072e42b484edfbf46f3a53f1125264bddf) | `` linux-rt_5_10: 5.10.215-rt107 -> 5.10.216-rt108 ``                                |
| [`1724948b`](https://github.com/NixOS/nixpkgs/commit/1724948b0c33ae4a184fd056b564cb476e33a14f) | `` python312Packages.snitun: 0.36.2 -> 0.39.1 ``                                     |
| [`44d32d9e`](https://github.com/NixOS/nixpkgs/commit/44d32d9ed4cc3a8f8b554941c80e6218d84510c9) | `` linux_4_19: 4.19.313 -> 4.19.314 ``                                               |
| [`b08795f4`](https://github.com/NixOS/nixpkgs/commit/b08795f448ef2267715b406f8caf3a335f12d1c0) | `` linux_5_4: 5.4.275 -> 5.4.276 ``                                                  |
| [`e6d38cbd`](https://github.com/NixOS/nixpkgs/commit/e6d38cbd029eb6eb3a71e6724669a5a2a8d34685) | `` linux_5_10: 5.10.216 -> 5.10.217 ``                                               |
| [`99502e04`](https://github.com/NixOS/nixpkgs/commit/99502e04236a57a638bf143126120979e8cf98d5) | `` linux_5_15: 5.15.158 -> 5.15.159 ``                                               |
| [`2203b3b7`](https://github.com/NixOS/nixpkgs/commit/2203b3b79b211f7d315cf953db98f3a003f3fa30) | `` linux_6_1: 6.1.90 -> 6.1.91 ``                                                    |
| [`92fcd99d`](https://github.com/NixOS/nixpkgs/commit/92fcd99d4721dea8e2bf0cc64fc0e4c984baccc0) | `` linux_6_6: 6.6.30 -> 6.6.31 ``                                                    |
| [`6943a5b1`](https://github.com/NixOS/nixpkgs/commit/6943a5b19ea6427a2a9d852dc35b6d0b6b3ec9e2) | `` linux_6_8: 6.8.9 -> 6.8.10 ``                                                     |
| [`6ee87024`](https://github.com/NixOS/nixpkgs/commit/6ee8702408a2be58cf42cc67d44ac80742e93b54) | `` linux_6_9: 6.9 -> 6.9.1 ``                                                        |
| [`17e3bbc8`](https://github.com/NixOS/nixpkgs/commit/17e3bbc8ab47e39421fd13ca1463d875214ac9b1) | `` kdePackages.kirigami-addons: 1.2.0 -> 1.2.1 ``                                    |
| [`411556d8`](https://github.com/NixOS/nixpkgs/commit/411556d8ad23affd2970939fa686bd8e9b1c0749) | `` python312Packages.prometrix: unstable-2024-02-20 -> 0.1.18-unstable-2024-04-30 `` |
| [`e17488e8`](https://github.com/NixOS/nixpkgs/commit/e17488e8fbbb30703f7af43ecd7ed83ed9b2f1c7) | `` evcc: 0.126.2 -> 0.126.3 ``                                                       |
| [`1184c6ad`](https://github.com/NixOS/nixpkgs/commit/1184c6ad949c4726142ffbaa504eecd0a917f732) | `` moneydance: restrict supported platforms to linux ``                              |
| [`b03b2ae3`](https://github.com/NixOS/nixpkgs/commit/b03b2ae33521e80a738fc680b825bb6536ae09c1) | `` ocamlPackages.menhir: 20230608 → 20231231 (#290480) ``                            |
| [`8d0e57b2`](https://github.com/NixOS/nixpkgs/commit/8d0e57b248908d63ec722281a5028d5bff3b002b) | `` python312Packages.slack-bolt: format with nixfmt ``                               |
| [`85ec597f`](https://github.com/NixOS/nixpkgs/commit/85ec597fbb096caf721c3b79f30fc581ab62a5b1) | `` python312Packages.slack-bolt: refactor ``                                         |
| [`5b6469f2`](https://github.com/NixOS/nixpkgs/commit/5b6469f2ee93d6b0758bdd3023709882906ea13b) | `` python311Packages.slack-bolt: add patch for moto >= 5 support ``                  |
| [`7f4c36c9`](https://github.com/NixOS/nixpkgs/commit/7f4c36c982a798a954a2f8643060de3a10a3bac9) | `` neovim: Update bundled tree-sitter parsers ``                                     |
| [`5b4915a2`](https://github.com/NixOS/nixpkgs/commit/5b4915a29e27694674f62e844eb95c70cdac7343) | `` Revert "geos: fix build for darwin" ``                                            |
| [`83d2fca2`](https://github.com/NixOS/nixpkgs/commit/83d2fca25425f7a3a209bf9ac26c4adc1f48d197) | `` sigma-cli: format with nixfmt ``                                                  |
| [`22ee207e`](https://github.com/NixOS/nixpkgs/commit/22ee207e130f84569e3cd4cfe1bf234c30dc5797) | `` sigma-cli: refactor ``                                                            |
| [`effc519f`](https://github.com/NixOS/nixpkgs/commit/effc519f3972339d841ee8570b1ef9f173959b7d) | `` sigma-cli: 1.0.1 -> 1.0.2 ``                                                      |
| [`a6228435`](https://github.com/NixOS/nixpkgs/commit/a62284352d76ce48fbed209124e41cde2fd325e9) | `` python312Packages.slack-sdk: format with nixfmt ``                                |
| [`3e868973`](https://github.com/NixOS/nixpkgs/commit/3e8689730c297d6e651819baccd6e3960d6ecefd) | `` python312Packages.slack-sdk: refactor ``                                          |
| [`f4a7288e`](https://github.com/NixOS/nixpkgs/commit/f4a7288e68ea797ab98e947a899556bb38ad731d) | `` python312Packages.slack-sdk: 3.27.1 -> 3.27.2 ``                                  |
| [`03ae87e9`](https://github.com/NixOS/nixpkgs/commit/03ae87e9b25472cd264013b7b8d2e47504aa0ce9) | `` python312Packages.tesla-fleet-api: 0.5.9 -> 0.5.11 ``                             |
| [`0a4d50f1`](https://github.com/NixOS/nixpkgs/commit/0a4d50f1970aac0edcff0e745939116dd1cfa7d1) | `` python312Packages.python-roborock: 2.2.1 -> 2.2.2 ``                              |
| [`1a8ffd6a`](https://github.com/NixOS/nixpkgs/commit/1a8ffd6af965b4ce79e46258ced03e95a24e56aa) | `` python312Packages.goodwe: 0.4.1 -> 0.4.2 ``                                       |
| [`56c51fdc`](https://github.com/NixOS/nixpkgs/commit/56c51fdc21e141fdcdc6c06984999ebaf8de021f) | `` trufflehog: 3.76.0 -> 3.76.3 ``                                                   |
| [`072167a5`](https://github.com/NixOS/nixpkgs/commit/072167a5aa92140fbd19d6720e4cfcda20a13893) | `` python312Packages.boto3-stubs: 1.34.106 -> 1.34.107 ``                            |
| [`7c71016f`](https://github.com/NixOS/nixpkgs/commit/7c71016fdbbd1cda23cdc9d96d8b647af18e69eb) | `` python312Packages.tencentcloud-sdk-python: 3.0.1148 -> 3.0.1149 ``                |
| [`03c33d6a`](https://github.com/NixOS/nixpkgs/commit/03c33d6aeaa29a1c503b6639cbae9a23ef2dfc74) | `` python312Packages.roadtx: 1.8.1 -> 1.8.2 ``                                       |
| [`29d1219d`](https://github.com/NixOS/nixpkgs/commit/29d1219d456fbf47265fe15d0844d9e71ffc14bf) | `` exploitdb: 2024-05-09 -> 2024-05-16 ``                                            |
| [`ff8aa8b9`](https://github.com/NixOS/nixpkgs/commit/ff8aa8b9ec0300ce770c7eb0e62a8f95a0d47f13) | `` ocamlPackages.js_of_ocaml-compiler: 5.7.1 -> 5.8.1 ``                             |
| [`ee5b9225`](https://github.com/NixOS/nixpkgs/commit/ee5b9225be4df5c964a966f7674f8fccc83f2d86) | `` workshop-runner: init at 0.1.5 ``                                                 |
| [`e6424887`](https://github.com/NixOS/nixpkgs/commit/e64248877b611bd34ed3a134145053383b8a1e7d) | `` python311Packages.json-schema-for-humans: 1.0.1 -> 1.0.2 ``                       |
| [`30c85c86`](https://github.com/NixOS/nixpkgs/commit/30c85c86b0f7e4b5cec521a262727a3b40c6142b) | `` svd2rust: 0.33.2 -> 0.33.3 ``                                                     |
| [`405e7731`](https://github.com/NixOS/nixpkgs/commit/405e7731062241dc48fbb31cfc4743aa5a6166fa) | `` kubectl-gadget: 0.28.0 -> 0.28.1 ``                                               |
| [`b7e30cb4`](https://github.com/NixOS/nixpkgs/commit/b7e30cb4ea0c4d9ea21b3abca16c38a168411f33) | `` dnscontrol: 4.10.0 -> 4.11.0 ``                                                   |
| [`173adef9`](https://github.com/NixOS/nixpkgs/commit/173adef96dafaccce150bbe44c1646ac06965b32) | `` balena-cli: 18.2.2 -> 18.2.3 ``                                                   |
| [`3995d345`](https://github.com/NixOS/nixpkgs/commit/3995d3450b2d3da714d1730fa887978f874b1aed) | `` qmmp: 2.1.7 -> 2.1.8 ``                                                           |
| [`3b14590b`](https://github.com/NixOS/nixpkgs/commit/3b14590bc265ca53354718db94d8bced38bdecca) | `` conmon: 2.1.11 -> 2.1.12 ``                                                       |
| [`d7f95b78`](https://github.com/NixOS/nixpkgs/commit/d7f95b78a8f55ffb1854482c0a4e075a025df901) | `` go-mockery: 2.43.0 -> 2.43.1 ``                                                   |
| [`455325e3`](https://github.com/NixOS/nixpkgs/commit/455325e31d0923d4c556a0823cdb36715dc43493) | `` cyberchef: 10.18.3 -> 10.18.6 ``                                                  |
| [`b8a56384`](https://github.com/NixOS/nixpkgs/commit/b8a56384a00ff3036a6d66c38c122e173b14401a) | `` ddev: 1.23.0 -> 1.23.1 ``                                                         |
| [`3426ed3c`](https://github.com/NixOS/nixpkgs/commit/3426ed3cc9c30e6222227ef821c44e79ac5a83e4) | `` zsh-abbr: 5.4.1 -> 5.6.0 ``                                                       |
| [`7b00c363`](https://github.com/NixOS/nixpkgs/commit/7b00c3636461c16676c6d970b66e388d2ecabb65) | `` cargo-component: 0.11.0 -> 0.12.0 ``                                              |
| [`ac5e6909`](https://github.com/NixOS/nixpkgs/commit/ac5e6909e40a81f1418d7579721093ed2fa0a630) | `` mautrix-meta: 0.3.0 -> 0.3.1 ``                                                   |
| [`c8f19678`](https://github.com/NixOS/nixpkgs/commit/c8f196788fe347435b1b1a1a04ae7187b7395ec1) | `` mautrix-signal: 0.6.0 -> 0.6.1 ``                                                 |
| [`850067c2`](https://github.com/NixOS/nixpkgs/commit/850067c2f3884ca30a0de3b0ba068c4a064247f2) | `` subxt: 0.35.3 -> 0.36.0 ``                                                        |
| [`6fde483d`](https://github.com/NixOS/nixpkgs/commit/6fde483d5907b83356a00f479432c770a7114bc0) | `` zeek: 6.2.0 -> 6.2.1 ``                                                           |
| [`28a99fc3`](https://github.com/NixOS/nixpkgs/commit/28a99fc3f32c1e9beaa615b146c33a69fdd1470d) | `` sslh: 2.1.1 -> 2.1.2 ``                                                           |
| [`61cbfeca`](https://github.com/NixOS/nixpkgs/commit/61cbfeca919d1efa3dcc5ad29836523a6ca32768) | `` cimg: 3.3.5 -> 3.3.6 ``                                                           |
| [`465257bc`](https://github.com/NixOS/nixpkgs/commit/465257bcb2daec5e8dccda1c78b099d12f3b1fda) | `` godot_4: Add installPhase hooks ``                                                |
| [`bb606c84`](https://github.com/NixOS/nixpkgs/commit/bb606c848a82858f955bbbbfbd7d2b0a0836a59c) | `` python311Packages.python-manilaclient: 4.8.0 -> 4.9.0 ``                          |
| [`e14cbde2`](https://github.com/NixOS/nixpkgs/commit/e14cbde2f5f60c01649ccd6b585f4516b0ab253d) | `` python311Packages.python-glanceclient: 4.5.0 -> 4.6.0 ``                          |
| [`01d7cc7c`](https://github.com/NixOS/nixpkgs/commit/01d7cc7c3c9d972d2f3f5e4db752e13c8ffd7e0e) | `` zsh-you-should-use: 1.7.3 -> 1.7.4 ``                                             |
| [`8febca5e`](https://github.com/NixOS/nixpkgs/commit/8febca5ee9e4c1aad16932de12bb4c6a358a4400) | `` aespipe: 2.4g -> 2.4h ``                                                          |
| [`da165cbc`](https://github.com/NixOS/nixpkgs/commit/da165cbccba375f840ef852b4b6692b80fadc65a) | `` ctre: 3.8.1 -> 3.9.0 ``                                                           |
| [`b38f00e0`](https://github.com/NixOS/nixpkgs/commit/b38f00e0fd1ebb0166cb91d7d239abc4cfe8af33) | `` pinnwand: 1.4.0 -> 1.5.0 ``                                                       |
| [`3809fdf5`](https://github.com/NixOS/nixpkgs/commit/3809fdf55c2147613bf123d46e0190c7bf3717c9) | `` ungoogled-chromium: 124.0.6367.207-1 -> 125.0.6422.60-1 ``                        |
| [`1d76eb0f`](https://github.com/NixOS/nixpkgs/commit/1d76eb0f7186122aabd92b5cb7adf6b2a7c39bd4) | `` matrix-synapse-unwrapped: 1.106.0 -> 1.107.0 ``                                   |
| [`4a2fb291`](https://github.com/NixOS/nixpkgs/commit/4a2fb291942398c15a05a45146e86222708b0dca) | `` ko: 0.15.2 -> 0.15.3 ``                                                           |
| [`c7b9844f`](https://github.com/NixOS/nixpkgs/commit/c7b9844fcee65a60e8d222a40ccfcbf453f21e45) | `` vimPlugins: resolve github repository redirects ``                                |
| [`fce88e4b`](https://github.com/NixOS/nixpkgs/commit/fce88e4b6a00241630636f8b0727d5300aa03254) | `` vimPlugins: update on 2024-05-16 ``                                               |
| [`b15a7ce6`](https://github.com/NixOS/nixpkgs/commit/b15a7ce674b012f93ed325a791691f8333b60c8e) | `` mendeley: 2.114.0 -> 2.114.1 ``                                                   |
| [`e82f36e1`](https://github.com/NixOS/nixpkgs/commit/e82f36e188aaa7cd8d1df3fd87c204570d7a645d) | `` qcad: 3.29.6.4 -> 3.29.6.5 ``                                                     |
| [`a283a84b`](https://github.com/NixOS/nixpkgs/commit/a283a84b3caf2e85bae86620b719afaf32bf5a85) | `` trezor-suite: update outdated hash ``                                             |
| [`aaf89835`](https://github.com/NixOS/nixpkgs/commit/aaf8983529bde4fc7f3cc6c27455ad164ccbe55f) | `` python312Packages.msgraph-sdk: 1.2.0 -> 1.4.0 ``                                  |
| [`fcd9efc7`](https://github.com/NixOS/nixpkgs/commit/fcd9efc71834508c5d09c6ab714664d5b04f99dc) | `` goofcord: init at 1.4.2 ``                                                        |
| [`ae48735c`](https://github.com/NixOS/nixpkgs/commit/ae48735c531aaa01fb083333b1ec7e538c04b99d) | `` nixos/loki: use `cfg.package` ``                                                  |
| [`a765cd4a`](https://github.com/NixOS/nixpkgs/commit/a765cd4a701923ea2e3d7b71914f950516f10727) | `` nixos/kdeconnect: don't install `sshfs` ``                                        |
| [`d2c38c6b`](https://github.com/NixOS/nixpkgs/commit/d2c38c6b08d6f4d011a20f9d26ef3d767afa1f1b) | `` dbeaver-bin: init at 24.0.4 ``                                                    |
| [`41aba865`](https://github.com/NixOS/nixpkgs/commit/41aba865e7ed3e02d67a8ff70d3eea20f235ba0b) | `` python3Packages.jsonrpc-server,docker: drop python 3.2 checks ``                  |