### PR TITLE
chore(flake/nix-fast-build): `02c50df6` -> `030e5861`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -248,11 +248,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1719305207,
-        "narHash": "sha256-gxJ1xgkXe/iHpyYBtx96D7AKccQYqutC6R7cKv2uBNY=",
+        "lastModified": 1719475157,
+        "narHash": "sha256-8zW6eWvE9T03cMpo/hY8RRZIsSCfs1zmsJOkEZzuYwM=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "02c50df6881266f5425f06f475d504e90e491767",
+        "rev": "030e586195c97424844965d2ce680140f6565c02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message             |
| ----------------------------------------------------------------------------------------------------- | ------------------- |
| [`254f66f3`](https://github.com/Mic92/nix-fast-build/commit/254f66f30ee7951e3cdad2cba5220161149da083) | `` release 1.0.0 `` |