### PR TITLE
chore(flake/nixpkgs): `9f4128e0` -> `655a58a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -250,11 +250,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720031269,
-        "narHash": "sha256-rwz8NJZV+387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ=",
+        "lastModified": 1720418205,
+        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
+        "rev": "655a58a72a6601292512670343087c2d75d859c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`655a58a7`](https://github.com/NixOS/nixpkgs/commit/655a58a72a6601292512670343087c2d75d859c1) | `` swayimg: 2.2 -> 2.3 ``                                                      |
| [`0e8b2930`](https://github.com/NixOS/nixpkgs/commit/0e8b29306b8831f9a65a57b2cdbacc09e5869b94) | `` kubernetes-helmPlugins.helm-git: 0.16.1 -> 0.17.0 ``                        |
| [`30ef8b6b`](https://github.com/NixOS/nixpkgs/commit/30ef8b6ba927cbe5f68160e5ff6a9a307669acea) | `` edk2: 202405 -> 202402 ``                                                   |
| [`bf451f01`](https://github.com/NixOS/nixpkgs/commit/bf451f016e89cd6445a08a58b5f9c111b0e6480f) | `` cudaPackages.cutensor: fix license field name ``                            |
| [`3cd5ecc1`](https://github.com/NixOS/nixpkgs/commit/3cd5ecc1a9a1b59e030de79ca6d74b2a5000a80b) | `` lib/licenses: fix field names ``                                            |
| [`cc742650`](https://github.com/NixOS/nixpkgs/commit/cc7426501dbba35d473c3375b945674c4ae794ff) | `` python312Packages.pycrdt: 0.8.24 -> 0.8.31 ``                               |
| [`e170ba17`](https://github.com/NixOS/nixpkgs/commit/e170ba17d1417bf721d549cb9e5e8adb26c6f876) | `` cached-nix-shell: 0.1.5 -> 0.1.6 ``                                         |
| [`4e651749`](https://github.com/NixOS/nixpkgs/commit/4e6517496cae5e7c66e2b2f0a656e78b5e46a77f) | `` rye: 0.35.0 -> 0.36.0 ``                                                    |
| [`13514d5f`](https://github.com/NixOS/nixpkgs/commit/13514d5faa127d4b8cf749875e91799861ab2b7e) | `` texpresso: fix build on darwin ``                                           |
| [`ed490bc0`](https://github.com/NixOS/nixpkgs/commit/ed490bc06b97102503a9a0cf3ae09529e4903b50) | `` texpresso: 0-unstable-2024-05-23 -> 0-unstable-2024-06-22 ``                |
| [`3efe0780`](https://github.com/NixOS/nixpkgs/commit/3efe0780209a260b6178c53686e8244ec165fc5d) | `` php83: 8.3.8 -> 8.3.9 ``                                                    |
| [`4f6b60b1`](https://github.com/NixOS/nixpkgs/commit/4f6b60b1a2ccd871fbd441f40a67d147c23f128c) | `` minio: 2024-06-28T09-06-49Z -> 2024-07-04T14-25-45Z ``                      |
| [`06ecf990`](https://github.com/NixOS/nixpkgs/commit/06ecf990bce92d63fa44deb2fb3a8362656b22e8) | `` v2ray-domain-list-community: 20240624143214 -> 20240707162925 ``            |
| [`4576f015`](https://github.com/NixOS/nixpkgs/commit/4576f015eb57ae53289ff38977e6581fd1283da6) | `` ibus-engines.typing-booster-unwrapped: set meta.platforms ``                |
| [`f582d00f`](https://github.com/NixOS/nixpkgs/commit/f582d00fde7d4cf494a57eb15a0672cab0ff2d6c) | `` pylyzer: 0.0.55 -> 0.0.56 ``                                                |
| [`3a0c9b1e`](https://github.com/NixOS/nixpkgs/commit/3a0c9b1e227da50bc56c8c3251e66edce45a0162) | `` androidStudioPackages.canary: 2024.1.2.7 -> 2024.1.2.8 ``                   |
| [`146fa6b1`](https://github.com/NixOS/nixpkgs/commit/146fa6b114dddb4ccc5b51fbca1014d357fac4b9) | `` nzbhydra2: changed test maintainers ``                                      |
| [`a3d0527c`](https://github.com/NixOS/nixpkgs/commit/a3d0527ccb7372908b2bb978b01b0f3b4f18981c) | `` nzbhydra2: remove jamiemagee from maintainers ``                            |
| [`eb930b09`](https://github.com/NixOS/nixpkgs/commit/eb930b09ab7b526869dde03713eb0f15ce15a521) | `` vscode-extensions.mgt19937.typst-preview: remove package ``                 |
| [`6f2d668d`](https://github.com/NixOS/nixpkgs/commit/6f2d668db6157ec8de08a4fad3d6af98eeaa8e57) | `` linux-firmware: remove FOD ``                                               |
| [`23184660`](https://github.com/NixOS/nixpkgs/commit/2318466065854769639fb2f47b996741dcfb77a7) | `` typst-preview: remove package ``                                            |
| [`72a4f148`](https://github.com/NixOS/nixpkgs/commit/72a4f148f9a35344f2c767a2051d9249a56f2721) | `` nixos/bee: prefer 'install' over 'chmod' ``                                 |
| [`f8a9a264`](https://github.com/NixOS/nixpkgs/commit/f8a9a2645c8aec2a68c01520bd643f03c7cad102) | `` nh: 3.5.17 -> 3.5.18 ``                                                     |
| [`c96f34fd`](https://github.com/NixOS/nixpkgs/commit/c96f34fdfd872108d6f24c1b3e590dc9267bff52) | `` ospd-openvas: relax dependencies ``                                         |
| [`5d9ae17b`](https://github.com/NixOS/nixpkgs/commit/5d9ae17b849d286a3bb2fd7cfd3052ee84c286fc) | `` python312Packages.asyncio-mqtt: drop ``                                     |
| [`304a034d`](https://github.com/NixOS/nixpkgs/commit/304a034d330c7913c78c97540c08a1f5c52e16ca) | `` python312Packages.aiomysensors: drop ``                                     |
| [`a7cc1dcd`](https://github.com/NixOS/nixpkgs/commit/a7cc1dcd68ab546d3e456cd565f802bf2429c39c) | `` treewide: fix broken 'nix.dev' URLs ``                                      |
| [`6b8de6bf`](https://github.com/NixOS/nixpkgs/commit/6b8de6bf3c6770e66033a7dfc0be1378833c510c) | `` treewide: clean up pythonRelaxDepsHook references ``                        |
| [`1fd9c06c`](https://github.com/NixOS/nixpkgs/commit/1fd9c06c6e7d90c41484d0bc941ef77efc4da495) | `` python312Packages.paho-mqtt_2: init at 2.1.0 ``                             |
| [`9b60aa34`](https://github.com/NixOS/nixpkgs/commit/9b60aa34d8b20f569edbfbcd1e4c3eb8d6a00278) | `` gpac: 2.2.1 -> 2.4.0, clear knownVulnerabilities list (#305402) ``          |
| [`f27d5f0d`](https://github.com/NixOS/nixpkgs/commit/f27d5f0de59d66ce1b3ca9b4351fb2b69a882117) | `` radicle-node: don't test on aarch64 ``                                      |
| [`ee348b46`](https://github.com/NixOS/nixpkgs/commit/ee348b461b984104c15b4acbd0ec10649f03d50f) | `` vscode-extensions.myriad-dreamin.tinymist: 0.11.13 -> 0.11.14 ``            |
| [`a41bb5d2`](https://github.com/NixOS/nixpkgs/commit/a41bb5d2fbf181e48b67a50033da160665031d44) | `` tinymist: 0.11.13 -> 0.11.14 ``                                             |
| [`a3ddc87f`](https://github.com/NixOS/nixpkgs/commit/a3ddc87f714fb26adb1a4a9a23fa7a9c83234fd0) | `` files-cli: 2.13.80 -> 2.13.85 ``                                            |
| [`a345e796`](https://github.com/NixOS/nixpkgs/commit/a345e796b3632df1fc76fd5c3866aa5d683665bf) | `` silice: refactor, add maintainer pbsds ``                                   |
| [`f573e8d7`](https://github.com/NixOS/nixpkgs/commit/f573e8d789e7e707e59f0565d61ed22dceec0447) | `` mimir: 2.12.0 -> 2.13.0 ``                                                  |
| [`5831972d`](https://github.com/NixOS/nixpkgs/commit/5831972dc65db0199a085949532b591eaac5edfc) | `` frigate: pin to python3.11, support mpl 3.9.0 ``                            |
| [`8f926ea5`](https://github.com/NixOS/nixpkgs/commit/8f926ea5ed079ed82a17b4f2ac9ff169a03f6202) | `` swiftbar: 1.4.3 -> 2.0.0 ``                                                 |
| [`413b10ed`](https://github.com/NixOS/nixpkgs/commit/413b10edb0eae021400e1a8e2e91e9c78d3893dd) | `` keycastr: init at 0.9.18 ``                                                 |
| [`7384b9ab`](https://github.com/NixOS/nixpkgs/commit/7384b9abdcaec35bffaa58e2b58d9e7da3595fdc) | `` treewide: set `meta.changelog` ``                                           |
| [`07dbdcf3`](https://github.com/NixOS/nixpkgs/commit/07dbdcf3fee79f1a33e2a950c617e467a044be7e) | `` dovecot_fts_xapian: 1.7.13 -> 1.7.14 ``                                     |
| [`2f782ddd`](https://github.com/NixOS/nixpkgs/commit/2f782ddd6a1f5fd8b44f7f2de6f0558b262e7c18) | `` cargo-make: 0.37.12 -> 0.37.13 ``                                           |
| [`d387025b`](https://github.com/NixOS/nixpkgs/commit/d387025ba3ec37548323da3e82203799867c0c62) | `` codeberg-cli: change owner ``                                               |
| [`91a54905`](https://github.com/NixOS/nixpkgs/commit/91a549051b18f96e2402d50d6294dc02b03cae89) | `` gamescope: 3.14.22 -> 3.14.23 ``                                            |
| [`2cf621a8`](https://github.com/NixOS/nixpkgs/commit/2cf621a871fba0d6444c29f4dd06086d4ce7fa45) | `` Revert "nv-codec-headers: recreate under by-name" ``                        |
| [`01543e78`](https://github.com/NixOS/nixpkgs/commit/01543e789c3a8d4f81f8c464d4cf23fa5c781987) | `` nixos/utils: support JSON secret files in genJqSecretsReplacementSnippet `` |
| [`257f6a62`](https://github.com/NixOS/nixpkgs/commit/257f6a62174811f4d5f6fbf9e92efe5101aded80) | `` minify: 2.20.34 -> 2.20.35 ``                                               |
| [`0a1bb731`](https://github.com/NixOS/nixpkgs/commit/0a1bb7311975cc82ad458118e90cc0b2b6996934) | `` mov-cli: 1.5.4 -> 4.4.5 ``                                                  |
| [`5e1481cc`](https://github.com/NixOS/nixpkgs/commit/5e1481ccc794f9cd72e615fd54ae2ebb00449ae8) | `` nixos/systemd-boot: fix invalid escape sequences ``                         |
| [`1e18109d`](https://github.com/NixOS/nixpkgs/commit/1e18109d76a55c4943ae3d1d1f4d46d0ae082ba6) | `` glusterfs: detect correct Python version by using local m4 files ``         |
| [`1a12a2d8`](https://github.com/NixOS/nixpkgs/commit/1a12a2d879cf694ee487c8ce76317a50b0203e1a) | `` Update from r1050 to r1056 ``                                               |
| [`6656326f`](https://github.com/NixOS/nixpkgs/commit/6656326f03d4ba8ee4a325cffaeea2b3943ce414) | `` fdkaac: 1.0.5 -> 1.0.6 ``                                                   |
| [`3eff2015`](https://github.com/NixOS/nixpkgs/commit/3eff20150d8ecf5b0e245887f946d4267d6511cd) | `` python3Packages.torch-bin: gpuChecks -> tests.tester-<name>.gpuCheck ``     |
| [`8cfb27bc`](https://github.com/NixOS/nixpkgs/commit/8cfb27bc21f608e5116310f0f4550a4ed0dc2a14) | `` python3*: backport fix for armv7l, aarch64, riscv64 ``                      |
| [`168f8700`](https://github.com/NixOS/nixpkgs/commit/168f8700f54e98a2556e0861881076ccdbc2db45) | `` python312Packages.aiocoap: 0.4.8 -> 0.4.10 ``                               |
| [`1a7463fc`](https://github.com/NixOS/nixpkgs/commit/1a7463fc8c3dba488fd9d14760c6470d511ef6ee) | `` below: fix bpf build, zerocallusedregs unavailable ``                       |
| [`a9c8ff2c`](https://github.com/NixOS/nixpkgs/commit/a9c8ff2ceee591cead5e4e266002329490e2d05d) | `` lorri: 1.6.0 -> 1.7.0 (#322749) ``                                          |
| [`6f80b637`](https://github.com/NixOS/nixpkgs/commit/6f80b637fb6ca24b46a5a28e1ddf4dcc80b8121d) | `` python312Packages.cpe: enable tests ``                                      |
| [`358d137b`](https://github.com/NixOS/nixpkgs/commit/358d137b5c742f1fe765f088a968f2ea2ac13f34) | `` wash-cli: 0.28.1 -> 0.29.2 ``                                               |
| [`46c18d0b`](https://github.com/NixOS/nixpkgs/commit/46c18d0b2ab899bebc9afaf5696e048503b58000) | `` python312Packages.pyloadapi: 1.2.0 -> 1.3.1 ``                              |
| [`91f5c7ac`](https://github.com/NixOS/nixpkgs/commit/91f5c7ac3e1a60bd88a4162f35ceaf1f21dca3e5) | `` pinentry: 1.3.0 -> 1.3.1 ``                                                 |
| [`dfe25b6c`](https://github.com/NixOS/nixpkgs/commit/dfe25b6c25efd7cbd9713b4fb5281f61993b658a) | `` python312Packages.pypoolstation: 0.5.3 -> 0.5.4 ``                          |
| [`d3e6b1f7`](https://github.com/NixOS/nixpkgs/commit/d3e6b1f7fc981bac405065f245ddfd96686f75ba) | `` python312Packages.pyenphase: 1.20.5 -> 1.20.6 ``                            |
| [`8e858475`](https://github.com/NixOS/nixpkgs/commit/8e858475a3478c8840c1a44d9dee53560504e519) | `` python312Packages.pyexploitdb: 0.2.24 -> 0.2.25 ``                          |
| [`3085e6a0`](https://github.com/NixOS/nixpkgs/commit/3085e6a02e7894a7a62f550825e896e725983f59) | `` deck: 1.38.1 -> 1.39.2 ``                                                   |
| [`29ff0c84`](https://github.com/NixOS/nixpkgs/commit/29ff0c84561808f3cfc87734cc05631e3f11cb8d) | `` awscli2: pin python311 ``                                                   |
| [`bbb9e8d1`](https://github.com/NixOS/nixpkgs/commit/bbb9e8d185d950d1b2faecbfe0c179916c3ad13c) | `` antora: 3.1.8 -> 3.1.9 ``                                                   |
| [`1b602bee`](https://github.com/NixOS/nixpkgs/commit/1b602bee095bd79a2d8b4e655cb4ed99c30743a9) | `` sqlfluff: 3.0.7 -> 3.1.0 ``                                                 |
| [`f9acb58f`](https://github.com/NixOS/nixpkgs/commit/f9acb58f4a1487e71555e6e57b915000030a25a8) | `` onboard: fixup install with python 3.12 ``                                  |
| [`3edd3bb2`](https://github.com/NixOS/nixpkgs/commit/3edd3bb25c60029985d1a6b0d233b82a92bea484) | `` python312Packages.ttn-client: 1.0.0 -> 1.1.0 ``                             |
| [`2ca98a08`](https://github.com/NixOS/nixpkgs/commit/2ca98a088cc58f1b0583821b503268a33c4da560) | `` garnet: 1.0.13 -> 1.0.15 ``                                                 |
| [`41fe1e89`](https://github.com/NixOS/nixpkgs/commit/41fe1e8962d676db05f60ddca190b6d4f289f427) | `` python312Packages.ipython-genutils: replace nose with pynose ``             |
| [`1e686ef2`](https://github.com/NixOS/nixpkgs/commit/1e686ef21b04466e15d02fe4edda8c8730c37ba0) | `` python312Packages.jupyterlab: 4.2.2 -> 4.2.3 ``                             |
| [`c9ccb379`](https://github.com/NixOS/nixpkgs/commit/c9ccb3791e0084134000f218d47ee8bc31580aaa) | `` python312Packages.jupyter-repo2docker: 2024.03.0 -> 2024.07.0 ``            |
| [`30fb858d`](https://github.com/NixOS/nixpkgs/commit/30fb858d9338b87ee623661b4c12f0c916096653) | `` tailwindcss-language-server: 0.0.18 -> 0.0.20 ``                            |
| [`a6bb5354`](https://github.com/NixOS/nixpkgs/commit/a6bb5354c7457ada3d503a865dd930d50af1af84) | `` jitsi-videobridge: 2.3-105-ge155b81e -> 2.3-149-g793df5a9 ``                |