### PR TITLE
chore(flake/nixvim): `1cc2e02f` -> `23276f62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1716673923,
-        "narHash": "sha256-2u/NXh4FBbj8myQJTd3Are+a+qvhkXeqnpT/jq6VX2s=",
+        "lastModified": 1716739594,
+        "narHash": "sha256-0iXuhpC57QUNaEG0qRMufWEL9mRPYEHfrnPNMOsO7fY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1cc2e02fcaabd224348fa0dbfeb311063787a060",
+        "rev": "23276f629b0c68ce869f32fae41323763981039c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`23276f62`](https://github.com/nix-community/nixvim/commit/23276f629b0c68ce869f32fae41323763981039c) | `` README: update 23.05 mentions for 23.11 ``                        |
| [`8212bf1c`](https://github.com/nix-community/nixvim/commit/8212bf1cd2d2dfe6ba521dd8c65a13b67e562d1a) | `` modules/keymaps: deprecate `lua` option ``                        |
| [`beb86eec`](https://github.com/nix-community/nixvim/commit/beb86eec7cad226d100d2841aae09fc2d4e152a8) | `` plugins/refactoring: add telescope option ``                      |
| [`61cc6e9f`](https://github.com/nix-community/nixvim/commit/61cc6e9f22e73fee904d7091f04f81cede1cd136) | `` plugins/refactoring: add missing option `show_success_message` `` |
| [`e3b43159`](https://github.com/nix-community/nixvim/commit/e3b43159035ec151c2ab1b696d8e0cf1a4e4f300) | `` plugins/refactoring: switch to mkNeovimPlugin ``                  |
| [`883d21d8`](https://github.com/nix-community/nixvim/commit/883d21d86602a71d158093a68d85fe0a36e269ab) | `` wrappers/output: omit blank `neovimRcContent` ``                  |