### PR TITLE
chore(flake/nixvim): `94a45207` -> `552e8b0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717771374,
-        "narHash": "sha256-/4wvx/TqcPkqXANSURsliFQ+8rWPjr6RZ19IXrEd+Rw=",
+        "lastModified": 1717799968,
+        "narHash": "sha256-NvmBPOpaf2z8aId+stIJK3/URuc4EaL3KeurKkHTxRA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "94a452074f5dc1eda18fe6d3f447cc49ab2adefb",
+        "rev": "552e8b0a8551acc43292d06258829fe0621980e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`552e8b0a`](https://github.com/nix-community/nixvim/commit/552e8b0a8551acc43292d06258829fe0621980e2) | `` plugins/dashboard: add additional examples ``                    |
| [`2ce578e3`](https://github.com/nix-community/nixvim/commit/2ce578e35fed7fda0c3c1895dd49e73044c06e26) | `` docs/lsp: Show LSP server homepage URLs ``                       |
| [`f34fda8d`](https://github.com/nix-community/nixvim/commit/f34fda8d990762f120074e55e3ea1fc9e872dc42) | `` meta: extend `meta.nixvimInfo` support treewide ``               |
| [`b2a47726`](https://github.com/nix-community/nixvim/commit/b2a477260d6c198ca1390e7169a1c98e488351c1) | `` docs: emphasise "Plugin default" to match nixpkgs ``             |
| [`ade4539b`](https://github.com/nix-community/nixvim/commit/ade4539b3f150960fedc7e06dfee2aef6d31d387) | `` lib/options: `defaultNullOpts` don't require having a default `` |