### PR TITLE
chore(flake/nixvim): `7a2d065c` -> `01aa3d46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717525419,
-        "narHash": "sha256-5z2422pzWnPXHgq2ms8lcCfttM0dz+hg+x1pCcNkAws=",
+        "lastModified": 1718141734,
+        "narHash": "sha256-cA+6l8ZCZ7MXGijVuY/1f55+wF/RT4PlTR9+g4bx86w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7117efb3725e6197dd95424136f79147aa35e5b",
+        "rev": "892f76bd0aa09a0f7f73eb41834b8a904b6d0fad",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716993688,
-        "narHash": "sha256-vo5k2wQekfeoq/2aleQkBN41dQiQHNTniZeVONWiWLs=",
+        "lastModified": 1717976995,
+        "narHash": "sha256-u3HBinyIyUvL1+N816bODpJmSQdgn0Mbb8BprFw7kqo=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "c0d5b8c54d6828516c97f6be9f2d00c63a363df4",
+        "rev": "315aa649ba307704db0b16c92f097a08a65ec955",
         "type": "github"
       },
       "original": {
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1718098450,
-        "narHash": "sha256-QDKPhT61Cf82/7G7vMyEfKQSIGGzs33FyT+4RB34spo=",
+        "lastModified": 1718282813,
+        "narHash": "sha256-Rlf+UmAZ8nr5dBEqIiubLcxT8x/LSmS3ID+HNwyq+D4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7a2d065ccec902c17db71bd2ba3e485a0952f43b",
+        "rev": "01aa3d469e0cb0430e16fde6c5c3176f453bfba8",
         "type": "github"
       },
       "original": {
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717850719,
-        "narHash": "sha256-npYqVg+Wk4oxnWrnVG7416fpfrlRhp/lQ6wQ4DHI8YE=",
+        "lastModified": 1718139168,
+        "narHash": "sha256-1TZQcdETNdJMcfwwoshVeCjwWfrPtkSQ8y8wFX3it7k=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "4fc1c45a5f50169f9f29f6a98a438fb910b834ed",
+        "rev": "1cb529bffa880746a1d0ec4e0f5076876af931f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`01aa3d46`](https://github.com/nix-community/nixvim/commit/01aa3d469e0cb0430e16fde6c5c3176f453bfba8) | `` plugins/lsp: fix incorrect inlay_hint usage ``                                                 |
| [`4ab2b289`](https://github.com/nix-community/nixvim/commit/4ab2b289b6a9d2b5d970d515c087c64cc2b24847) | `` plugins/none-ls: more compatible gdtoolkit fix ``                                              |
| [`f8787bd2`](https://github.com/nix-community/nixvim/commit/f8787bd23b0975121be8762617e9046b52a0fc56) | `` docs: capitalize URL ``                                                                        |
| [`5c9b98e6`](https://github.com/nix-community/nixvim/commit/5c9b98e64d8384553452192a6bebdb1e4e81b907) | `` docs: render maintainers with github links ``                                                  |
| [`cc9023fb`](https://github.com/nix-community/nixvim/commit/cc9023fb1d74fad3b7b704a1c161a2ce9f378431) | `` plugins/languages/lint: allow irregular linters ``                                             |
| [`34d75943`](https://github.com/nix-community/nixvim/commit/34d75943ede23827a4c0cd5ee4e4a5c957ede166) | `` plugins/neotest/adapters/playwright: temporarily enable telescope when this adapter is used `` |
| [`4edfed10`](https://github.com/nix-community/nixvim/commit/4edfed1075a06833e87c9f5470cd559ef3c64c98) | `` plugins/none-ls: add package association for xmllint ``                                        |
| [`d777475e`](https://github.com/nix-community/nixvim/commit/d777475e693a06c00dfe592b913194b3ad4a4b24) | `` plugins/none-ls: add package association for opentofu_fmt ``                                   |
| [`ca7db431`](https://github.com/nix-community/nixvim/commit/ca7db4316d49d338eb6b94fefc954e437d391f7f) | `` plugins/none-ls: update gdtoolkit to gdtoolkit_4 ``                                            |
| [`ded9ca40`](https://github.com/nix-community/nixvim/commit/ded9ca40297122494d7a82a0e2c59039d17823c8) | `` flake.lock: Update ``                                                                          |