### PR TITLE
chore(flake/nixvim): `36f2e51b` -> `94a45207`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717681257,
-        "narHash": "sha256-0PhFvfc4wDjba1cus2ALsfn0wVizeKkcuF+aqvDJivg=",
+        "lastModified": 1717771374,
+        "narHash": "sha256-/4wvx/TqcPkqXANSURsliFQ+8rWPjr6RZ19IXrEd+Rw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "36f2e51b28ee3389a67ed5e9ed5c4bd388b06918",
+        "rev": "94a452074f5dc1eda18fe6d3f447cc49ab2adefb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`94a45207`](https://github.com/nix-community/nixvim/commit/94a452074f5dc1eda18fe6d3f447cc49ab2adefb) | `` plugins/tmux-navigator: add keymaps option ``         |
| [`4634c378`](https://github.com/nix-community/nixvim/commit/4634c3781bfb1be4b8d30056bd663c52fb03bdf5) | `` plugins/tmux-navigator: remove old deprecations ``    |
| [`30226230`](https://github.com/nix-community/nixvim/commit/302262304e55ea596218eeecb67f43510816ff02) | `` lib/keymaps: refactor `mkMapOptionSubmodule` again `` |
| [`c16533b3`](https://github.com/nix-community/nixvim/commit/c16533b3f7e7fa7ed7e077fbd90da8285383603a) | `` lib: add `upperFirstChar` ``                          |