### PR TITLE
chore(flake/nixpkgs): `9ca3f649` -> `ad57eef4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -254,11 +254,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716769173,
-        "narHash": "sha256-7EXDb5WBw+d004Agt+JHC/Oyh/KTUglOaQ4MNjBbo5w=",
+        "lastModified": 1716948383,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ca3f649614213b2aaf5f1e16ec06952fe4c2632",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`5f294ad0`](https://github.com/NixOS/nixpkgs/commit/5f294ad0274c12f5f9125a89bdd8786d69cf05bd) | `` python312Packages.amcrest: replace distutils usage ``                                   |
| [`17d94493`](https://github.com/NixOS/nixpkgs/commit/17d94493a054faef15bc7f45a7dc42c917361d3d) | `` _389-ds-base: remove broken=true ``                                                     |
| [`ac7eb397`](https://github.com/NixOS/nixpkgs/commit/ac7eb3979d8d87b0787734056adae70ca4407076) | `` _389-ds-base: add fix-32bit patch ``                                                    |
| [`b511f3e2`](https://github.com/NixOS/nixpkgs/commit/b511f3e2ed142acec818875fabf7ab4873d9a86d) | `` _389-ds-base: 2.4.3 -> 2.4.5 ``                                                         |
| [`34387813`](https://github.com/NixOS/nixpkgs/commit/343878138d6212f20b7a6c1572638f18e694a6dc) | `` python311Packages.cleanlab: 2.6.1 -> 2.6.5 ``                                           |
| [`b2fd2453`](https://github.com/NixOS/nixpkgs/commit/b2fd24537155ffb605b0dcf93b5d8b6b2901a472) | `` gmnitohtml: 0.1.2 -> 0.1.3 ``                                                           |
| [`f0617415`](https://github.com/NixOS/nixpkgs/commit/f0617415f5680ee2cc1eafff7d1dc718ca61c185) | `` helmfile: 0.162.0 -> 0.165.0 ``                                                         |
| [`41104f8d`](https://github.com/NixOS/nixpkgs/commit/41104f8dae128dd2609cae9da20158a39fc11b11) | `` kiln: 0.4.0 -> 0.4.1 ``                                                                 |
| [`bcdacc08`](https://github.com/NixOS/nixpkgs/commit/bcdacc083f38dfe4fa3e164db3c890e34676ffea) | `` python311Packages.pycaption: 2.2.7 -> 2.2.10 ``                                         |
| [`22da5d3a`](https://github.com/NixOS/nixpkgs/commit/22da5d3a053a949b62975f2542d70eaa9181d34f) | `` ocamlPackages.eio: 1.0 -> 1.1 ``                                                        |
| [`629ad8cf`](https://github.com/NixOS/nixpkgs/commit/629ad8cfeaea1151e486dbaab32a990c7365f136) | `` crunchy-cli: 3.6.4 -> 3.6.6 ``                                                          |
| [`315b8a04`](https://github.com/NixOS/nixpkgs/commit/315b8a0466244c43a901a41799622de7f42b7a85) | `` apptainer: 1.3.1 -> 1.3.2 ``                                                            |
| [`b28adaa4`](https://github.com/NixOS/nixpkgs/commit/b28adaa43a21bfc945c18feb86d605282feb9e4e) | `` libretro.genesis-plus-gx: unstable-2024-05-17 -> unstable-2024-05-25 ``                 |
| [`7ae091f1`](https://github.com/NixOS/nixpkgs/commit/7ae091f1d386e2f8f4c2807ffe45f6fd827871d4) | `` libretro.swanstation: unstable-2024-05-21 -> unstable-2024-05-27 ``                     |
| [`31998895`](https://github.com/NixOS/nixpkgs/commit/3199889584c8797bd63737c4c82841cdaeeffb00) | `` libretro.fceumm: unstable-2024-04-06 -> unstable-2024-05-27 ``                          |
| [`f9bca3ac`](https://github.com/NixOS/nixpkgs/commit/f9bca3ac453d878e43e9d431151ce5decbb1d26f) | `` libretro.flycast: unstable-2024-05-21 -> unstable-2024-05-27 ``                         |
| [`827cef3a`](https://github.com/NixOS/nixpkgs/commit/827cef3a17b98e269e07f4d75f55b557d30a81fe) | `` linuxPackages.lttng-modules: 2.13.10 -> 2.13.13 ``                                      |
| [`ccec1e22`](https://github.com/NixOS/nixpkgs/commit/ccec1e22ab12047e74f5a914b982cbea4673826a) | `` linux/hardened/patches/6.9: 6.9.1-hardened1 -> 6.9.2-hardened1 ``                       |
| [`c950de9a`](https://github.com/NixOS/nixpkgs/commit/c950de9a2ee7f0a26cfe27c974c578f99f79cf1f) | `` linux/hardened/patches/6.8: 6.8.10-hardened1 -> 6.8.11-hardened1 ``                     |
| [`73e51e8a`](https://github.com/NixOS/nixpkgs/commit/73e51e8afe8cb06eb2e0e22051b2b73100653160) | `` linux/hardened/patches/6.6: 6.6.31-hardened1 -> 6.6.32-hardened1 ``                     |
| [`8258efe5`](https://github.com/NixOS/nixpkgs/commit/8258efe5c72f0563c42d3093898d3a1753eabb06) | `` linux/hardened/patches/6.1: 6.1.91-hardened1 -> 6.1.92-hardened1 ``                     |
| [`b7c765ba`](https://github.com/NixOS/nixpkgs/commit/b7c765ba86f56b00b9f44e672124d7097f34528b) | `` linux/hardened/patches/5.4: 5.4.276-hardened1 -> 5.4.277-hardened1 ``                   |
| [`aafb178d`](https://github.com/NixOS/nixpkgs/commit/aafb178d2772c7a1710f119d55722f77dd0e2e35) | `` linux/hardened/patches/5.15: 5.15.159-hardened1 -> 5.15.160-hardened1 ``                |
| [`49b66132`](https://github.com/NixOS/nixpkgs/commit/49b6613241f584c77682188e765fa85e8ac5e7a7) | `` linux/hardened/patches/5.10: 5.10.217-hardened1 -> 5.10.218-hardened1 ``                |
| [`e3d6d0f9`](https://github.com/NixOS/nixpkgs/commit/e3d6d0f977ee639ab3ecfbaf16a264784578e441) | `` linux/hardened/patches/4.19: 4.19.314-hardened1 -> 4.19.315-hardened1 ``                |
| [`6398cdcd`](https://github.com/NixOS/nixpkgs/commit/6398cdcd53a710766e3b52161e6416acf6504dc5) | `` linux_latest-libre: 19569 -> 19575 ``                                                   |
| [`6d2c5bf0`](https://github.com/NixOS/nixpkgs/commit/6d2c5bf0d41e9aec116810c43289891258ec2953) | `` linux-rt_6_6: 6.6.31-rt31 -> 6.6.32-rt32 ``                                             |
| [`80fe431b`](https://github.com/NixOS/nixpkgs/commit/80fe431b8035565eda890a839f1ab896f38fa2fd) | `` linux-rt_5_10: 5.10.216-rt108 -> 5.10.217-rt109 ``                                      |
| [`4da4db4b`](https://github.com/NixOS/nixpkgs/commit/4da4db4b32b0fe47273054273aa1b0ca421af200) | `` linux_testing: 6.9-rc6 -> 6.10-rc1 ``                                                   |
| [`a84c4c31`](https://github.com/NixOS/nixpkgs/commit/a84c4c31686b49a9353b47706ecddee224152a82) | `` linux/common-config: update for 6.10 ``                                                 |
| [`e077c8a0`](https://github.com/NixOS/nixpkgs/commit/e077c8a077cbcaa41c47f302fb36108211d77c7e) | `` pdfplumber: Enable tests depending on ghostscript ``                                    |
| [`9c7b3558`](https://github.com/NixOS/nixpkgs/commit/9c7b3558ca8a5bc2ff1368f3c0253cc34c12dbfe) | `` libretro.fbneo: unstable-2024-05-20 -> unstable-2024-05-28 ``                           |
| [`e8593a5e`](https://github.com/NixOS/nixpkgs/commit/e8593a5ea77080201dde2b86f7df1000a8f68f9d) | `` polypane: 19.0.1 -> 19.0.2 ``                                                           |
| [`f9dd75af`](https://github.com/NixOS/nixpkgs/commit/f9dd75af1528894c0da816a88d59400356f36984) | `` httpx: 1.6.1 -> 1.6.2 ``                                                                |
| [`30aa294e`](https://github.com/NixOS/nixpkgs/commit/30aa294e02dcdbf419a4ff6014ec109aec97dfbd) | `` xgboost: mark as broken when building with CUDA pre-11.4 ``                             |
| [`46a15946`](https://github.com/NixOS/nixpkgs/commit/46a15946258c3a63f5562fe9de424265807b5d71) | `` xgboost: fix build with CUDA 12.4 ``                                                    |
| [`1dbed1c6`](https://github.com/NixOS/nixpkgs/commit/1dbed1c64fb045fc5369bb38e8138111fd0cab34) | `` sentry-cli: 2.31.2 -> 2.32.1 ``                                                         |
| [`c598e857`](https://github.com/NixOS/nixpkgs/commit/c598e857934a898a37fddbf330b636423fcf8014) | `` stackit-cli: 0.6.0 -> 0.7.0 ``                                                          |
| [`9c686124`](https://github.com/NixOS/nixpkgs/commit/9c6861249c6042a48a480f2b82653162bc5a01b4) | `` Further tweaks to release notes ``                                                      |
| [`005ef76e`](https://github.com/NixOS/nixpkgs/commit/005ef76e9eccae95c3c696256760556497171b76) | `` Consistently use capitalized Nix in plain text ``                                       |
| [`9708aca8`](https://github.com/NixOS/nixpkgs/commit/9708aca85369187389af1ef8755c357bc680aaee) | `` Various tweaks to release notes ``                                                      |
| [`e36f83ea`](https://github.com/NixOS/nixpkgs/commit/e36f83eac4a21297cf0a669dfe2c7ac451e356c9) | `` Clean up the curious dwarf-fortress note ``                                             |
| [`52389292`](https://github.com/NixOS/nixpkgs/commit/523892928dfd692c915c82b98c6f922f7c2720ea) | `` ctagsWrapped: rewrite to use callPackage injection and be a derivation (#299245) ``     |
| [`58516d6e`](https://github.com/NixOS/nixpkgs/commit/58516d6ee8c4cb56fe91a8c8e34f4b210b8c6e7f) | `` oauth2c: 1.13.0 -> 1.14.0 ``                                                            |
| [`fe94f50c`](https://github.com/NixOS/nixpkgs/commit/fe94f50c751a6691708f1194b684beb770e6fa72) | `` havn: init at 0.1.11 (#314290) ``                                                       |
| [`bfc0b558`](https://github.com/NixOS/nixpkgs/commit/bfc0b558e1732c2f6923cf48167151c0790025ad) | `` libretro.puae: unstable-2024-05-20 -> unstable-2024-05-25 ``                            |
| [`3438f840`](https://github.com/NixOS/nixpkgs/commit/3438f8404703e36c37e2a83d486302c9500d5bcc) | `` experienced-pixel-dungeon: 2.17.2 -> 2.18 ``                                            |
| [`595e10ca`](https://github.com/NixOS/nixpkgs/commit/595e10ca00c7f4838f6fc0a9b0580cf53c89786d) | `` shorter-pixel-dungeon: 1.3.0 -> 1.4.0 ``                                                |
| [`be92457c`](https://github.com/NixOS/nixpkgs/commit/be92457ca6ca785a6ac41d28d0235cbcf547ff4d) | `` civo: 1.0.83 -> 1.0.84 ``                                                               |
| [`a7585a28`](https://github.com/NixOS/nixpkgs/commit/a7585a282376399a51e8b38583e436ce4a362e11) | `` crowdin-cli: 3.19.4 -> 4.0.0 ``                                                         |
| [`d156c7e2`](https://github.com/NixOS/nixpkgs/commit/d156c7e23dad0be5d33c776cdb402a66bfdf47dc) | `` desync: 0.9.5 -> 0.9.6 ``                                                               |
| [`25e319b7`](https://github.com/NixOS/nixpkgs/commit/25e319b76cf4240e0244d7f3cd1e61d6447afb4b) | `` kube-state-metrics: init at 2.12.0 (#314208) ``                                         |
| [`d43dfcd8`](https://github.com/NixOS/nixpkgs/commit/d43dfcd8c73388210823ddbc43a07a97154a2352) | `` libretro.mame2003: unstable-2024-05-21 -> unstable-2024-05-27 ``                        |
| [`bac8a4b6`](https://github.com/NixOS/nixpkgs/commit/bac8a4b64af9e02a62a5de8299f9e83101cf6012) | `` lint-staged: 15.2.4 -> 15.2.5 ``                                                        |
| [`4b7c4c44`](https://github.com/NixOS/nixpkgs/commit/4b7c4c44ce1decc0b66e3a2452db40c3cf0596ad) | `` libretro.mame2003-plus: unstable-2024-05-21 -> unstable-2024-05-28 ``                   |
| [`43a76437`](https://github.com/NixOS/nixpkgs/commit/43a764371ad292b42c21e079d90169d560d1be10) | `` libretro.ppsspp: unstable-2024-05-21 -> unstable-2024-05-28 ``                          |
| [`aa07045b`](https://github.com/NixOS/nixpkgs/commit/aa07045ba1abc83abbaef5de5256cda072f2a851) | `` ginkgo: 2.18.0 -> 2.19.0 ``                                                             |
| [`85bbcfc3`](https://github.com/NixOS/nixpkgs/commit/85bbcfc31f62b26c4232f89979521aaebdf851c2) | `` ayatana-indicator-power: 24.1.0 -> 24.5.0 ``                                            |
| [`c5118014`](https://github.com/NixOS/nixpkgs/commit/c51180147c34c78f7011d749c988d919d28c6112) | `` Laravel: init at 5.8.1 (#314548) ``                                                     |
| [`34823ec0`](https://github.com/NixOS/nixpkgs/commit/34823ec059bb32c1e3446834d93db660e96c7652) | `` jq-zsh-plugin: init at 0.6.1 (#314502) ``                                               |
| [`d9a47d8a`](https://github.com/NixOS/nixpkgs/commit/d9a47d8ae003c7d87c4e30331e028a2dd2480bc8) | `` libretro.beetle-psx-hw: unstable-2024-05-17 -> unstable-2024-05-24 ``                   |
| [`85eea8d9`](https://github.com/NixOS/nixpkgs/commit/85eea8d9a1cbb29515cbcf063e8ac17e38026328) | `` libretro.snes9x: unstable-2024-05-19 -> unstable-2024-05-26 ``                          |
| [`1fffe13b`](https://github.com/NixOS/nixpkgs/commit/1fffe13b2fa3f9bbabf66d9e8528ad7e89303d50) | `` argocd: 2.11.1 -> 2.11.2 ``                                                             |
| [`ae34cb95`](https://github.com/NixOS/nixpkgs/commit/ae34cb9560a578b6354655538e98fb69e8bc8d39) | `` gleam: 1.1.0 -> 1.2.0 ``                                                                |
| [`acaf6830`](https://github.com/NixOS/nixpkgs/commit/acaf6830048f0d3d6e12638549c1a5668322fcbb) | `` vim-startuptime: init at 1.3.2 ``                                                       |
| [`3c179aaa`](https://github.com/NixOS/nixpkgs/commit/3c179aaa723ecc0e1fb208b5f1946beddc5a4f72) | `` smile: 2.9.0 → 2.9.5 (#314521) ``                                                       |
| [`b7515b86`](https://github.com/NixOS/nixpkgs/commit/b7515b8670973052f8355ddcbabcc3a5871b9941) | `` labwc-tweaks-gtk: 0-unstable-2024-05-19 → 0-unstable-2024-05-22 (#314599) ``            |
| [`8c508758`](https://github.com/NixOS/nixpkgs/commit/8c5087589a1d7469952592c7c20dddb209fc3817) | `` libretro.prboom: unstable-2024-05-07 -> unstable-2024-05-23 ``                          |
| [`ab57676e`](https://github.com/NixOS/nixpkgs/commit/ab57676e0a4553d9cdf694434b75c85fbd3c1083) | `` libretro.play: unstable-2024-05-17 -> unstable-2024-05-27 ``                            |
| [`7343dde6`](https://github.com/NixOS/nixpkgs/commit/7343dde6d33981ff6ceb1d3d374aa83d414ae3ed) | `` dbxml: fix clang build ``                                                               |
| [`7546fd61`](https://github.com/NixOS/nixpkgs/commit/7546fd6123cb17ede0dc4014ab4aebb40ff4b7ee) | `` netsurf.libparserutils: use libiconv for darwin ``                                      |
| [`d32beeba`](https://github.com/NixOS/nixpkgs/commit/d32beebac23f7f237de24a9ba8c0ccc039566b6d) | `` xqilla: unbreak darwin; add required frameworks ``                                      |
| [`fea1d8ed`](https://github.com/NixOS/nixpkgs/commit/fea1d8ed5d5edda003132c54c258f4cbc8a34f2f) | `` python311Packages.ptpython: 3.0.26 -> 3.0.27 ``                                         |
| [`1f6d5ccf`](https://github.com/NixOS/nixpkgs/commit/1f6d5ccf14b99cb6c21052b01f6cf69269c6b373) | `` motif: prePatch -> postPatch ``                                                         |
| [`4bf323a2`](https://github.com/NixOS/nixpkgs/commit/4bf323a2cf5355db2fe450ce8bd7cad468f98625) | `` motif: fix build with clang ``                                                          |
| [`1a5ef41b`](https://github.com/NixOS/nixpkgs/commit/1a5ef41b84b333d2effe424111fe037846679f35) | `` motif: fix disabling demos ``                                                           |
| [`c398cede`](https://github.com/NixOS/nixpkgs/commit/c398cede576cd8464decb41240b5013697f9a7eb) | `` xqilla: fix clang build ``                                                              |
| [`e9ebdec8`](https://github.com/NixOS/nixpkgs/commit/e9ebdec89ef26e1cad5df6d8e99a7ecfc27656bb) | `` pantheon-tweaks: 2.0.1 -> 2.0.2 ``                                                      |
| [`48b8a2f5`](https://github.com/NixOS/nixpkgs/commit/48b8a2f5f9dcabbc03affe65d8d305e0c17dbd01) | `` graphite-cli: 1.3.4 -> 1.3.5 ``                                                         |
| [`b24ae9fe`](https://github.com/NixOS/nixpkgs/commit/b24ae9fe44dae77d36aa96d80aeffe4989e4c925) | `` poptracker: 0.25.7 -> 0.26.1 ``                                                         |
| [`dc39050b`](https://github.com/NixOS/nixpkgs/commit/dc39050b95e8715f4e575e2c670595513bf12b78) | `` tftui: 0.13.1 -> 0.13.2 ``                                                              |
| [`e5135b25`](https://github.com/NixOS/nixpkgs/commit/e5135b258542e72eaa730063362a7f6856302df2) | `` zsh-abbr: 5.7.1 -> 5.8.0 ``                                                             |
| [`1d659495`](https://github.com/NixOS/nixpkgs/commit/1d6594959f2e022a6dea73bcdc16a868e8e04aab) | `` letterpress: init at 2.1 ``                                                             |
| [`c3da36c2`](https://github.com/NixOS/nixpkgs/commit/c3da36c2a7f74a9321f131493ce00de1191d2ccc) | `` esphome: 2024.5.3 -> 2024.5.4 ``                                                        |
| [`cc42e47b`](https://github.com/NixOS/nixpkgs/commit/cc42e47b8cb79bd788bbea807116ff1c657c7769) | `` vinegar: 1.7.3 -> 1.7.4; Add childwindow patch; pinned Wine to 9.2-staging (#305099) `` |
| [`709604f9`](https://github.com/NixOS/nixpkgs/commit/709604f9c9fbaa380d28dc4700fedbfa442055e1) | `` anisfilter: update homepage url ``                                                      |
| [`ce45c8b7`](https://github.com/NixOS/nixpkgs/commit/ce45c8b72b089487f52463b4a3be9e5e84b697ac) | `` python312Packages.ax: disable tests on Python 3.12 (#314710) ``                         |
| [`e37da895`](https://github.com/NixOS/nixpkgs/commit/e37da895a60594c82c465e54edf4431e026d93a3) | `` python311Packages.bugsnag: 4.7.0 -> 4.7.1 ``                                            |
| [`c4252653`](https://github.com/NixOS/nixpkgs/commit/c4252653c15285a13d6550dd8d17e966e0812365) | `` photofield: add patch for Go 1.22 support ``                                            |
| [`ef4db778`](https://github.com/NixOS/nixpkgs/commit/ef4db778059ce8bd4779a7ce4bcd638ecc807f23) | `` phoc: Add missing dependency ``                                                         |
| [`544465ef`](https://github.com/NixOS/nixpkgs/commit/544465ef9820c0a0569a675265a0bd05f899a158) | `` sageWithDoc: add sphinx 7.3 update patch ``                                             |
| [`2d11b19f`](https://github.com/NixOS/nixpkgs/commit/2d11b19f3b66570b6e2709da5304411aecd540b6) | `` python312Packages.resend: 1.1.0 -> 2.0.0 ``                                             |
| [`caab6315`](https://github.com/NixOS/nixpkgs/commit/caab6315d804120c9bb7f820cbdcaf479713e27d) | `` gnome-control-center: Add missing dependency ``                                         |
| [`05f8ebf4`](https://github.com/NixOS/nixpkgs/commit/05f8ebf40301313f84fdb25149e2fcdcd33dbd39) | `` python312Packages.yara-python: 4.5.0 -> 4.5.1 ``                                        |
| [`748fb063`](https://github.com/NixOS/nixpkgs/commit/748fb06370c92f600f31ffba0885b7d32ffeba51) | `` python312Packages.heatzypy: 2.5.4 -> 2.5.5 ``                                           |
| [`2c1df556`](https://github.com/NixOS/nixpkgs/commit/2c1df5567b9d1784fdd508e8780832f2bba8ad84) | `` python312Packages.tencentcloud-sdk-python: 3.0.1155 -> 3.0.1156 ``                      |
| [`dfe609c0`](https://github.com/NixOS/nixpkgs/commit/dfe609c00eee7939ef0de52e9b606445944881bd) | `` python312Packages.tencentcloud-sdk-python: 3.0.1154 -> 3.0.1155 ``                      |
| [`2ce35db1`](https://github.com/NixOS/nixpkgs/commit/2ce35db124918dc037b3911a94622577d3408eb8) | `` python312Packages.aioshutil: 1.3 -> 1.4 ``                                              |
| [`4d4571b2`](https://github.com/NixOS/nixpkgs/commit/4d4571b20a29a8bf53a2a75ee1da64758b88288a) | `` nixos/devpi-server: fix loading credentials as DynamicUser ``                           |
| [`bda086da`](https://github.com/NixOS/nixpkgs/commit/bda086da1e5c311121007f6c026e2ebb04d5757a) | `` libcxxrt: 4.0.10-unstable-2024-04-15 -> 4.0.10-unstable-2024-05-26 ``                   |
| [`46909595`](https://github.com/NixOS/nixpkgs/commit/46909595ad069682ddbf066966f0ff5d6e883263) | `` fluent-bit: 3.0.4 -> 3.0.6 ``                                                           |
| [`aa6b2d6d`](https://github.com/NixOS/nixpkgs/commit/aa6b2d6df502af547724054d1f5fb95e75135dbc) | `` icloudpd: 1.17.6 -> 1.18.0 ``                                                           |
| [`73660e93`](https://github.com/NixOS/nixpkgs/commit/73660e935146b6d3c3b47e1fddece132254c23a9) | `` deepin.dtk6core: fix build on 6.7.1 ``                                                  |
| [`30dac56d`](https://github.com/NixOS/nixpkgs/commit/30dac56dab94c3dfbf50cd18c0003cf2d87839c1) | `` jellyfin-web: add `assert version == jellyfin.version` to `src` ``                      |
| [`5cd7bbe6`](https://github.com/NixOS/nixpkgs/commit/5cd7bbe6fef246db9c1e3cbbd4e26c45f8c13074) | `` jellyfin-web: 10.9.2 -> 10.9.3 ``                                                       |
| [`a7441feb`](https://github.com/NixOS/nixpkgs/commit/a7441feb23f2ba370fb3ae130f51113c5c72b8f2) | `` jellyfin: 10.9.1 -> 10.9.3 ``                                                           |
| [`29356d66`](https://github.com/NixOS/nixpkgs/commit/29356d6692ea77f824a91e44fa09f30023a38b67) | `` gamescope: 3.14.16 -> 3.14.18 ``                                                        |
| [`8f2d1bf9`](https://github.com/NixOS/nixpkgs/commit/8f2d1bf902e861e21a2ceda82a28a23f19954d31) | `` rubyfmt: Use system jemalloc (#304087) ``                                               |
| [`b8e5799a`](https://github.com/NixOS/nixpkgs/commit/b8e5799a635291007d2fdbed704e84a76294223d) | `` nixos/tests/rke2: add tests for single-node and multi-node ``                           |
| [`a642efcd`](https://github.com/NixOS/nixpkgs/commit/a642efcdab1402e45db5aa2bbff7b24322679219) | `` nixos/rke2: add rke2 service ``                                                         |
| [`e34fb346`](https://github.com/NixOS/nixpkgs/commit/e34fb3467bc3b91c2526c057b19f6ad8f0b418d5) | `` nimble: 0.14.2 -> 0-unstable-2024-05-14 ``                                              |
| [`8b882f55`](https://github.com/NixOS/nixpkgs/commit/8b882f55a07b928c6ef237c8b174d8fef753148e) | `` logiops: 0.3.3 -> 0.3.4 ``                                                              |
| [`1652a914`](https://github.com/NixOS/nixpkgs/commit/1652a914fd32680fd8e6947a738b87c0fd41fa2b) | `` nixos/steam: fix evaluation failure when `fonts.packages`  contains path ``             |
| [`110d28de`](https://github.com/NixOS/nixpkgs/commit/110d28defd33c0c4323d95a8e79a26fd1854f6aa) | `` texpresso: 0-unstable-2024-05-09 -> 0-unstable-2024-05-23 ``                            |
| [`ca2f6635`](https://github.com/NixOS/nixpkgs/commit/ca2f66357302cd359a5fe5ee17618c42b05d7d0b) | `` maintainers: add matrix and gpg fingerprint for RossComputerGuy ``                      |
| [`39899298`](https://github.com/NixOS/nixpkgs/commit/398992986d223d333d5f40422b978512427bca0a) | `` rke2: add runtime dependencies for kubelet ``                                           |
| [`a6076646`](https://github.com/NixOS/nixpkgs/commit/a607664682cc7247fe2504689cdbcb0a13a9f959) | `` minio: 2024-05-10T01-41-38Z -> 2024-05-27T19-17-46Z ``                                  |
| [`b810aaee`](https://github.com/NixOS/nixpkgs/commit/b810aaee44adb77aea7964e6f97b934e4eb689dc) | `` fflogs: 8.5.6 -> 8.5.9 ``                                                               |
| [`95f8d6e5`](https://github.com/NixOS/nixpkgs/commit/95f8d6e5306ebb7459fc372fd7a5db776abb82a5) | `` mdbook-i18n-helpers: 0.3.2 -> 0.3.3 ``                                                  |
| [`09dda6c3`](https://github.com/NixOS/nixpkgs/commit/09dda6c3988f0807344a852a4ebad3ea691f9561) | `` kubescape: 3.0.10 -> 3.0.11 ``                                                          |