### PR TITLE
chore(flake/nixvim): `079c2c47` -> `9b25eaaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719745305,
-        "narHash": "sha256-xwgjVUpqSviudEkpQnioeez1Uo2wzrsMaJKJClh+Bls=",
+        "lastModified": 1719877454,
+        "narHash": "sha256-g5N1yyOSsPNiOlFfkuI/wcUjmtah+nxdImJqrSATjOU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c3c5ecc05edc7dafba779c6c1a61cd08ac6583e9",
+        "rev": "4e3583423212f9303aa1a6337f8dffb415920e4f",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719677234,
-        "narHash": "sha256-qO9WZsj/0E6zcK4Ht1y/iJ8XfwbBzq7xdqhBh44OP/M=",
+        "lastModified": 1719827439,
+        "narHash": "sha256-tneHOIv1lEavZ0vQ+rgz67LPNCgOZVByYki3OkSshFU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "36317d4d38887f7629876b0e43c8d9593c5cc48d",
+        "rev": "59ce796b2563e19821361abbe2067c3bb4143a7d",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719128254,
-        "narHash": "sha256-I7jMpq0CAOZA/i70+HDQO/ulLttyQu/K70cSESiMX7A=",
+        "lastModified": 1719845423,
+        "narHash": "sha256-ZLHDmWAsHQQKnmfyhYSHJDlt8Wfjv6SQhl2qek42O7A=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "50581970f37f06a4719001735828519925ef8310",
+        "rev": "ec12b88104d6c117871fad55e931addac4626756",
         "type": "github"
       },
       "original": {
@@ -319,11 +319,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1719860300,
-        "narHash": "sha256-ZeF+zI+/53HeS567/mXS2Gw+w8k9FsjRC/TzoVQOpi4=",
+        "lastModified": 1720021470,
+        "narHash": "sha256-wJ8NGzPRkwDao4Om9/P+RLxussLGvtGGH2XdjDgJqRE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "079c2c479b5707adf0b03f817be30945c92c15cf",
+        "rev": "9b25eaaa6f64a584ffccdd90b23d0962d9138352",
         "type": "github"
       },
       "original": {
@@ -408,11 +408,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719749022,
-        "narHash": "sha256-ddPKHcqaKCIFSFc/cvxS14goUhCOAwsM1PbMr0ZtHMg=",
+        "lastModified": 1719887753,
+        "narHash": "sha256-p0B2r98UtZzRDM5miGRafL4h7TwGRC4DII+XXHDHqek=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8df5ff62195d4e67e2264df0b7f5e8c9995fd0bd",
+        "rev": "bdb6355009562d8f9313d9460c0d3860f525bc6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`9b25eaaa`](https://github.com/nix-community/nixvim/commit/9b25eaaa6f64a584ffccdd90b23d0962d9138352) | `` lib/to-lua: fix removing empties nested in lists ``                       |
| [`87f50db8`](https://github.com/nix-community/nixvim/commit/87f50db84ded18151b57ee4c924e5ac1553a7b99) | `` modules/nixpkgs: don't set args.lib ``                                    |
| [`11df0d6c`](https://github.com/nix-community/nixvim/commit/11df0d6c9e3fef9b1e8c9a2ac3ba878dcb0a6975) | `` modules: use assertions module from nixpkgs ``                            |
| [`d2afb176`](https://github.com/nix-community/nixvim/commit/d2afb176ff85bd5797b1e84026d5405f598ecea1) | `` modules: refactor module bootstrapping ``                                 |
| [`3d969603`](https://github.com/nix-community/nixvim/commit/3d969603481c745f8faa411f1e8b7c97517c67a3) | `` wrappers: simplify modules ``                                             |
| [`6252a41f`](https://github.com/nix-community/nixvim/commit/6252a41fc61ef5ab3603d171adf9937354d8f2f3) | `` plugins/preview: init ``                                                  |
| [`18bea9ba`](https://github.com/nix-community/nixvim/commit/18bea9bad6f8e81631885226c380ff4b207a7be7) | `` plugins/markdown-preview: move source in dedicated markdown sub-folder `` |
| [`1760f791`](https://github.com/nix-community/nixvim/commit/1760f7912ef8d5ae5a01c6ad3cb1b8294b4f34c8) | `` flake.lock: Update ``                                                     |