### PR TITLE
chore(flake/nixvim): `b59fa976` -> `367380bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -319,11 +319,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1720191961,
-        "narHash": "sha256-p67UionzurpCRjSIhhgRgRAapZLfXHG9nvQQ37qerdA=",
+        "lastModified": 1720210105,
+        "narHash": "sha256-AjcTv44xEAOxGqpoMxbfYcUwhCWLHESQIOIMcBFUCKk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b59fa976d0f42eba35bf89c8fbc4107de7ef1db2",
+        "rev": "367380bd8462419f0199d262b058fadfb43823ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`367380bd`](https://github.com/nix-community/nixvim/commit/367380bd8462419f0199d262b058fadfb43823ff) | `` modules/output: Remove the initContent option ``                                  |
| [`8fbcfcb4`](https://github.com/nix-community/nixvim/commit/8fbcfcb469d6b55b7c93e9a939bf970fec9278e8) | `` dev: Move assert in derivation for generated file in the derivation definition `` |
| [`930f5fdd`](https://github.com/nix-community/nixvim/commit/930f5fdd219a290f52f2db9e7bdd48007b013094) | `` plugins/none-ls: Adapt to autogenerated builtin list ``                           |
| [`776835b0`](https://github.com/nix-community/nixvim/commit/776835b0664e4b2952e30bab3e2f4f554461c3a8) | `` generated: Generate the none-ls builitins ``                                      |
| [`0b93815d`](https://github.com/nix-community/nixvim/commit/0b93815db546e380be857d771356793ca7711446) | `` dev: Add a script to generate the none-ls builtins ``                             |
| [`517648da`](https://github.com/nix-community/nixvim/commit/517648dac0fd0c10007b4fc20700261f9ffe3bf9) | `` wrappers/standalone: move module to wrappers/modules ``                           |
| [`38d43a74`](https://github.com/nix-community/nixvim/commit/38d43a740f0bee6afb9b781f7301f40fceec0187) | `` modules/files: don't include modules in the docs ``                               |
| [`f5ba05ec`](https://github.com/nix-community/nixvim/commit/f5ba05ec8206cdb9f75a48fbf2d61610de318963) | `` modules/files: move submodule to its own file ``                                  |
| [`2deb61f6`](https://github.com/nix-community/nixvim/commit/2deb61f6a55b87e4bd2f43215ce6c578aacf29c8) | `` modules/top-level: move out of wrappers/modules ``                                |