### PR TITLE
chore(flake/nixvim): `df3aa867` -> `e58380ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717255175,
-        "narHash": "sha256-MtsnAwzY2cmufUoFQvI/1mTzd3FKbZLCb8zF4jXkZLY=",
+        "lastModified": 1717274692,
+        "narHash": "sha256-CnMCPxY9GfBAONN3BoWmPc36QV5Sv9uZFKH9VkE5KJI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "df3aa867137227bda9e44beab82a63443d700f18",
+        "rev": "e58380adcddc450eb08c37760a3f282077386d19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`e58380ad`](https://github.com/nix-community/nixvim/commit/e58380adcddc450eb08c37760a3f282077386d19) | `` plugins/lsp/ltex: refactoring of the settings options ``          |
| [`9a9d6c69`](https://github.com/nix-community/nixvim/commit/9a9d6c69d8be9c5fa66f0714de22564df72aaa96) | `` plugins/copilot-chat: init ``                                     |
| [`f4ce7dad`](https://github.com/nix-community/nixvim/commit/f4ce7dad0e9ba16692783a70ed7f5b79e41d6c58) | `` plugins/lsp/lua-ls: add tests ``                                  |
| [`7c3ae8c7`](https://github.com/nix-community/nixvim/commit/7c3ae8c718a6b08fa61f803f53281d63bd1f9649) | `` plugins/lsp/lua-ls: refactor settings options ``                  |
| [`adf7bb13`](https://github.com/nix-community/nixvim/commit/adf7bb1301f6e5ba1f5b028dcf8cb967d19b9d98) | `` plugins/lsp/lua-ls: remove useless if/else for default package `` |