### PR TITLE
chore(flake/nixvim): `e58380ad` -> `f7e009d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717274692,
-        "narHash": "sha256-CnMCPxY9GfBAONN3BoWmPc36QV5Sv9uZFKH9VkE5KJI=",
+        "lastModified": 1717294691,
+        "narHash": "sha256-OdScAoNJjqGA+g0Nznlaa4J7Wrx7QSzEFSXqdHZYnzg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e58380adcddc450eb08c37760a3f282077386d19",
+        "rev": "f7e009d29ea3da3d9741902222cc280fcfca594a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f7e009d2`](https://github.com/nix-community/nixvim/commit/f7e009d29ea3da3d9741902222cc280fcfca594a) | `` lib/options: add `mkEnum'` argument assertions ``    |
| [`a2443ac0`](https://github.com/nix-community/nixvim/commit/a2443ac0d62e0f980b6dcfc0864e8fdaea163c21) | `` lib/options: add more `defaultNullOpts` 'variants `` |
| [`d136c08f`](https://github.com/nix-community/nixvim/commit/d136c08f3aad2a8a20fbae8e659822417d59f60a) | `` plugins: normalise `null` plugin-defaults ``         |