### PR TITLE
chore(flake/nixvim): `367380bd` -> `843fb302`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -319,11 +319,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1720210105,
-        "narHash": "sha256-AjcTv44xEAOxGqpoMxbfYcUwhCWLHESQIOIMcBFUCKk=",
+        "lastModified": 1720267267,
+        "narHash": "sha256-oXroBCRyTtHmiDqSFrTmLC//8fef5ECd6uEsh3bkerc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "367380bd8462419f0199d262b058fadfb43823ff",
+        "rev": "843fb302ebaa2559b7c50ad69ba9a00ae1a5836d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`843fb302`](https://github.com/nix-community/nixvim/commit/843fb302ebaa2559b7c50ad69ba9a00ae1a5836d) | `` lib/neovim-plugin: allow disabling `installPackage` `` |
| [`04a255ed`](https://github.com/nix-community/nixvim/commit/04a255ed7e24b0d54a158de5252e8471ac4c6d8f) | `` modules/context: init with `isDocs` ``                 |
| [`edc8602d`](https://github.com/nix-community/nixvim/commit/edc8602d4723e172405ae00e778c7b407885d6c8) | `` docs: use pkgsDoc to build helpers ``                  |