### PR TITLE
chore(flake/nixvim): `da9bd1f2` -> `6ff3493c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717081007,
-        "narHash": "sha256-GNr1i6itjFKGXSco3lcdKe8GxEwrmSYFDUpZyXsXWp4=",
+        "lastModified": 1717100844,
+        "narHash": "sha256-cKEGHGLaZoiNroMd34RrDgVDB7xgfff7HBShMz7cEy8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "da9bd1f2e8fc8cd8553a76a9e22afd386c18f205",
+        "rev": "6ff3493c9bc85063ae829f0c25c21be3bde5c5b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`6ff3493c`](https://github.com/nix-community/nixvim/commit/6ff3493c9bc85063ae829f0c25c21be3bde5c5b3) | `` modules/keymaps: doc: add backticks around `noremap` ``         |
| [`6d3d3bd0`](https://github.com/nix-community/nixvim/commit/6d3d3bd0c28d9b2b6a760064fa4974694c524d56) | `` modules/keymaps: doc: add backticks around special arguments `` |
| [`25338942`](https://github.com/nix-community/nixvim/commit/25338942a7ee8d641c8d56ba3726a1cb114580ea) | `` docs/user-guide: add configuration examples ``                  |