### PR TITLE
chore(flake/nixvim): `7087b601` -> `b822078e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1718611490,
-        "narHash": "sha256-4rd3tTGdUsIoqABoJG9OjNikNoc5ZAHZ6fEqE2gpjE4=",
+        "lastModified": 1718614971,
+        "narHash": "sha256-ID/Fvvd9Bz01gpm36mIfjoqXIknb2WkacSukW75cRNw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7087b6014dae5ce3169f822dbccfb69fca0325a8",
+        "rev": "b822078ec1b2bbf666af767061e29575edc5ec05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`b822078e`](https://github.com/nix-community/nixvim/commit/b822078ec1b2bbf666af767061e29575edc5ec05) | `` plugins/ts-autotag: switch to mkNeovimPlugin `` |