### PR TITLE
chore(flake/nixvim): `9d858de2` -> `1cc2e02f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -191,11 +191,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716448020,
-        "narHash": "sha256-u1ddoBOILtLVX4NYzqSZ9Qaqusql1M4reLd1fs554hY=",
+        "lastModified": 1716457508,
+        "narHash": "sha256-ZxzffLuWRyuMrkVVq7wastNUqeO0HJL9xqfY1QsYaqo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "25dedb0d52c20448f6a63cc346df1adbd6ef417e",
+        "rev": "850cb322046ef1a268449cf1ceda5fd24d930b05",
         "type": "github"
       },
       "original": {
@@ -212,11 +212,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716329735,
-        "narHash": "sha256-ap51w+VqG21vuzyQ04WrhI2YbWHd3UGz0e7dc/QQmoA=",
+        "lastModified": 1716511055,
+        "narHash": "sha256-5Fe/DGgvMhPEMl9VdVxv3zvwRcwNDmW5eRJ0gk72w7U=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "eac4f25028c1975a939c8f8fba95c12f8a25e01c",
+        "rev": "0bea8222f6e83247dd13b055d83e64bce02ee532",
         "type": "github"
       },
       "original": {
@@ -284,11 +284,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1716566815,
-        "narHash": "sha256-WO3MF4W1SrSD0lanU1n7dfuHizeSLfDHJNEir9exlcM=",
+        "lastModified": 1716673923,
+        "narHash": "sha256-2u/NXh4FBbj8myQJTd3Are+a+qvhkXeqnpT/jq6VX2s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9d858de2e9ab136d1c53d92af62fed8fccf492ab",
+        "rev": "1cc2e02fcaabd224348fa0dbfeb311063787a060",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`1cc2e02f`](https://github.com/nix-community/nixvim/commit/1cc2e02fcaabd224348fa0dbfeb311063787a060) | `` wrappers/output: fix `initContent` formatting ``      |
| [`546b4b02`](https://github.com/nix-community/nixvim/commit/546b4b029d0e8ef54aa73347cb08d454ded62bb2) | `` plugins/jsonls: add settings option ``                |
| [`f3e2a064`](https://github.com/nix-community/nixvim/commit/f3e2a064a19ecbafef9b374b1b99668a90dff052) | `` plugins/yamlls: add settings option ``                |
| [`3d9e5d04`](https://github.com/nix-community/nixvim/commit/3d9e5d04a5e998147281ad9bd505d6e406ebebba) | `` flake.lock: Update ``                                 |
| [`2494e0af`](https://github.com/nix-community/nixvim/commit/2494e0af08b90034995a691fe48900b1c510c96a) | `` plugins/telescope: make `enabledExtensions` public `` |