### PR TITLE
chore(flake/nixvim): `6ff3493c` -> `fa43854e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717100844,
-        "narHash": "sha256-cKEGHGLaZoiNroMd34RrDgVDB7xgfff7HBShMz7cEy8=",
+        "lastModified": 1717148599,
+        "narHash": "sha256-F5ooc75rvGOrofZ/Qy9gVdt0sPahc5HuVfc0Zxn9tOE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6ff3493c9bc85063ae829f0c25c21be3bde5c5b3",
+        "rev": "fa43854e022140cd19b50d265cd481c461d6dd82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`fa43854e`](https://github.com/nix-community/nixvim/commit/fa43854e022140cd19b50d265cd481c461d6dd82) | `` plugins/edgy: init ``                                         |
| [`c95b0a5d`](https://github.com/nix-community/nixvim/commit/c95b0a5d79952f7d49dda61db087ec1dc4498260) | `` docs/user-guide/config-examples: add MikaelFangel's config `` |
| [`4e7ff2b4`](https://github.com/nix-community/nixvim/commit/4e7ff2b4274eb3976d6237edef94e5ab7b9c289f) | `` plugins/git/octo: init ``                                     |