### PR TITLE
chore(flake/nixvim): `2031a09b` -> `da9bd1f2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -218,11 +218,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716457508,
-        "narHash": "sha256-ZxzffLuWRyuMrkVVq7wastNUqeO0HJL9xqfY1QsYaqo=",
+        "lastModified": 1717052710,
+        "narHash": "sha256-LRhOxzXmOza5SymhOgnEzA8EAQp+94kkeUYWKKpLJ/U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "850cb322046ef1a268449cf1ceda5fd24d930b05",
+        "rev": "29c69d9a466e41d46fd3a7a9d0591ef9c113c2ae",
         "type": "github"
       },
       "original": {
@@ -239,11 +239,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716511055,
-        "narHash": "sha256-5Fe/DGgvMhPEMl9VdVxv3zvwRcwNDmW5eRJ0gk72w7U=",
+        "lastModified": 1716993688,
+        "narHash": "sha256-vo5k2wQekfeoq/2aleQkBN41dQiQHNTniZeVONWiWLs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "0bea8222f6e83247dd13b055d83e64bce02ee532",
+        "rev": "c0d5b8c54d6828516c97f6be9f2d00c63a363df4",
         "type": "github"
       },
       "original": {
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717012327,
-        "narHash": "sha256-hmm9DA0+7RSbxudrscrjKJ3EGSwxvrkpjpCEAa+GtT8=",
+        "lastModified": 1717081007,
+        "narHash": "sha256-GNr1i6itjFKGXSco3lcdKe8GxEwrmSYFDUpZyXsXWp4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2031a09b36c19526aa82d27167942edf62915b66",
+        "rev": "da9bd1f2e8fc8cd8553a76a9e22afd386c18f205",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`da9bd1f2`](https://github.com/nix-community/nixvim/commit/da9bd1f2e8fc8cd8553a76a9e22afd386c18f205) | `` plugins/efmls-configs: add typstyle formatter ``                  |
| [`bea8492e`](https://github.com/nix-community/nixvim/commit/bea8492e197aa557d35e8608ba27e2c2ff903cad) | `` modules/keymaps: add "buffer" option to mapConfigOptions ``       |
| [`398cc8bf`](https://github.com/nix-community/nixvim/commit/398cc8bfcfd429fa3ddff028cdd94a89a6786f1a) | `` flake.lock: Update ``                                             |
| [`bcfef991`](https://github.com/nix-community/nixvim/commit/bcfef991f8aba211ca81a6413be2f46695c28de1) | `` flake: add the nix-community binary cache ``                      |
| [`51240cef`](https://github.com/nix-community/nixvim/commit/51240cef0e89c80f6ae911d8ee31eede861516bb) | `` lib/options: `defaultNullOpts` delegate string rendering ``       |
| [`ff1ab170`](https://github.com/nix-community/nixvim/commit/ff1ab1700cbd400eb0f0cc82816f78ff6936cc01) | `` lib/options: `mkEnum` quote default if string ``                  |
| [`993deb22`](https://github.com/nix-community/nixvim/commit/993deb227eb56f25fb98e200fa572bab43011c05) | `` plugins/lsp-status: init ``                                       |
| [`ea69144d`](https://github.com/nix-community/nixvim/commit/ea69144d60c9b3faf06eec881ded153d9059b11d) | `` maintainers: add b3nb5n ``                                        |
| [`5c8f85dd`](https://github.com/nix-community/nixvim/commit/5c8f85dd27a045c874115fb13a8cdf9f6731b4f9) | `` plugins/debugprint: remove deprecated ignore_treesitter option `` |