### PR TITLE
chore(flake/nixvim): `fa43854e` -> `d15fade6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717148599,
-        "narHash": "sha256-F5ooc75rvGOrofZ/Qy9gVdt0sPahc5HuVfc0Zxn9tOE=",
+        "lastModified": 1717191071,
+        "narHash": "sha256-wue0+NHKFhTiY7dTtP0jyNwVgUCMOBfcP7mSHVa6PMw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "fa43854e022140cd19b50d265cd481c461d6dd82",
+        "rev": "d15fade62b743839a20d927d3506d503858f49f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`d15fade6`](https://github.com/nix-community/nixvim/commit/d15fade62b743839a20d927d3506d503858f49f0) | `` helpers/toLuaObject: fix rawKey handling ``          |
| [`1bbd58b6`](https://github.com/nix-community/nixvim/commit/1bbd58b6b293840716355e63fb3d5aa5af00d389) | `` plugins/lsp: add ruby-lsp ``                         |
| [`0ba2ea54`](https://github.com/nix-community/nixvim/commit/0ba2ea5416485d3f6552a108710711acd688cfef) | `` helpers: add rawKeysAttrs ``                         |
| [`03c5f5eb`](https://github.com/nix-community/nixvim/commit/03c5f5eb74ae0c1ae190e01d6a0f4428ead23ec1) | `` helpers/toLuaObject: add support for raw keys ``     |
| [`29922e13`](https://github.com/nix-community/nixvim/commit/29922e13f7040c1f46b1cf9aeb06f1bda44bea92) | `` modules/keymaps: fix false-positive `lua` warning `` |
| [`db32a4eb`](https://github.com/nix-community/nixvim/commit/db32a4ebdae0a84c07098c6d2b585033e51eb7e5) | `` flake-modules/wrappers: add default module ``        |