### PR TITLE
chore(flake/nixvim): `169d7f4d` -> `5d2e0149`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1716192498,
-        "narHash": "sha256-InEctfSjPgeu4DjJKUtQY/guQKmpGIi0+CwnbbVfoxY=",
+        "lastModified": 1716326274,
+        "narHash": "sha256-1LyTvpjb8Cmlg3TRnP56rvqK1WSNa518pD6F0tjgM+U=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "169d7f4dc0df90820f50e00d8764a6cec5445fa9",
+        "rev": "5d2e01495944dcf7cf7ee53a7074c4010165d756",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`5d2e0149`](https://github.com/nix-community/nixvim/commit/5d2e01495944dcf7cf7ee53a7074c4010165d756) | `` docs: Fix the path to the unstable docs ``                    |
| [`b0b010a0`](https://github.com/nix-community/nixvim/commit/b0b010a0e960bd91c45f06a1a93269e1811adb13) | `` docs: Deploy both stable & unstable docs to github pages ``   |
| [`1c9f2a23`](https://github.com/nix-community/nixvim/commit/1c9f2a23a6cb9406c35980f4af1a4356f56771e9) | `` modules/commands: allow commands to be raw lua ``             |
| [`3ec6dff1`](https://github.com/nix-community/nixvim/commit/3ec6dff17b4fa80ad1c7bdb6b0d226fe3e065b32) | `` modules/commands: fix nargs enum ``                           |
| [`63cfd8ce`](https://github.com/nix-community/nixvim/commit/63cfd8cefcf7d5656f891d97d3d53bd515524375) | `` plugins/ccc: Add more settings ``                             |
| [`c9f3d157`](https://github.com/nix-community/nixvim/commit/c9f3d15796c80c336662e9dd2a0d6820e5fa2841) | `` github-workflows/build_documentation: update cachix action `` |
| [`5b09c711`](https://github.com/nix-community/nixvim/commit/5b09c711e28e9b41ad0fe094e7d62232c1e7c3de) | `` plugins/rustaceanvim: switch to mkNeovimPlugin ``             |
| [`c490fbe5`](https://github.com/nix-community/nixvim/commit/c490fbe5d988fc0c53539fbf887f28b964f9898d) | `` plugins/neogit: Adapt to upstream options changes ``          |
| [`08b4f679`](https://github.com/nix-community/nixvim/commit/08b4f6794a5d82651017435d8322c4379156eb99) | `` flake.lock: Update ``                                         |
| [`818834a7`](https://github.com/nix-community/nixvim/commit/818834a7bbd23a093b0980f209a1b25c1972f349) | `` plugins/lsp-format: fix setup example ``                      |