### PR TITLE
chore(flake/nixvim): `de9b81c7` -> `7a2d065c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1718086329,
-        "narHash": "sha256-47e+g0SuET3NQTBhwf0SLVOeDHq4+NpzjiTS3FsEl+g=",
+        "lastModified": 1718098450,
+        "narHash": "sha256-QDKPhT61Cf82/7G7vMyEfKQSIGGzs33FyT+4RB34spo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "de9b81c7e7fa8a4c9c8cf44538d06184e5d0be3b",
+        "rev": "7a2d065ccec902c17db71bd2ba3e485a0952f43b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`7a2d065c`](https://github.com/nix-community/nixvim/commit/7a2d065ccec902c17db71bd2ba3e485a0952f43b) | `` misc: ensure all options have a description ``           |
| [`3be9db71`](https://github.com/nix-community/nixvim/commit/3be9db71c2ddd7c33a9746835866b8198ecdf5ad) | `` plugins/lsp/nixd: add "diagnostic" options ``            |
| [`893b2877`](https://github.com/nix-community/nixvim/commit/893b28779dbc3df70d621807809160c901a94e33) | `` plugins/lsp/nixd: remove pre-formatted string default `` |