### PR TITLE
chore(flake/nixvim): `6ac0d286` -> `7087b601`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1718560097,
-        "narHash": "sha256-JI17CzgQbbzeB2H0n3G9N/HtTAMFSq2IFbRPnlJNTt8=",
+        "lastModified": 1718611490,
+        "narHash": "sha256-4rd3tTGdUsIoqABoJG9OjNikNoc5ZAHZ6fEqE2gpjE4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6ac0d2869d8d5a71547a504900f9199871d62506",
+        "rev": "7087b6014dae5ce3169f822dbccfb69fca0325a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`7087b601`](https://github.com/nix-community/nixvim/commit/7087b6014dae5ce3169f822dbccfb69fca0325a8) | `` plugins/cmp-git: general cleanup of options ``      |
| [`130a66bc`](https://github.com/nix-community/nixvim/commit/130a66bce7d5af1727f618f6f358a87d24b767d3) | `` plugins/ltex-extra: minor options cleanup ``        |
| [`36b4a39b`](https://github.com/nix-community/nixvim/commit/36b4a39b2bd3bafc0cfd28bf94e1b21f142b6884) | `` lib/types: allow assigning raw lua to string lua `` |
| [`2d063c2c`](https://github.com/nix-community/nixvim/commit/2d063c2c247cef93dc79f0807feb7eaae8506397) | `` lib/types: simplify isRawType ``                    |
| [`69e43a6b`](https://github.com/nix-community/nixvim/commit/69e43a6bf948429f15db4e8865f361fb80590253) | `` plugins/none-ls: refactor `mkRaw` ``                |