### PR TITLE
chore(flake/nixvim): `f7e009d2` -> `514413f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717294691,
-        "narHash": "sha256-OdScAoNJjqGA+g0Nznlaa4J7Wrx7QSzEFSXqdHZYnzg=",
+        "lastModified": 1717367392,
+        "narHash": "sha256-7Kpbdp6muCCggQqYPVl0wqxuEE7Gf5b/IZwMWP7MouM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f7e009d29ea3da3d9741902222cc280fcfca594a",
+        "rev": "514413f6316a9a37648ba87e7519b148d66bd042",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`514413f6`](https://github.com/nix-community/nixvim/commit/514413f6316a9a37648ba87e7519b148d66bd042) | `` wrappers/hm: add vimdiffAlias option ``                      |
| [`34d56c71`](https://github.com/nix-community/nixvim/commit/34d56c712ece5527c1be8dd08ed74dc7225e29ea) | `` plugins/barbar: add keymaps.* options for missing actions `` |
| [`1c270521`](https://github.com/nix-community/nixvim/commit/1c270521ad67bff80511a2d18fae5f50745e6427) | `` plugins/barbar: switch to mkNeovimPlugin + update options `` |
| [`513b3c76`](https://github.com/nix-community/nixvim/commit/513b3c76e23e730eb30ec533666551c13477bd70) | `` plugins/lsp/nil_ls: refactor options ``                      |