### PR TITLE
chore(flake/nixvim): `552e8b0a` -> `db32ebe2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717799968,
-        "narHash": "sha256-NvmBPOpaf2z8aId+stIJK3/URuc4EaL3KeurKkHTxRA=",
+        "lastModified": 1717861394,
+        "narHash": "sha256-U7E1Wg5PRKUYqfeL8H6KU/5VjFo8bkxbFzigN2grkQI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "552e8b0a8551acc43292d06258829fe0621980e2",
+        "rev": "db32ebe205111af0b74d74684df64674ffcf3b36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`db32ebe2`](https://github.com/nix-community/nixvim/commit/db32ebe205111af0b74d74684df64674ffcf3b36) | `` flake.lock: Update ``                            |
| [`dedb1f85`](https://github.com/nix-community/nixvim/commit/dedb1f85936b730ff181bdc732639701cfc619be) | `` plugins/nvim-cmp: don't specify default twice `` |