### PR TITLE
chore(flake/nixvim): `33a32c94` -> `de9b81c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1718028681,
-        "narHash": "sha256-C27X1vnsxKaKd1dCUU/u3LU+3DiA3Jo/ApvDiDNPIrI=",
+        "lastModified": 1718086329,
+        "narHash": "sha256-47e+g0SuET3NQTBhwf0SLVOeDHq4+NpzjiTS3FsEl+g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "33a32c94176feebd3ff5259ce418b989b428d5ae",
+        "rev": "de9b81c7e7fa8a4c9c8cf44538d06184e5d0be3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`de9b81c7`](https://github.com/nix-community/nixvim/commit/de9b81c7e7fa8a4c9c8cf44538d06184e5d0be3b) | `` plugins/specs: add tests ``                          |
| [`9d0960b9`](https://github.com/nix-community/nixvim/commit/9d0960b986187d6e922b6168e3f7d40f9f919f9a) | `` plugins/specs: switch to mkNeovimPlugin ``           |
| [`5361e428`](https://github.com/nix-community/nixvim/commit/5361e428284a60daffa161b4c69bfbc96f96e462) | `` plugins/specs: move source files to the ui folder `` |