### PR TITLE
chore(flake/nixvim): `4a22c35e` -> `8a462dc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717919753,
-        "narHash": "sha256-2nl1NGuin2MFFniD+E/T5cXxweTprh86YkoVEVsEJmI=",
+        "lastModified": 1717922156,
+        "narHash": "sha256-C/TgTnKY4iWXnBmKocV9KeV+OtZGCh+1Pcw26Elx7JM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4a22c35e6dc28379abc5c0888adee2c98afbf20f",
+        "rev": "8a462dc9570bce1de5a7dd1beabd83f95958315b",
         "type": "github"
       },
       "original": {
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717278143,
-        "narHash": "sha256-u10aDdYrpiGOLoxzY/mJ9llST9yO8Q7K/UlROoNxzDw=",
+        "lastModified": 1717850719,
+        "narHash": "sha256-npYqVg+Wk4oxnWrnVG7416fpfrlRhp/lQ6wQ4DHI8YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3eb96ca1ae9edf792a8e0963cc92fddfa5a87706",
+        "rev": "4fc1c45a5f50169f9f29f6a98a438fb910b834ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`8a462dc9`](https://github.com/nix-community/nixvim/commit/8a462dc9570bce1de5a7dd1beabd83f95958315b) | `` plugins/lsp: fix inlayHints description `` |
| [`f2d38e0a`](https://github.com/nix-community/nixvim/commit/f2d38e0a3c4d97415d257580c755e460a42a65d2) | `` flake.lock: Update ``                      |