### PR TITLE
chore(flake/nixvim): `451beb4e` -> `a5e9dbde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1720425287,
-        "narHash": "sha256-iKcXfOtB2XLDSRZdwi2+cxoO/wOEidHIJOQRSRd7rV0=",
+        "lastModified": 1720530938,
+        "narHash": "sha256-kUmpiyPfVFKPPLKfq3p50ddi6MdwcW7g4IqM8b7bRxg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "451beb4ecaf56fea38ffe82588364aae4161a2d8",
+        "rev": "a5e9dbdef1530a76056db12387d489a68eea6f80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`a5e9dbde`](https://github.com/nix-community/nixvim/commit/a5e9dbdef1530a76056db12387d489a68eea6f80) | `` plugins/bufdelete: init ``                                          |
| [`023dc1c9`](https://github.com/nix-community/nixvim/commit/023dc1c93a17181502269609924950acaa9091d3) | `` plugins/treesitter: Add a treesitter injection query for raw lua `` |
| [`29118021`](https://github.com/nix-community/nixvim/commit/29118021b3ed5d373241f7dd9fef6ba3676c541e) | `` plugins/treesitter: Adapt nixvim queries to 0.10 ``                 |
| [`0f76a8cd`](https://github.com/nix-community/nixvim/commit/0f76a8cdfccd99d3a97d8fed493413c6fd671de5) | `` plugins/glow: init ``                                               |
| [`1a644b8c`](https://github.com/nix-community/nixvim/commit/1a644b8c2b89b4a804c40a02ed1f954d5008ad1c) | `` plugins/treesitter: fix settingsExample ``                          |
| [`0e8b248a`](https://github.com/nix-community/nixvim/commit/0e8b248a5202c73127b0ff41906042134058f3e8) | `` lib/options: allow `rawLua` in `mkEnum'` default ``                 |
| [`aad2e32b`](https://github.com/nix-community/nixvim/commit/aad2e32b5af60b32b945d7026dd42bd7201affeb) | `` treewide: reformat ``                                               |
| [`3c786ae9`](https://github.com/nix-community/nixvim/commit/3c786ae98889e5f044d0af49f8d290e22f4a1d29) | `` flake: ignore unformatted files ``                                  |
| [`f1a0cf3a`](https://github.com/nix-community/nixvim/commit/f1a0cf3a90c87f616f4d2f2cf5a7f3e91e1efc1b) | `` flake: format toml using "taplo" ``                                 |
| [`2339ddc3`](https://github.com/nix-community/nixvim/commit/2339ddc3a011dbbceefb285abcfb1321347be061) | `` flake: format lua with "stylua" ``                                  |
| [`b310affe`](https://github.com/nix-community/nixvim/commit/b310affef33073681c9c6cfd89d0417ea0fe5b0a) | `` flake: format + lint python with "ruff" ``                          |
| [`7c02148e`](https://github.com/nix-community/nixvim/commit/7c02148e683d96d4ff5a2d77aef0285201710d2e) | `` flake: format JS & YML with "prettier" ``                           |
| [`2583f542`](https://github.com/nix-community/nixvim/commit/2583f54225d5255c6cf3af136ffcb6993dcc5b35) | `` flake/pre-commit: use treefmt in git hook ``                        |
| [`8c44124a`](https://github.com/nix-community/nixvim/commit/8c44124a1fed75e88334a4f3f88035f4d30616a7) | `` docs/user-guide: fix blurb on accessing `helpers` ``                |
| [`8b9ba441`](https://github.com/nix-community/nixvim/commit/8b9ba44195ec15ceb932cb6ceaa7319329577d56) | `` flake: remove `getHelpers` function ``                              |
| [`1b7efacd`](https://github.com/nix-community/nixvim/commit/1b7efacdf4297928549b610bb97da63c376ef4c5) | `` wrappers: bootstrap "helpers" directly ``                           |
| [`cfa44bbb`](https://github.com/nix-community/nixvim/commit/cfa44bbb663f8f40eeaa2ebb06a44eebc5d58873) | `` wrappers: make `_shared.nix` return a module ``                     |
| [`97fa4737`](https://github.com/nix-community/nixvim/commit/97fa47376b73d774b081c8e5dd54fcfd0ad278cb) | `` treewide: treesitter moduleConfig -> settings ``                    |
| [`435ef287`](https://github.com/nix-community/nixvim/commit/435ef287ab8658f75599ab4508b0454c95a4274d) | `` plugins/treesitter: switch to mkNeovimPlugin ``                     |
| [`c0ea106b`](https://github.com/nix-community/nixvim/commit/c0ea106b4bdf8707837bb0d80efd6affbc128bdf) | `` colorschemes/base16: add `settings` + refactor ``                   |
| [`6055d0f2`](https://github.com/nix-community/nixvim/commit/6055d0f28cd84195c1f599d94ea11a521c57f93d) | `` lib/types: allow emptyTable as a valid rawLua value ``              |