### PR TITLE
chore(flake/nixpkgs): `6c0b7a92` -> `3eaeaeb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716137900,
-        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
+        "lastModified": 1716293225,
+        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
+        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`a0b1f286`](https://github.com/NixOS/nixpkgs/commit/a0b1f28661d4d7bce6ca86276bb8a64c8720f6be) | `` povray: add fgaz to maintainers ``                                        |
| [`58d34a87`](https://github.com/NixOS/nixpkgs/commit/58d34a875cbc1c0cef91958adcbd21958dc25461) | `` povray: use NixOS as vendor id ``                                         |
| [`e2dd91f4`](https://github.com/NixOS/nixpkgs/commit/e2dd91f4dc541e11428c3725b8ad7ec40b0becd7) | `` povray: update SDL and use pkg-config ``                                  |
| [`fe2fc076`](https://github.com/NixOS/nixpkgs/commit/fe2fc07656d137a3ba2038e7a975bc373b3c2ca8) | `` povray: use finalAttrs pattern ``                                         |
| [`bc4e19a5`](https://github.com/NixOS/nixpkgs/commit/bc4e19a57001c00fd5cf53b74dd5318771c5446d) | `` povray: 3.8.0-x.10064738 -> 3.8.0-beta.2 ``                               |
| [`14985fa5`](https://github.com/NixOS/nixpkgs/commit/14985fa51b1e96838d434331294d9d0b115d5705) | `` python311Packages.plugwise: 0.37.5 -> 0.37.8 ``                           |
| [`fc4e93e2`](https://github.com/NixOS/nixpkgs/commit/fc4e93e2ee612b08448e5d6a6181bc6f31597793) | `` python312Packages.colormath: format with nixfmt ``                        |
| [`7fb25efa`](https://github.com/NixOS/nixpkgs/commit/7fb25efa8b8d6739a71e52162041f7ea980603bc) | `` python312Packages.colormath: refactor ``                                  |
| [`944c377e`](https://github.com/NixOS/nixpkgs/commit/944c377e0fc3e2ed6e4eee924010c07469d26ff3) | `` python312Packages.glances-api: 0.6.0 -> 0.7.0 ``                          |
| [`35ef00b5`](https://github.com/NixOS/nixpkgs/commit/35ef00b58686ce9ba58100ecb0ef87d5af3aed90) | `` ocamlPackages.eio: fix homepage and changelog ``                          |
| [`007a604a`](https://github.com/NixOS/nixpkgs/commit/007a604add6adf325c47bce1c762261aa9bb04bc) | `` typstyle: 0.11.21 -> 0.11.22 ``                                           |
| [`0fc78b93`](https://github.com/NixOS/nixpkgs/commit/0fc78b936e98c11e6be4f3cbb5922b5b81ac1e83) | `` python312Packages.stickytape: format with nixfmt ``                       |
| [`533ce4cf`](https://github.com/NixOS/nixpkgs/commit/533ce4cf057fdff5573c5cf7d5c6197b1b9fc997) | `` osu-lazer: avoid rebuild when meta changes ``                             |
| [`2cd17d14`](https://github.com/NixOS/nixpkgs/commit/2cd17d14bc9f4ae4e3e9207016431a2772dbdb93) | `` osu-lazer: 2024.412.1 -> 2024.521.2 ``                                    |
| [`376309fc`](https://github.com/NixOS/nixpkgs/commit/376309fc14fed804c295638991b24c65ff735534) | `` python312Packages.stickytape: refactor ``                                 |
| [`c259efb1`](https://github.com/NixOS/nixpkgs/commit/c259efb16db863cdd07df5dec4f12a4af6ac699c) | `` osu-lazer-bin: 2024.412.1 -> 2024.521.2 ``                                |
| [`fb03c9c5`](https://github.com/NixOS/nixpkgs/commit/fb03c9c55887d714c41b09fac4947942c4a442de) | `` asusctl: 6.0.6 -> 6.0.9 ``                                                |
| [`e379db6e`](https://github.com/NixOS/nixpkgs/commit/e379db6ea9334243480f0899bed6bfb7caa29965) | `` python312Packages.monzopy: init at 1.2.0 ``                               |
| [`58df87c0`](https://github.com/NixOS/nixpkgs/commit/58df87c09be27760a13c9960dd75673b43edf56c) | `` metals: 1.3.0 -> 1.3.1 ``                                                 |
| [`c6005d83`](https://github.com/NixOS/nixpkgs/commit/c6005d83736d66ef80075f9c00494a287f1017ef) | `` python312Packages.boto3-stubs: 1.34.108 -> 1.34.109 ``                    |
| [`2482fc8b`](https://github.com/NixOS/nixpkgs/commit/2482fc8bd116f2c97e4ea82199e743a898d6c0c5) | `` python311Packages.piep: refactor and drop nose ``                         |
| [`129b9ad2`](https://github.com/NixOS/nixpkgs/commit/129b9ad2368522b9723a87fc5cb9a12f636d4b49) | `` exploitdb: 2024-05-16 -> 2024-05-20 ``                                    |
| [`2105dab7`](https://github.com/NixOS/nixpkgs/commit/2105dab750a93ae2bec9328f350b075615001af8) | `` python312Packages.dbus-fast: 2.21.2 -> 2.21.3 ``                          |
| [`99a3774a`](https://github.com/NixOS/nixpkgs/commit/99a3774a0ffb19eac8beeb951512a84b555d09c7) | `` python312Packages.tencentcloud-sdk-python: 3.0.1150 -> 3.0.1151 ``        |
| [`ea50ab34`](https://github.com/NixOS/nixpkgs/commit/ea50ab34f64d82a4bb852eadc21f235ce4f3dced) | `` python311Packages.piep: format with nixfmt ``                             |
| [`bcb6d785`](https://github.com/NixOS/nixpkgs/commit/bcb6d7853fea69a42e41e9555978a0e82febe21a) | `` malwoverview: 5.4.2 -> 5.4.3 ``                                           |
| [`e9208d70`](https://github.com/NixOS/nixpkgs/commit/e9208d701c2f3aae444cf3bad415fecf82c0db1f) | `` python312Packages.azure-mgmt-security: format with nixfmt ``              |
| [`8d13b5ea`](https://github.com/NixOS/nixpkgs/commit/8d13b5ea99408f45a0781881ecb933e390ed2fd5) | `` python312Packages.azure-mgmt-security: refactor ``                        |
| [`7d37713f`](https://github.com/NixOS/nixpkgs/commit/7d37713f0b7ed82299c65cf748cef63b7e55a4c3) | `` python312Packages.python-telegram-bot: format with nixfmt ``              |
| [`18c46374`](https://github.com/NixOS/nixpkgs/commit/18c46374da9d48b33173982d6682608aa62d4f6f) | `` python312Packages.python-telegram-bot: refactor ``                        |
| [`1f820208`](https://github.com/NixOS/nixpkgs/commit/1f82020865a982a3f82934b420165ceb331a3505) | `` nixos/tests/keepalived: use openFirewall option ``                        |
| [`785aef54`](https://github.com/NixOS/nixpkgs/commit/785aef54cf95ca2c219af52bcc5345fdb1abfcbc) | `` python311Packages.dask-image: 2024.5.1 -> 2024.5.2 ``                     |
| [`718b237d`](https://github.com/NixOS/nixpkgs/commit/718b237d0b8afd4e0b3423b20d8c516c08842457) | `` bintools: Add dynamic loader path for FreeBSD native ``                   |
| [`8073fc75`](https://github.com/NixOS/nixpkgs/commit/8073fc75a89da020c40069f2e8d8a08b5e102612) | `` bintools: Add an assertion which produces better error messages ``        |
| [`c3f2175c`](https://github.com/NixOS/nixpkgs/commit/c3f2175cf4257f3a39657b082ed811e60808ea97) | `` python311Packages.fastapi-sso: 0.14.2 -> 0.15.0 ``                        |
| [`38cd8da8`](https://github.com/NixOS/nixpkgs/commit/38cd8da809f7773f7be0bd1a4002d4fa7c0f6e84) | `` doc: migrate filesets to doc-comment format (#303811) ``                  |
| [`8ed4a36a`](https://github.com/NixOS/nixpkgs/commit/8ed4a36a6cae647be42cb5c5c412d14617ca7a27) | `` python311Packages.resend: 1.0.2 -> 1.1.0 ``                               |
| [`6db58749`](https://github.com/NixOS/nixpkgs/commit/6db58749d87a73570c09ae39f9a24474ffac1d02) | `` home-assistant-custom-lovelace-modules.android-tv-card: 3.7.1 -> 3.7.3 `` |
| [`030bcbc7`](https://github.com/NixOS/nixpkgs/commit/030bcbc7ef1403e89f4877584979ca214f33386e) | `` python311Packages.dask-image: add GaetanLepage as maintainer ``           |
| [`f969fbd2`](https://github.com/NixOS/nixpkgs/commit/f969fbd2d5a95f2d169c66d5ebf5d38639525806) | `` home-assistant-custom-components.yassi: 0.4.0b2 -> 0.4.0b4 ``             |
| [`f6663cf2`](https://github.com/NixOS/nixpkgs/commit/f6663cf2876b161a00498a406e70205f1f9d8ef2) | `` python311Packages.dask-image: 2023.8.1 -> 2024.5.1 ``                     |
| [`293f7446`](https://github.com/NixOS/nixpkgs/commit/293f74466563ef72d8cfed15b6ec13240f67ff84) | `` python311Packages.shimmy: disable broken test ``                          |
| [`ed50bfcf`](https://github.com/NixOS/nixpkgs/commit/ed50bfcf378c2a9888c6b4bb14bd4775c86bdbb0) | `` python311Packages.ale-py: 0.8.1 -> 0.9.0 ``                               |
| [`f88f2732`](https://github.com/NixOS/nixpkgs/commit/f88f27329177e1f94d47e0bdf54432a9e09d9618) | `` Update liquidsoap and its dependencies (#310112) ``                       |
| [`08e65e47`](https://github.com/NixOS/nixpkgs/commit/08e65e472e25c99e1af3e5f727b33220cadf2fda) | `` ocamlPackages.rope: 0.6.2 → 0.6.3 ``                                      |
| [`cfb4ca32`](https://github.com/NixOS/nixpkgs/commit/cfb4ca3234f3b854bb1e23d3a8ba71eb109e5425) | `` wayland-proxy-virtwl: build with default OCaml ``                         |
| [`cbf1674f`](https://github.com/NixOS/nixpkgs/commit/cbf1674f72f3128b870c81e989344c2e63ebfffe) | `` python311Packages.azure-mgmt-security: 6.0.0 -> 7.0.0 ``                  |
| [`8e12c25a`](https://github.com/NixOS/nixpkgs/commit/8e12c25a4f62bbb4dd86e2fce7443b33d66ec793) | `` python311Packages.python-telegram-bot: 21.1.1 -> 21.2 ``                  |
| [`d47d4f60`](https://github.com/NixOS/nixpkgs/commit/d47d4f60fbb5dacf6877f2b32b2c8ffb17395b4e) | `` python311Packages.nbdev: 2.3.22 -> 2.3.23 ``                              |
| [`3bec0590`](https://github.com/NixOS/nixpkgs/commit/3bec0590064839444ef39a1ab1bbb111a103ee1b) | `` flyctl: buildGo122Module -> buildGoModule ``                              |
| [`f4d02f47`](https://github.com/NixOS/nixpkgs/commit/f4d02f476ce245b0bcc44f4abc28deedb0d1a704) | `` wit-bindgen: 0.24.0 -> 0.25.0 ``                                          |
| [`20b75abc`](https://github.com/NixOS/nixpkgs/commit/20b75abc291823e06a2dfa284392419770a98730) | `` tailscale-nginx-auth: 1.66.3 -> 1.66.4 ``                                 |
| [`cfb79d0f`](https://github.com/NixOS/nixpkgs/commit/cfb79d0f61cf7cd19b641f3a4f48f97fd6e1a78a) | `` api-linter: 1.65.2 -> 1.66.0 ``                                           |
| [`50cc50fa`](https://github.com/NixOS/nixpkgs/commit/50cc50fa0d5a7fccf2b352cee0fbaf8e8ebf2609) | `` slurp: mark platforms as linux only ``                                    |
| [`6168f663`](https://github.com/NixOS/nixpkgs/commit/6168f663c83efc890789467ac3f99594442e5166) | `` tailscale: 1.66.3 -> 1.66.4 ``                                            |
| [`706b421a`](https://github.com/NixOS/nixpkgs/commit/706b421a503c42d475a162893408b16b3693e37c) | `` slurp: format with nixfmt ``                                              |
| [`b809ad0c`](https://github.com/NixOS/nixpkgs/commit/b809ad0cc35aeb2ea5a949322e6659b768540258) | `` slurp: migrate to by-name ``                                              |
| [`a89f9756`](https://github.com/NixOS/nixpkgs/commit/a89f97564f2009fc4360b0081fb968b2718f146c) | `` elixir: 1.16.2 -> 1.16.3 ``                                               |
| [`5958a111`](https://github.com/NixOS/nixpkgs/commit/5958a111ad3f6b865627cd9e3d72389aecf688b8) | `` python311Packages.nose-cprof: remove ``                                   |
| [`060707a0`](https://github.com/NixOS/nixpkgs/commit/060707a02152528e5e404e1e0f9aa85ccf330e91) | `` erlang_27-rc3: remove ``                                                  |
| [`8180d2af`](https://github.com/NixOS/nixpkgs/commit/8180d2afe02de57cb0efe0a46ca1b1bf3865c426) | `` screenly-cli: 0.2.6 -> 0.2.7 ``                                           |
| [`12c14993`](https://github.com/NixOS/nixpkgs/commit/12c1499363750b52b652e5a4e1d2fc7ac9cf35aa) | `` python311Packages.ipdbplugin: drop ``                                     |
| [`afe46d21`](https://github.com/NixOS/nixpkgs/commit/afe46d21365469ffa6d689ca9ed737fb015b249b) | `` python312Packages.pycron: refactor and remove nose ``                     |
| [`150d2b9c`](https://github.com/NixOS/nixpkgs/commit/150d2b9c76bf3442ceddbdbca234f340ad0e99a9) | `` python311Packages.pycron: format with nixfmt ``                           |
| [`c257b3e4`](https://github.com/NixOS/nixpkgs/commit/c257b3e4a7e9862aa343232defde92355d2e17f2) | `` erlang_27: init 27.0 ``                                                   |
| [`27adbbf0`](https://github.com/NixOS/nixpkgs/commit/27adbbf025128974df3da625e8fa864b77af3557) | `` uv: 0.1.44 -> 0.1.45 ``                                                   |
| [`510c8249`](https://github.com/NixOS/nixpkgs/commit/510c82499c21c1f1b78dcedf8b924f43585002af) | `` s0ix-selftest-tool: 0-unstable-2024-02-07 -> 0-unstable-2024-05-16 ``     |
| [`78a9be25`](https://github.com/NixOS/nixpkgs/commit/78a9be25485910c4352cd4bfa51640077ee22cac) | `` npins: fix darwin build ``                                                |
| [`598f2ffe`](https://github.com/NixOS/nixpkgs/commit/598f2ffee3a20826c7aa504849a862897a535e04) | `` rye: 0.33.0 -> 0.34.0 ``                                                  |
| [`95367da8`](https://github.com/NixOS/nixpkgs/commit/95367da834f59a8cb63b425257b2503aa199e072) | `` k3s_1_26: add deprecation notice alias ``                                 |
| [`15aa7652`](https://github.com/NixOS/nixpkgs/commit/15aa7652eb452dc16514df0c75cdd80596662cd8) | `` pyprland: 2.2.20 -> 2.3.2 ``                                              |
| [`992735db`](https://github.com/NixOS/nixpkgs/commit/992735db2203b32b2eaf516ca46b353c8dc9d4fa) | `` nixosTests.castopod: fix mp3 generation ``                                |
| [`dddad855`](https://github.com/NixOS/nixpkgs/commit/dddad8555c763b4a3ddfba728648a1456995b706) | `` nixosTests.castopod: fix timeout ``                                       |
| [`f32e8ba8`](https://github.com/NixOS/nixpkgs/commit/f32e8ba859d41c6259a6e43ac9742b268b8a5bed) | `` htcondor: fix build ``                                                    |
| [`4bf826c1`](https://github.com/NixOS/nixpkgs/commit/4bf826c147c17d34a38ba09bf886d248c8e0bfdd) | `` fastly: 10.9.0 -> 10.10.0 ``                                              |
| [`78e94225`](https://github.com/NixOS/nixpkgs/commit/78e942253ec03a623581df6757af34300415a03d) | `` gmic: 3.3.5 -> 3.3.6 ``                                                   |
| [`1bd89fb2`](https://github.com/NixOS/nixpkgs/commit/1bd89fb210dbc5de2ea44dd0870b934a9af85e3a) | `` python312Packages.monai: mark `disabled` ``                               |
| [`a82dda38`](https://github.com/NixOS/nixpkgs/commit/a82dda38027d0b735e864a6d0bb49c8bf3580cfe) | `` stats: 2.10.13 -> 2.10.14 ``                                              |
| [`c0b5df52`](https://github.com/NixOS/nixpkgs/commit/c0b5df5225126f9a9a58ea3aef33d7d79aae2b0a) | `` stats: sort meta alphabetically ``                                        |
| [`a2cb6b67`](https://github.com/NixOS/nixpkgs/commit/a2cb6b674c329c68d79738d2d60bc51f26df68cf) | `` stats: remove `with lib;` from meta ``                                    |
| [`d3e60871`](https://github.com/NixOS/nixpkgs/commit/d3e608716f7660d7a9d54445d05c7b63e1290031) | `` slack: 4.38.121 -> 4.38.125 ``                                            |
| [`53081d31`](https://github.com/NixOS/nixpkgs/commit/53081d312162fd5fa32cb98b61ad333bfca95cf2) | `` stats: refactor updateScript ``                                           |
| [`6e5ba8cd`](https://github.com/NixOS/nixpkgs/commit/6e5ba8cdbbcf65c883d3d1d16eda7551e1a2a7b2) | `` stats: format with nixfmt-rfc-style ``                                    |
| [`ac029b6e`](https://github.com/NixOS/nixpkgs/commit/ac029b6e4b0aef2938916776c675948dfc6b5a09) | `` fastfetch: 2.12.0 -> 2.13.0 ``                                            |
| [`6a5f9aa7`](https://github.com/NixOS/nixpkgs/commit/6a5f9aa788d9fe64290927a8b19519db7d0dfb69) | `` croc: 9.6.15 -> 9.6.16 ``                                                 |
| [`bac27139`](https://github.com/NixOS/nixpkgs/commit/bac2713991598d901f2b59bcdf251bd3f914ccbc) | `` dart-sass: 1.77.0 -> 1.77.2 ``                                            |
| [`165fc395`](https://github.com/NixOS/nixpkgs/commit/165fc39538a75942f1627febe927784b59dc014e) | `` codeium: 1.8.32 -> 1.8.42 ``                                              |
| [`88785de6`](https://github.com/NixOS/nixpkgs/commit/88785de61e0cd4e6f0def57327f4caa01f3b10fa) | `` electron-source.electron_30: 30.0.3 -> 30.0.6 ``                          |
| [`4a4be48b`](https://github.com/NixOS/nixpkgs/commit/4a4be48bd776464e859f2b148aa8461260504530) | `` electron-source.electron_29: 29.3.3 -> 29.4.0 ``                          |
| [`8435fc3c`](https://github.com/NixOS/nixpkgs/commit/8435fc3cabfdf3d28dea95f75898bfa7692401ce) | `` electron_30-bin: 30.0.3 -> 30.0.6 ``                                      |
| [`d62c2035`](https://github.com/NixOS/nixpkgs/commit/d62c20353a3c048b14d3ef1dfed54b656b44286f) | `` electron_29-bin: 29.3.3 -> 29.4.0 ``                                      |
| [`3e86d4de`](https://github.com/NixOS/nixpkgs/commit/3e86d4de3a2af3f3a43da48709037297724ed7e5) | `` offat: 0.17.5 -> 0.18.0 ``                                                |
| [`30bae603`](https://github.com/NixOS/nixpkgs/commit/30bae603d0c43d5904041dc629783adf667abe9e) | `` python311Packages.cld2-cffi: drop ``                                      |
| [`a7f2f627`](https://github.com/NixOS/nixpkgs/commit/a7f2f627ec60a9e9809f81ce2281166511d89b9c) | `` misconfig-mapper: 1.1.1 -> 1.2.0 ``                                       |
| [`d6d81b33`](https://github.com/NixOS/nixpkgs/commit/d6d81b33867d836516149ce83efc19556cfa277b) | `` jellyfin-media-player: 1.10.0 -> 1.10.1 ``                                |
| [`a9fd32bc`](https://github.com/NixOS/nixpkgs/commit/a9fd32bcf360dbf86f918e4bf17147dd88cce851) | `` python310Packages.doctest-ignore-unicode: drop ``                         |
| [`a4a7279b`](https://github.com/NixOS/nixpkgs/commit/a4a7279ba8e5f5c1f21c1cc4785b7afb98a3034c) | `` makima: 0.7.2 -> 0.8.4 ``                                                 |
| [`c6f0e677`](https://github.com/NixOS/nixpkgs/commit/c6f0e677afb7b20938e8f8ddbdea44816e95255e) | `` blockbench: 4.10.0 -> 4.10.1 ``                                           |
| [`cf53f46c`](https://github.com/NixOS/nixpkgs/commit/cf53f46ccf1b94faf1f7c3f51053f91967921d27) | `` errands: 46.1 -> 46.2 ``                                                  |
| [`63347957`](https://github.com/NixOS/nixpkgs/commit/633479572e40312f0b38936a3262a073242a25c2) | `` nixos/nsswitch: add support for overriding sudoers entries (#310818) ``   |
| [`3568744c`](https://github.com/NixOS/nixpkgs/commit/3568744c6b112c2ffc0856820f6bf9d0bc236faa) | `` python310Packages.proboscis: drop ``                                      |
| [`bf4890c3`](https://github.com/NixOS/nixpkgs/commit/bf4890c37d6f730088346a5d4a019d58602c2841) | `` nixos/release-combined: ship Plasma 6 ISOs instead of Plasma 5 ``         |
| [`8dbe89fb`](https://github.com/NixOS/nixpkgs/commit/8dbe89fbe00b6a6954d21ba1f1d66969e05515ea) | `` freebsd: fix eval with Nix < 2.6 ``                                       |
| [`432bbca4`](https://github.com/NixOS/nixpkgs/commit/432bbca403fcbbe5dd10542e58ab393cf665b438) | `` python311Packages.nosejs: drop ``                                         |
| [`e51c7ec4`](https://github.com/NixOS/nixpkgs/commit/e51c7ec4c0e85e5fa411097b4216923e9030f2a6) | `` python312Packages.tesla-fleet-api: 0.5.11 -> 0.5.12 ``                    |
| [`fde23407`](https://github.com/NixOS/nixpkgs/commit/fde23407fc54bb9be5796fcd7e514af68dc12312) | `` python312Packages.aranet4: 2.3.3 -> 2.3.4 ``                              |
| [`ccad6d83`](https://github.com/NixOS/nixpkgs/commit/ccad6d8360eaf102d2ea26b964dd78ca0337b718) | `` python312Packages.pydiscovergy: format with nixfmt ``                     |
| [`7d959fa0`](https://github.com/NixOS/nixpkgs/commit/7d959fa092e76650c3eebb5ca4ae637f178fe979) | `` python312Packages.pydiscovergy: refactor ``                               |
| [`b077a4f6`](https://github.com/NixOS/nixpkgs/commit/b077a4f65ac014792be1b81c9c8660bfd04aa49a) | `` python312Packages.pydiscovergy: 3.0.0 -> 3.0.1 ``                         |
| [`54a85a69`](https://github.com/NixOS/nixpkgs/commit/54a85a69a597ab75ff30c9817a499673e5ea07a1) | `` flyctl: add updateScript ``                                               |