### PR TITLE
chore(flake/nixvim): `6674dea8` -> `41794c22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,22 +52,6 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -127,7 +111,10 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": [
+          "nixvim",
+          "flake-compat"
+        ],
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixvim",
@@ -319,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1720298683,
-        "narHash": "sha256-CNtfHBwlKuTTanwmUI85Z/HkHShnqZs+WYyxQR8zRFY=",
+        "lastModified": 1720382751,
+        "narHash": "sha256-i+wpxx7NMEIoxAl0IQ3bNDX4faTcO13ZJ6j75SJUIzA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6674dea8403747827431d4d8497c34023f93d047",
+        "rev": "41794c222a5eaa966e5513c707c0b3f5e7abf5e0",
         "type": "github"
       },
       "original": {
@@ -334,7 +321,7 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_2",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "nixpkgs"


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`41794c22`](https://github.com/nix-community/nixvim/commit/41794c222a5eaa966e5513c707c0b3f5e7abf5e0) | `` flake: document optional inputs ``                |
| [`5feeb4ee`](https://github.com/nix-community/nixvim/commit/5feeb4eef875067e46d6b730139a9ef6db3633a4) | `` flake/dev: make `treefmt-nix` optional ``         |
| [`432a513c`](https://github.com/nix-community/nixvim/commit/432a513ccd26286c34596a5b15f5ab1f4c0fc04b) | `` flake/dev: make `git-hooks` optional ``           |
| [`2f21379b`](https://github.com/nix-community/nixvim/commit/2f21379b8c8ba62e71c7e0a448b7c21b3bc1fa05) | `` flake/devshell: make `devshell` optional ``       |
| [`22a66782`](https://github.com/nix-community/nixvim/commit/22a6678279e92aef833abb1f2e2b48733ba334d3) | `` flake: deduplicate flake-compat ``                |
| [`a6cc4c6c`](https://github.com/nix-community/nixvim/commit/a6cc4c6c331c86e6b1ff7316fdc076f4ca7b163b) | `` modules/files: format `files` submodule output `` |
| [`f11f991e`](https://github.com/nix-community/nixvim/commit/f11f991e09aac29530b3f7f4384115abf01f405b) | `` flake/checks: test extraFiles are in the build `` |
| [`086873be`](https://github.com/nix-community/nixvim/commit/086873bed9ff25b6aa3ea05b707645f2d9d1d174) | `` modules: refactor `extraFiles` ``                 |
| [`c12694f4`](https://github.com/nix-community/nixvim/commit/c12694f4ba43a5f4e013261667a9e0b6772427ef) | `` lib/deprecation: add `transitionType` ``          |