### PR TITLE
chore(flake/nixvim): `70088f6f` -> `4a22c35e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717879126,
-        "narHash": "sha256-dylweBqNKh7FoFJisuCxeUSJcBxoiY3QnEsx2nCWLXE=",
+        "lastModified": 1717919753,
+        "narHash": "sha256-2nl1NGuin2MFFniD+E/T5cXxweTprh86YkoVEVsEJmI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "70088f6f8945023115f090f26764e5a71ae87a91",
+        "rev": "4a22c35e6dc28379abc5c0888adee2c98afbf20f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`4a22c35e`](https://github.com/nix-community/nixvim/commit/4a22c35e6dc28379abc5c0888adee2c98afbf20f) | `` plugins/lsp: add inlay-hint option `` |