### PR TITLE
chore(flake/nixvim): `9b25eaaa` -> `92e9f546`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -319,11 +319,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1720021470,
-        "narHash": "sha256-wJ8NGzPRkwDao4Om9/P+RLxussLGvtGGH2XdjDgJqRE=",
+        "lastModified": 1720126856,
+        "narHash": "sha256-xtRwIUKv7EpuyGtvq+rO7PoZZIpD55AYe6rl+plEhY8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9b25eaaa6f64a584ffccdd90b23d0962d9138352",
+        "rev": "92e9f5466dcfd51e8e2e7627e992c1c9d5fc6fd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------- |
| [`92e9f546`](https://github.com/nix-community/nixvim/commit/92e9f5466dcfd51e8e2e7627e992c1c9d5fc6fd6) | `` plugins/chatgpt: init `` |