### PR TITLE
chore(flake/pre-commit-hooks): `0e8fcc54` -> `cc4d466c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -318,11 +318,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1716213921,
-        "narHash": "sha256-xrsYFST8ij4QWaV6HEokCUNIZLjjLP1bYC60K8XiBVA=",
+        "lastModified": 1717664902,
+        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "0e8fcc54b842ad8428c9e705cb5994eaf05c26a0",
+        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`d74bff58`](https://github.com/cachix/git-hooks.nix/commit/d74bff580363f769289a4b4938d30555433b858f) | `` fix: update tools.nix to include yamlfmt `` |
| [`e4eba37a`](https://github.com/cachix/git-hooks.nix/commit/e4eba37a68d50179ff5af1705a54d5fd508f7bd5) | `` feat: add yamlfmt ``                        |