### PR TITLE
chore(flake/nixvim): `a2afa563` -> `56d39f54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1716833970,
-        "narHash": "sha256-K3tVrTna4EN86GW9IeOQJkbj57zT2xNGJg1hh26xy5c=",
+        "lastModified": 1716925245,
+        "narHash": "sha256-MO32KGgZUiWWsDYu93H47iOGWNlXO9BVOMrZzauZKCc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a2afa5634495ee739e682e5ccb743c5c6dd90ec1",
+        "rev": "56d39f54fe11776ba83903ec077bffc7a7d0e638",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`56d39f54`](https://github.com/nix-community/nixvim/commit/56d39f54fe11776ba83903ec077bffc7a7d0e638) | `` plugins/telescope: remove redundant `keymapsSilent` option ``             |
| [`bc0db275`](https://github.com/nix-community/nixvim/commit/bc0db2751c93c025ccf8794220137ced14aa3394) | `` plugins/telescope: support non-builtin keymaps ``                         |
| [`ef63d347`](https://github.com/nix-community/nixvim/commit/ef63d3477fa3aaecc18512cc48ff4e977449cb4a) | `` colorschemes: set the colorscheme as mkDefault to allow for overriding `` |
| [`daa6b0f5`](https://github.com/nix-community/nixvim/commit/daa6b0f5cff90397b8ebd9ab5f5976b06b95c5e6) | `` lib/options: defaultNullOpts support non-string defaults ``               |
| [`deafcf44`](https://github.com/nix-community/nixvim/commit/deafcf44de0d867faae824e1574bd9ef86533c70) | `` colorschemes/nightfox: init ``                                            |