### PR TITLE
chore(flake/nixvim): `7ffff28f` -> `cfff48c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717514166,
-        "narHash": "sha256-aBDthjID+f9veJFPpJcrfXYPnQfx/ZAjUZMEUSgta6w=",
+        "lastModified": 1717522463,
+        "narHash": "sha256-GYmgttJ7Dzs84Fb8wYsnF6KaQCafp99gKQaQWTvV/wo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7ffff28f432ffaf46390140b9cf059c413aaf824",
+        "rev": "cfff48c2673bb7ac2841201ed700d332b6d643ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`cfff48c2`](https://github.com/nix-community/nixvim/commit/cfff48c2673bb7ac2841201ed700d332b6d643ab) | `` plugins/lsp: add r_language_server `` |