### PR TITLE
chore(flake/pre-commit-hooks): `0ff4381b` -> `2b6bd3c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -329,11 +329,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1719259945,
-        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
+        "lastModified": 1720450253,
+        "narHash": "sha256-1in42htN3g3MnE3/AO5Qgs6pMWUzmtPQ7s675brO8uw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
+        "rev": "2b6bd3c87d3a66fb0b8f2f06c985995e04b4fb96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`8ee4af3f`](https://github.com/cachix/git-hooks.nix/commit/8ee4af3fd1a442d01cc0b9ccf4240347f595519c) | `` docs: clarify terraform-format `` |