### PR TITLE
chore(flake/nixvim): `cfff48c2` -> `f530700c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -107,21 +107,6 @@
         "type": "github"
       }
     },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1713493429,
-        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -301,7 +286,6 @@
         "devshell": "devshell",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts_2",
-        "flake-root": "flake-root",
         "git-hooks": "git-hooks",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
@@ -311,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717522463,
-        "narHash": "sha256-GYmgttJ7Dzs84Fb8wYsnF6KaQCafp99gKQaQWTvV/wo=",
+        "lastModified": 1717607611,
+        "narHash": "sha256-lpyXoLb/DhbPNl59wc64NWX4ZySfqDFiXtYaRgPb5ho=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cfff48c2673bb7ac2841201ed700d332b6d643ab",
+        "rev": "f530700ccd2955ceb620cd12fc1f5b04d2c752f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`f530700c`](https://github.com/nix-community/nixvim/commit/f530700ccd2955ceb620cd12fc1f5b04d2c752f4) | `` plugins/dashboard: switch to `mkNeovimPlugin` + update options ``         |
| [`a54ee8ad`](https://github.com/nix-community/nixvim/commit/a54ee8ad64c91b587c3460126bad25a441c1118c) | `` flake-modules: explicitly set the same nixfmt for treefmt + pre-commit `` |
| [`d9789956`](https://github.com/nix-community/nixvim/commit/d9789956d909ba5fa32e5ebbe53a740a36be4695) | `` flake-modules: don't explicitly set treefmt package ``                    |
| [`4d1d008e`](https://github.com/nix-community/nixvim/commit/4d1d008e784909b39ccecd28bcfb9894a4b8aebe) | `` flake-modules: treefmt is formatter by default ``                         |
| [`ec78d2e1`](https://github.com/nix-community/nixvim/commit/ec78d2e1ab17bb9c52158af3534f6ad494548fb5) | `` flake-modules: drop flake-root ``                                         |
| [`77d4e909`](https://github.com/nix-community/nixvim/commit/77d4e909f88ed8ce7b8e7092aa0780de7dfd89f4) | `` .git-blame-ignore-revs: init ``                                           |
| [`37dbf9d2`](https://github.com/nix-community/nixvim/commit/37dbf9d2e211ac5ad47a4cc958e46948be14e46c) | `` modules/clipboard: use md link in description ``                          |