### PR TITLE
chore(flake/nixvim): `4b05fde8` -> `b7a8b031`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717427806,
-        "narHash": "sha256-WiM5Ccu5vo/gUGjZujqbDA7XBbTt3v0BJzvxTx0x67w=",
+        "lastModified": 1717444597,
+        "narHash": "sha256-8enVHsN7hLn1hPkY1U5Cfr3rzij4FsWRUx4jjHUHZQE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4b05fde8730b79501f4b53cf763e5b6368e0f67a",
+        "rev": "b7a8b0319098fdbaa719ef4dc375337ec4543c6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`b7a8b031`](https://github.com/nix-community/nixvim/commit/b7a8b0319098fdbaa719ef4dc375337ec4543c6e) | `` plugins/lsp: normalise kebab-case-names ``                  |
| [`0a243276`](https://github.com/nix-community/nixvim/commit/0a2432763235658445f096f7d879dde050696b0c) | `` plugins/lsp: automatically add `serverName` alias ``        |
| [`61fa26c9`](https://github.com/nix-community/nixvim/commit/61fa26c9e90effea591f927b38af04ca036ebd27) | `` plugins/lsp: remove `installLanguageServer` assertion ``    |
| [`0c2834c5`](https://github.com/nix-community/nixvim/commit/0c2834c50b68c8c2ebe75bd28a74701c573cac49) | `` readme: add "plugin settings" and "raw lua" sections ``     |
| [`a7cbb0ec`](https://github.com/nix-community/nixvim/commit/a7cbb0ecf06f3af22e46cb3ad1bf9a1126d758a7) | `` readme: move "how it works" near the top ``                 |
| [`cf487e09`](https://github.com/nix-community/nixvim/commit/cf487e09af159b00fc1b1634224f9d02570173ed) | `` readme: move "advanced usage" next to "standalone usage" `` |
| [`80ed8664`](https://github.com/nix-community/nixvim/commit/80ed86649b063bd3deafb66bbf98d26eaed5ba80) | `` readme: use `pkgs.system` in standalone example ``          |
| [`d3f12340`](https://github.com/nix-community/nixvim/commit/d3f12340e153af9ea7c71c80d72e4c163d1ef15f) | `` readme: put installation instruction in `<details>` ``      |