### PR TITLE
chore(flake/nixvim): `db93efff` -> `7a2a25af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1718348724,
-        "narHash": "sha256-5+sszYvCywf8bl/gNJEVhw0fxGOOXJ22lv4cEYlU9hw=",
+        "lastModified": 1718376125,
+        "narHash": "sha256-NIJZxmY2CWsqJK/9BQCRSHfcCY9K6thjq/1XtJobxmU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "db93efffdba8ed24624c2c81de397ab040e70646",
+        "rev": "7a2a25af02be25987aa43cd681312f4b5ba12317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`7a2a25af`](https://github.com/nix-community/nixvim/commit/7a2a25af02be25987aa43cd681312f4b5ba12317) | `` ci: simplify docs-build workflow ``                              |
| [`3834c4e0`](https://github.com/nix-community/nixvim/commit/3834c4e0db1929aa0e91fbfd9c12be01dbf976bb) | `` plugins/cmp: add cmp_ai source ``                                |
| [`582641a6`](https://github.com/nix-community/nixvim/commit/582641a639c5687aa50964c88cdc243e32983a02) | `` lib/options: fix minor typo ``                                   |
| [`8e8c22ce`](https://github.com/nix-community/nixvim/commit/8e8c22ce6514aebe35b1afb67f866bc20a277738) | `` lib/options: rename `convertArgs` to `processDefaultNullArgs` `` |
| [`5cec79e5`](https://github.com/nix-community/nixvim/commit/5cec79e59f6ccad207d2f6f9a091a6b17e49dea8) | `` lib/options: migrate `defaultNullOpts` to use `pluginDefault` `` |
| [`e51b8b9b`](https://github.com/nix-community/nixvim/commit/e51b8b9b5c91aa49981d78c4aa1ac08a50150103) | `` lib/options: remove `defaultNullOpts.mkDesc` ``                  |
| [`6e979dbe`](https://github.com/nix-community/nixvim/commit/6e979dbe94d94c83dba193ffb550f9709cead6cf) | `` plugins/barbar: switch from `mkDesc` to `pluginDefaultText` ``   |
| [`44cd01b2`](https://github.com/nix-community/nixvim/commit/44cd01b253aec537c771a8bfeb74611ed6f8f524) | `` plugins/edgy: switch from `mkDesc` to `pluginDefault` ``         |
| [`a8943f25`](https://github.com/nix-community/nixvim/commit/a8943f2502376ced360f4fdd7f06aa12e7faadfb) | `` lib/options: allow `pluginDefault` in any helper ``              |
| [`eb5c090e`](https://github.com/nix-community/nixvim/commit/eb5c090e901be2a3038e1b17268672c0ce857ca8) | `` plugins/lsp/tflint: init ``                                      |
| [`ea5078fc`](https://github.com/nix-community/nixvim/commit/ea5078fc10f03bf5a3800e8d80135419fbd6d3f6) | `` plugins/lsp/jsonnet-ls: init ``                                  |