### PR TITLE
chore(flake/nixvim): `5755ff09` -> `9b25eaaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1719877454,
+        "narHash": "sha256-g5N1yyOSsPNiOlFfkuI/wcUjmtah+nxdImJqrSATjOU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "4e3583423212f9303aa1a6337f8dffb415920e4f",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717664902,
-        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
+        "lastModified": 1719259945,
+        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
+        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718141734,
-        "narHash": "sha256-cA+6l8ZCZ7MXGijVuY/1f55+wF/RT4PlTR9+g4bx86w=",
+        "lastModified": 1719827439,
+        "narHash": "sha256-tneHOIv1lEavZ0vQ+rgz67LPNCgOZVByYki3OkSshFU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "892f76bd0aa09a0f7f73eb41834b8a904b6d0fad",
+        "rev": "59ce796b2563e19821361abbe2067c3bb4143a7d",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717976995,
-        "narHash": "sha256-u3HBinyIyUvL1+N816bODpJmSQdgn0Mbb8BprFw7kqo=",
+        "lastModified": 1719845423,
+        "narHash": "sha256-ZLHDmWAsHQQKnmfyhYSHJDlt8Wfjv6SQhl2qek42O7A=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "315aa649ba307704db0b16c92f097a08a65ec955",
+        "rev": "ec12b88104d6c117871fad55e931addac4626756",
         "type": "github"
       },
       "original": {
@@ -319,11 +319,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1718656037,
-        "narHash": "sha256-uW9V+SZEAKWRpzF9o8Dl373Mmss83E16+iR1psvVq5Y=",
+        "lastModified": 1720021470,
+        "narHash": "sha256-wJ8NGzPRkwDao4Om9/P+RLxussLGvtGGH2XdjDgJqRE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5755ff0958bdb511f9791545888084c0a2c5ad50",
+        "rev": "9b25eaaa6f64a584ffccdd90b23d0962d9138352",
         "type": "github"
       },
       "original": {
@@ -408,11 +408,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718139168,
-        "narHash": "sha256-1TZQcdETNdJMcfwwoshVeCjwWfrPtkSQ8y8wFX3it7k=",
+        "lastModified": 1719887753,
+        "narHash": "sha256-p0B2r98UtZzRDM5miGRafL4h7TwGRC4DII+XXHDHqek=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1cb529bffa880746a1d0ec4e0f5076876af931f1",
+        "rev": "bdb6355009562d8f9313d9460c0d3860f525bc6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| [`9b25eaaa`](https://github.com/nix-community/nixvim/commit/9b25eaaa6f64a584ffccdd90b23d0962d9138352) | `` lib/to-lua: fix removing empties nested in lists ``                                                     |
| [`87f50db8`](https://github.com/nix-community/nixvim/commit/87f50db84ded18151b57ee4c924e5ac1553a7b99) | `` modules/nixpkgs: don't set args.lib ``                                                                  |
| [`11df0d6c`](https://github.com/nix-community/nixvim/commit/11df0d6c9e3fef9b1e8c9a2ac3ba878dcb0a6975) | `` modules: use assertions module from nixpkgs ``                                                          |
| [`d2afb176`](https://github.com/nix-community/nixvim/commit/d2afb176ff85bd5797b1e84026d5405f598ecea1) | `` modules: refactor module bootstrapping ``                                                               |
| [`3d969603`](https://github.com/nix-community/nixvim/commit/3d969603481c745f8faa411f1e8b7c97517c67a3) | `` wrappers: simplify modules ``                                                                           |
| [`6252a41f`](https://github.com/nix-community/nixvim/commit/6252a41fc61ef5ab3603d171adf9937354d8f2f3) | `` plugins/preview: init ``                                                                                |
| [`18bea9ba`](https://github.com/nix-community/nixvim/commit/18bea9bad6f8e81631885226c380ff4b207a7be7) | `` plugins/markdown-preview: move source in dedicated markdown sub-folder ``                               |
| [`1760f791`](https://github.com/nix-community/nixvim/commit/1760f7912ef8d5ae5a01c6ad3cb1b8294b4f34c8) | `` flake.lock: Update ``                                                                                   |
| [`079c2c47`](https://github.com/nix-community/nixvim/commit/079c2c479b5707adf0b03f817be30945c92c15cf) | `` plugins/lsp/pylsp: Add python option to generate obtain the pylsp from. ``                              |
| [`100ae402`](https://github.com/nix-community/nixvim/commit/100ae4027df581539ca41a1babd558db124a0ecb) | `` plugins/nvim-osc52: mark as obsolete ``                                                                 |
| [`55fee705`](https://github.com/nix-community/nixvim/commit/55fee7051f2fe45afa5b3a97eb94907bb9005c64) | `` standalone: rename `nixvimExtend` to `extend` ``                                                        |
| [`3bfe71f1`](https://github.com/nix-community/nixvim/commit/3bfe71f1ae8740c71b4e54d97a66ef12f5a7f1cf) | `` plugins/yanky: export 'utils' and 'mapping' for more readible settings ``                               |
| [`b3c520d1`](https://github.com/nix-community/nixvim/commit/b3c520d13e894f66e9f2d26a6d7734448cf6f5df) | `` plugins/yanky: switch to mkNeovimPlugin ``                                                              |
| [`f6e32ac3`](https://github.com/nix-community/nixvim/commit/f6e32ac3cfbf7665d69c09829855e044174a0315) | `` plugins/neoclip: init ``                                                                                |
| [`e054fe2b`](https://github.com/nix-community/nixvim/commit/e054fe2bc0d5f001c879d33d8e5464bfc7099417) | `` contributing: add note clarifying freeform `settings` ``                                                |
| [`71b8d0b3`](https://github.com/nix-community/nixvim/commit/71b8d0b3279f9886bfdce646f36f98452e357967) | `` readme: use markdown warning ``                                                                         |
| [`aaab869d`](https://github.com/nix-community/nixvim/commit/aaab869d4fed8272bdcf3668048521872cd32a80) | `` plugins/flash: switch to mkNeovimPlugin ``                                                              |
| [`7cc1685e`](https://github.com/nix-community/nixvim/commit/7cc1685eafdcf04cf1058949647ea2c7560f2d65) | `` plugins/neotest: add assertion to ensure that neotest is enabled if an adapter is ``                    |
| [`55a45b67`](https://github.com/nix-community/nixvim/commit/55a45b6713e77f2ade6271c837645a62444453ad) | `` flake.lock: Update ``                                                                                   |
| [`1391a64c`](https://github.com/nix-community/nixvim/commit/1391a64cf6f216315a6ce904db7144949585839a) | `` plugins/otter: switch to nvim-cmp association ``                                                        |
| [`17f4aa55`](https://github.com/nix-community/nixvim/commit/17f4aa555615df37ec68ed75a04b8a8b1d36fd98) | `` plugins/cmp: refactor sources list & mkCmpSourcePlugin ``                                               |
| [`3a8d4fee`](https://github.com/nix-community/nixvim/commit/3a8d4fee35642ee326f5fea8ddb7aacd1176f23e) | `` plugins/cmp: refactor source->plugin association ``                                                     |
| [`bd422db9`](https://github.com/nix-community/nixvim/commit/bd422db9baa1867584b2d8c7b2b031e99e250a6c) | `` plugins/cmp: fix secondary settings descriptions ``                                                     |
| [`78275321`](https://github.com/nix-community/nixvim/commit/78275321f813c30a6add74ccffb3797caed7d07c) | `` tests/test-derivation: don't invoke test modules ``                                                     |
| [`714aa7bb`](https://github.com/nix-community/nixvim/commit/714aa7bb18269b4ff8c3430e6b30689d340f3fcd) | `` flake/devshell: add `test-lib` command + improve `checks` ``                                            |
| [`662a0e1b`](https://github.com/nix-community/nixvim/commit/662a0e1bdbd529823f0c19cc1c8b4c346406d16d) | `` wrappers: use system from stdenv.hostPlatform ``                                                        |
| [`c062b976`](https://github.com/nix-community/nixvim/commit/c062b976eff9f13597c7c23d77a6b3ac677b7fd5) | `` flake/legacyPackages: simplify `makeNixvim`, making it more powerful ``                                 |
| [`10f64e6c`](https://github.com/nix-community/nixvim/commit/10f64e6c9680dc84a5855ba2959e7ec42ef11d8b) | `` tests/test-derivation: allow tests to be modules ``                                                     |
| [`049bbc16`](https://github.com/nix-community/nixvim/commit/049bbc168fe449cca37ddf3b0b56c4f93408052b) | `` github/mergify: rename yaml -> yml (#1775) ``                                                           |
| [`d564b529`](https://github.com/nix-community/nixvim/commit/d564b5299957329351a8cda6d18c77067db50474) | `` tests/plugins/none-ls: re-enable rubyfmt test for linux ``                                              |
| [`f938dfd9`](https://github.com/nix-community/nixvim/commit/f938dfd9bf53dcf1553b857f6e59c9a3dcd7743a) | `` flake.lock: Update ``                                                                                   |
| [`b0d8c002`](https://github.com/nix-community/nixvim/commit/b0d8c002643119d6c1f7c1c501614ae56a45cc39) | `` lib/vim-plugin: fix + improve settings example ``                                                       |
| [`039f6c19`](https://github.com/nix-community/nixvim/commit/039f6c197364a20dd6a25e03c6725cfa74589de7) | `` lib/lua: workaround `builtins.match` alias issue ``                                                     |
| [`7dcdd6e9`](https://github.com/nix-community/nixvim/commit/7dcdd6e989b50d1545487b011f141d9db7681f60) | `` plugins/lsp-lines: switch to mkNeovimPlugin ``                                                          |
| [`7c35bdb3`](https://github.com/nix-community/nixvim/commit/7c35bdb3f7dc03c6b924485ce53597cad3d189b7) | `` lib/neovim-plugin: allow overriding settings description ``                                             |
| [`c351c175`](https://github.com/nix-community/nixvim/commit/c351c175eccd2c9bc21a2f05db76f75a05eee9d4) | `` lib/neovim-plugin: support not having settings ``                                                       |
| [`aff12581`](https://github.com/nix-community/nixvim/commit/aff12581d8cbeb27c58b5871ebe6c1405cabd4d9) | `` lib/lua: refactor toLuaObject, now configurable ``                                                      |
| [`cd479ec0`](https://github.com/nix-community/nixvim/commit/cd479ec0ef4f41eeb45f9ec04afcd9e9ef0007a1) | `` plugins/otter: init ``                                                                                  |
| [`d823c146`](https://github.com/nix-community/nixvim/commit/d823c1463ed7b26c4f4700244894958fff237960) | `` github/mergify: init ``                                                                                 |
| [`1b3bda78`](https://github.com/nix-community/nixvim/commit/1b3bda78b40cb85341b69d86e39f09634fef18a1) | `` plugins/zk: switch to mkNeovimPlugin ``                                                                 |
| [`38e3849f`](https://github.com/nix-community/nixvim/commit/38e3849f4a68b2da2106a7db947ecea9f804f691) | `` plugins/surround: stop using alias ``                                                                   |
| [`15535343`](https://github.com/nix-community/nixvim/commit/155353436cfc1c83ed933f6b5b8ac4b020694f3a) | `` Update config-examples.md ``                                                                            |
| [`ab9bca4a`](https://github.com/nix-community/nixvim/commit/ab9bca4a1e0d2e4eca1839ece7478e1bd40f3c14) | `` colorschems/everforest: init ``                                                                         |
| [`479430c2`](https://github.com/nix-community/nixvim/commit/479430c2d87a61067b855b96b9fa6cbb2c0f56bc) | `` maintainers: add sheemap ``                                                                             |
| [`0957f5fd`](https://github.com/nix-community/nixvim/commit/0957f5fd8946c91b230fa10a4c48978432e92997) | `` flake/dev: fix nix-output-monitor ``                                                                    |
| [`35e837c1`](https://github.com/nix-community/nixvim/commit/35e837c10b767c3dbf580f3cade5084f376f7c70) | `` Update config-examples.md ``                                                                            |
| [`ca8ac5f8`](https://github.com/nix-community/nixvim/commit/ca8ac5f8e414253f36e1a4563d2e67f774ae5618) | `` plugins/none-ls: switch to mkNeovimPlugin ``                                                            |
| [`cb9ee70e`](https://github.com/nix-community/nixvim/commit/cb9ee70e8b6642b6c1131aa87547395c6cec3fe4) | `` flake.lock: Update ``                                                                                   |
| [`a5bc4e64`](https://github.com/nix-community/nixvim/commit/a5bc4e645b2b326de8b485a13864bf65b9ca49f0) | `` docs/config-examples: add comment for keeping entries sorted ``                                         |
| [`53a9599c`](https://github.com/nix-community/nixvim/commit/53a9599cc4da4f7557995b8611e5dba831261eef) | `` lib/lua: pad table `,` with a space ``                                                                  |
| [`00ce71f5`](https://github.com/nix-community/nixvim/commit/00ce71f51ac9a9fb716eae4797edc5de31c8086f) | `` lib/lua: only quote table keys when needed ``                                                           |
| [`01cf43db`](https://github.com/nix-community/nixvim/commit/01cf43dbaa409b5a6cbb1ce2f274c431df1ef23e) | `` lib/lua: add `isKeyword` and `isIdentifier` ``                                                          |
| [`b64ee08d`](https://github.com/nix-community/nixvim/commit/b64ee08d6b08b36b33fd1644b374ec2a5fd1a193) | `` plugins/codesnap: init ``                                                                               |
| [`1a46075d`](https://github.com/nix-community/nixvim/commit/1a46075dfe8dbbd2c99980b59af7860a1de010db) | `` flake.lock: Update ``                                                                                   |
| [`76a87907`](https://github.com/nix-community/nixvim/commit/76a8790764ec983ca0659c952c4b6924c4e9bf1a) | `` docs/mdbook: only include sub-options of visible options ``                                             |
| [`9e6d6901`](https://github.com/nix-community/nixvim/commit/9e6d6901045daa62f6a57662d11e2d0479766f33) | `` docs/mdbook: simplify `isVisible` ``                                                                    |
| [`7ac283f0`](https://github.com/nix-community/nixvim/commit/7ac283f05074485c08aefe578a139e34d508edb9) | `` plugins/gitsigns: remove deprecated options ``                                                          |
| [`54d11886`](https://github.com/nix-community/nixvim/commit/54d118869be9e324b938579d55e83515ee08859e) | `` lib/deprecation: init with mkDeprecatedSubOptionModule ``                                               |
| [`66c8592b`](https://github.com/nix-community/nixvim/commit/66c8592b31845cb0a1335ecc31ea40e89bed1a38) | `` fix url ``                                                                                              |
| [`00f77cbf`](https://github.com/nix-community/nixvim/commit/00f77cbfd0a0478c585ef0c58383f2603d3e0c32) | `` conform to alphabetical order ``                                                                        |
| [`d0bf018d`](https://github.com/nix-community/nixvim/commit/d0bf018de69b0bc19c74eee9ad82a9c1627f2618) | `` Update config-examples.md with my Nixvim Config ``                                                      |
| [`18ecd740`](https://github.com/nix-community/nixvim/commit/18ecd740e9246440a12b9ae19184681412a70052) | `` plugins.gitsigns: remove deprecated options ``                                                          |
| [`bd650b95`](https://github.com/nix-community/nixvim/commit/bd650b953e7432bb428015418ea110a699e516bf) | `` plugins/none-ls: add typstyle server ``                                                                 |
| [`47127abf`](https://github.com/nix-community/nixvim/commit/47127abf006a3556361e606825c86137726e1a53) | `` flake.lock: Update ``                                                                                   |
| [`49452662`](https://github.com/nix-community/nixvim/commit/49452662b7b4dd2467cbac19e0f9820d570d8976) | `` plugins/auto-save: switch to mkNeovimPlugin ``                                                          |
| [`54207d1e`](https://github.com/nix-community/nixvim/commit/54207d1efff3101b8dd1aad0769116e62f2adddd) | `` maintainers: add braindefender ``                                                                       |
| [`4e224d27`](https://github.com/nix-community/nixvim/commit/4e224d27ae0db889f92ef228ad6cb984b91777fb) | `` modules/diagnostics: add test ``                                                                        |
| [`e84881f4`](https://github.com/nix-community/nixvim/commit/e84881f46f2e5f454d3c23b28a5bc4118544edc2) | `` modules/diagnostics: rename source file ``                                                              |
| [`4766d05f`](https://github.com/nix-community/nixvim/commit/4766d05fb13a4837c20aabcc8b62de6ddeff8949) | `` plugins/octo: do not run tests as they are flaky ``                                                     |
| [`39d1c950`](https://github.com/nix-community/nixvim/commit/39d1c950616bf31ca5110ab14008f29b5ab807e7) | `` modules/diagnostic: init ``                                                                             |
| [`66b23fff`](https://github.com/nix-community/nixvim/commit/66b23fff8010d8f3b4c801564a617ffb4aca629a) | `` plugins/telescope: normalize plugin defaults ``                                                         |
| [`6ab2a39e`](https://github.com/nix-community/nixvim/commit/6ab2a39e6ad2a6cd38c61f30292854c7dc53285d) | `` plugins/utils: normalize plugin defaults ``                                                             |
| [`b10a391b`](https://github.com/nix-community/nixvim/commit/b10a391bd07a32b12629c7ea7e70004743abaf70) | `` plugins/ui: normalize plugin defaults ``                                                                |
| [`d7b0cf80`](https://github.com/nix-community/nixvim/commit/d7b0cf8014a8a1cb06a02688a58f2ed8db7f81a7) | `` plugins/statuslines: normalize plugin defaults ``                                                       |
| [`0caa5b95`](https://github.com/nix-community/nixvim/commit/0caa5b957e63b6b9c4c629b18e4204341e325402) | `` plugins/none-ls: normalize plugin defaults ``                                                           |
| [`f5965058`](https://github.com/nix-community/nixvim/commit/f596505897b9e808efc565d8a0ec720ddf6f9e5d) | `` plugins/neotest: normalize plugin defaults ``                                                           |
| [`0f07201a`](https://github.com/nix-community/nixvim/commit/0f07201a0cba8c2caaab87e8384ff52642a70025) | `` plugins/lsp: normalize plugin defaults ``                                                               |
| [`6f408f2b`](https://github.com/nix-community/nixvim/commit/6f408f2bd02b5969b963f76a0ee32719db6ef9f8) | `` plugins/languages: normalize plugin defaults ``                                                         |
| [`a208c718`](https://github.com/nix-community/nixvim/commit/a208c7181ccfd315fc4a18a0cc57ec106b694bce) | `` plugins/git: normalize plugin defaults ``                                                               |
| [`25eed3c2`](https://github.com/nix-community/nixvim/commit/25eed3c2f58e8be2660e0f1aeadfc96ba03683a6) | `` plugins/filetrees: normalize plugin defaults ``                                                         |
| [`b86db98f`](https://github.com/nix-community/nixvim/commit/b86db98f53c73afa7081cfa07103f21a724796ce) | `` plugins/dap-ui: normalize plugin defaults ``                                                            |
| [`d61ecb3f`](https://github.com/nix-community/nixvim/commit/d61ecb3f7365836b4eee84a3e34feee2f68a1215) | `` plugins/completion: normalize plugin defaults ``                                                        |
| [`48f1e30b`](https://github.com/nix-community/nixvim/commit/48f1e30bf7845c49d614c32f1808e1f234891644) | `` plugins/colorschemes: normalize plugin defaults ``                                                      |
| [`d57cbd86`](https://github.com/nix-community/nixvim/commit/d57cbd867ab08a3a31f4cef2812fb342bca8d5d2) | `` plugins/bufferlines: normalize plugin defaults ``                                                       |
| [`9000e69f`](https://github.com/nix-community/nixvim/commit/9000e69f4bd177a84cf4169e7bc99bdbfa9abed6) | `` lib/options: drop special case for string defaults ``                                                   |
| [`735fbeec`](https://github.com/nix-community/nixvim/commit/735fbeece8cbbd65e34572cd86e3516fb717a1e6) | `` Revert "helpers/vim-plugin: fix mkVimPlugin when defaultPackage.meta.homepage doesn't exist" ``         |
| [`86344b26`](https://github.com/nix-community/nixvim/commit/86344b265389a652e1f982d5408d587d459551a7) | `` flake.lock: Update ``                                                                                   |
| [`744dfea4`](https://github.com/nix-community/nixvim/commit/744dfea48bdd331e66b9e874822559fa6fae98af) | `` flake/dev: add list-plugins script/command ``                                                           |
| [`affee538`](https://github.com/nix-community/nixvim/commit/affee53852445727193138aa5d73bbc3839bcd43) | `` modules: use real nix expressions for option examples ``                                                |
| [`16db91b3`](https://github.com/nix-community/nixvim/commit/16db91b37abbfded3c61822cd6d7a854954c6b2a) | `` Fix typo in highlights.nix ``                                                                           |
| [`0e93a595`](https://github.com/nix-community/nixvim/commit/0e93a59567d0850e54cea26b1b5c541a7182c7cf) | `` Revert "plugins/neotest/adapters/playwright: temporarily enable telescope when this adapter is used" `` |
| [`c2c81a27`](https://github.com/nix-community/nixvim/commit/c2c81a273482e0e913636957515df6922ab1fd08) | `` tests/plugins/sniprun: disable old irrelevant test for sniprun ``                                       |
| [`9ed35386`](https://github.com/nix-community/nixvim/commit/9ed3538685b2c8a39d435eacaa5d26f2892939f5) | `` plugins/cmp-tabby: switch to RFC-42 style ``                                                            |
| [`bf109a3e`](https://github.com/nix-community/nixvim/commit/bf109a3e59845fd7806dfdd386edfa3ac1baa998) | `` plugins/none-ls: disable rubyfmt test as it is broken ``                                                |
| [`f5de31de`](https://github.com/nix-community/nixvim/commit/f5de31debc7e44765abfb358a1c22ba27799d0a4) | `` pugins/lsp/rust-analyzer: temporarily remove rust-analyzer settings options declarations ``             |
| [`846b3c99`](https://github.com/nix-community/nixvim/commit/846b3c991ef5c065b09622346ce6d7c2af2b3f01) | `` helpers/vim-plugin: fix mkVimPlugin when defaultPackage.meta.homepage doesn't exist ``                  |
| [`8609ea3c`](https://github.com/nix-community/nixvim/commit/8609ea3ce40db4887039b0e44611ec1a56d912e3) | `` plugins/lsp/bashls: set correct package ``                                                              |
| [`6d713199`](https://github.com/nix-community/nixvim/commit/6d7131995a63026c08abd969c1ad3bf8c71e072e) | `` flake.lock: Update ``                                                                                   |