### PR TITLE
chore(flake/nixvim): `b7a8b031` -> `7ffff28f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717444597,
-        "narHash": "sha256-8enVHsN7hLn1hPkY1U5Cfr3rzij4FsWRUx4jjHUHZQE=",
+        "lastModified": 1717514166,
+        "narHash": "sha256-aBDthjID+f9veJFPpJcrfXYPnQfx/ZAjUZMEUSgta6w=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b7a8b0319098fdbaa719ef4dc375337ec4543c6e",
+        "rev": "7ffff28f432ffaf46390140b9cf059c413aaf824",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`7ffff28f`](https://github.com/nix-community/nixvim/commit/7ffff28f432ffaf46390140b9cf059c413aaf824) | `` contributing: describe commit title style ``           |
| [`afc98b29`](https://github.com/nix-community/nixvim/commit/afc98b291d983332b225b24f45624ccbc4ccb2f2) | `` fix(hmts): correct error message on no `treesitter` `` |