### PR TITLE
chore(flake/pre-commit-hooks): `cc4d466c` -> `97c0dc86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -318,11 +318,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1717664902,
-        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
+        "lastModified": 1718825512,
+        "narHash": "sha256-nz7idS/SZWcTUGJ+lOFL+eJayrL/LpkUiy7+FxThAh4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
+        "rev": "97c0dc865fe9a062c5970f4bcf55bb9e6028bcf5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`7d16e393`](https://github.com/cachix/git-hooks.nix/commit/7d16e39360278891ba80ce1660f2963972298250) | `` feat: fix reuse not found in flake check ``   |
| [`9a04830f`](https://github.com/cachix/git-hooks.nix/commit/9a04830f93ea80c9fc0bf4cf883a4fcf30d0944c) | `` fix: pyright has moved out of nodePackages `` |
| [`21e0e90f`](https://github.com/cachix/git-hooks.nix/commit/21e0e90ff4d64f6aa47a8439d0b39e746fe2e7c3) | `` feat: add reuse ``                            |