### PR TITLE
chore(flake/nixvim): `b113bc69` -> `2031a09b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1716972603,
-        "narHash": "sha256-rfOOyiBW42bI+Nj3Cs7H3dZL4vdRelUWL5YSDniVcYM=",
+        "lastModified": 1717012327,
+        "narHash": "sha256-hmm9DA0+7RSbxudrscrjKJ3EGSwxvrkpjpCEAa+GtT8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b113bc69ea5c04c37020a63afa687abfb2d43474",
+        "rev": "2031a09b36c19526aa82d27167942edf62915b66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`2031a09b`](https://github.com/nix-community/nixvim/commit/2031a09b36c19526aa82d27167942edf62915b66) | `` colorschemes/modus: init ``  |
| [`099f9f0f`](https://github.com/nix-community/nixvim/commit/099f9f0f59aa4d5386c8f53cdaa62fa784d0bc54) | `` maintainers: add nwjsmith `` |