### PR TITLE
chore(flake/nixvim): `23276f62` -> `ba293d36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -284,11 +284,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1716739594,
-        "narHash": "sha256-0iXuhpC57QUNaEG0qRMufWEL9mRPYEHfrnPNMOsO7fY=",
+        "lastModified": 1716759197,
+        "narHash": "sha256-I4r9krPVUl1b70VbC8j8xDQ2mDBoGCx8tH9CExiJMd8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "23276f629b0c68ce869f32fae41323763981039c",
+        "rev": "ba293d36403c39c22dbb9a928f9af4d0df54b79f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`ba293d36`](https://github.com/nix-community/nixvim/commit/ba293d36403c39c22dbb9a928f9af4d0df54b79f) | `` plugins/lsp/language-servers/nil_ls: improve settings options `` |
| [`96973851`](https://github.com/nix-community/nixvim/commit/9697385115fe557468b2ddcbd1277602b3e58d5e) | `` actions: Update both stable & unstable flake.lock ``             |