### PR TITLE
chore(flake/nixvim): `cf037458` -> `b113bc69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1716961281,
-        "narHash": "sha256-rUSuwmGdd5yLJc1RHDR3mXGTJJ/fKRtqr26MU78Lnvc=",
+        "lastModified": 1716972603,
+        "narHash": "sha256-rfOOyiBW42bI+Nj3Cs7H3dZL4vdRelUWL5YSDniVcYM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cf037458ddc16f1b0d037630546760ecad0231c3",
+        "rev": "b113bc69ea5c04c37020a63afa687abfb2d43474",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`b113bc69`](https://github.com/nix-community/nixvim/commit/b113bc69ea5c04c37020a63afa687abfb2d43474) | `` lib/options: `mkStr` quote default string ``          |
| [`cedc1e47`](https://github.com/nix-community/nixvim/commit/cedc1e4799909952a701efabed40a0f0e6107852) | `` lib/options: use code-block for multiline defaults `` |
| [`9b340f8b`](https://github.com/nix-community/nixvim/commit/9b340f8babb5dcf5f3b25b559db19ad8a610791e) | `` modules/keymaps: more verbose `lua` deprecation ``    |