### PR TITLE
chore(flake/nixvim): `8a462dc9` -> `33a32c94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717922156,
-        "narHash": "sha256-C/TgTnKY4iWXnBmKocV9KeV+OtZGCh+1Pcw26Elx7JM=",
+        "lastModified": 1718028681,
+        "narHash": "sha256-C27X1vnsxKaKd1dCUU/u3LU+3DiA3Jo/ApvDiDNPIrI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8a462dc9570bce1de5a7dd1beabd83f95958315b",
+        "rev": "33a32c94176feebd3ff5259ce418b989b428d5ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`33a32c94`](https://github.com/nix-community/nixvim/commit/33a32c94176feebd3ff5259ce418b989b428d5ae) | `` lib/options: move "plugin default" into `defaultText` `` |