### PR TITLE
chore(flake/nixvim): `db32ebe2` -> `70088f6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717861394,
-        "narHash": "sha256-U7E1Wg5PRKUYqfeL8H6KU/5VjFo8bkxbFzigN2grkQI=",
+        "lastModified": 1717879126,
+        "narHash": "sha256-dylweBqNKh7FoFJisuCxeUSJcBxoiY3QnEsx2nCWLXE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "db32ebe205111af0b74d74684df64674ffcf3b36",
+        "rev": "70088f6f8945023115f090f26764e5a71ae87a91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`70088f6f`](https://github.com/nix-community/nixvim/commit/70088f6f8945023115f090f26764e5a71ae87a91) | `` plugins/wakatime: init ``               |
| [`e8a05261`](https://github.com/nix-community/nixvim/commit/e8a05261d59e644baf61386328ef2f794babde29) | `` plugins/luasnip: add SnipMate loader `` |