### PR TITLE
chore(flake/nixvim): `d15fade6` -> `df3aa867`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717191071,
-        "narHash": "sha256-wue0+NHKFhTiY7dTtP0jyNwVgUCMOBfcP7mSHVa6PMw=",
+        "lastModified": 1717255175,
+        "narHash": "sha256-MtsnAwzY2cmufUoFQvI/1mTzd3FKbZLCb8zF4jXkZLY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d15fade62b743839a20d927d3506d503858f49f0",
+        "rev": "df3aa867137227bda9e44beab82a63443d700f18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`df3aa867`](https://github.com/nix-community/nixvim/commit/df3aa867137227bda9e44beab82a63443d700f18) | `` lib/keymap-helpers: refactor `mkMapOptionSubmodule` ``       |
| [`87d6654a`](https://github.com/nix-community/nixvim/commit/87d6654a9f5b636dbd1876018075166478d85f10) | `` lib/options: remove `mkStr` assert ``                        |
| [`297aa6d0`](https://github.com/nix-community/nixvim/commit/297aa6d0a28c3ade20e669c08e7d5f6a3f519782) | `` lib/options: make `mkPackageOption` use `mkNullOrOption'` `` |
| [`1bb4cb9c`](https://github.com/nix-community/nixvim/commit/1bb4cb9c6c334a6d52755066b1747547da137b00) | `` lib/options: add `mkAttrsOf'` & `mkListOf'` (etc) ``         |
| [`e0b60bac`](https://github.com/nix-community/nixvim/commit/e0b60bac8b7c9fda6c4555ac2e497b2e758711a0) | `` lib/options: add `mkNullableWithRaw'` variant ``             |
| [`84b2b0d9`](https://github.com/nix-community/nixvim/commit/84b2b0d90c2434be99c648edf5957ebd9ceb76e9) | `` lib/options: add `mkNullable'` variant ``                    |
| [`ed562214`](https://github.com/nix-community/nixvim/commit/ed56221499b68d57d1db87029070cf97e2b43f91) | `` lib/options: add `mkNullOrStrLuaFnOr'` variant ``            |
| [`5bcb6184`](https://github.com/nix-community/nixvim/commit/5bcb6184b0c1ef2c16e79db964eb1d0f639ba4df) | `` lib/options: add `mkNullOrStrLuaOr'` variant ``              |
| [`56ee982c`](https://github.com/nix-community/nixvim/commit/56ee982cb47c23f81fc67293bf88056c3eb98085) | `` lib/options: add `mkNullOrLuaFn'` variant ``                 |
| [`207bfc6e`](https://github.com/nix-community/nixvim/commit/207bfc6e694a1da256e25fc69a96172bf40995a0) | `` lib/options: add `mkNullOrLua'` variant ``                   |
| [`3a151bbf`](https://github.com/nix-community/nixvim/commit/3a151bbf094977668d85379b67154a5eb0d76c68) | `` lib/options: add `mkNullOrStr'` variant ``                   |
| [`9bf7724b`](https://github.com/nix-community/nixvim/commit/9bf7724b98250aeca9d4c478c8035594f813ccd6) | `` lib/options: add `mkCompositeOption'` variant ``             |
| [`fc542329`](https://github.com/nix-community/nixvim/commit/fc542329cd023c0909ef7244ddda31c788e0fccd) | `` lib/options: add `mkNullOrOption'` variant ``                |
| [`57003fea`](https://github.com/nix-community/nixvim/commit/57003fea4e0dce32b518c1a1356f9de9226ff141) | `` lib/options: inline `mkDefaultDesc` into `mkDesc` ``         |