### PR TITLE
chore(flake/pre-commit-hooks): `2b6bd3c8` -> `8d6a17d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -278,16 +278,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718811006,
-        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -329,11 +329,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720450253,
-        "narHash": "sha256-1in42htN3g3MnE3/AO5Qgs6pMWUzmtPQ7s675brO8uw=",
+        "lastModified": 1720524665,
+        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2b6bd3c87d3a66fb0b8f2f06c985995e04b4fb96",
+        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`11e7fbf7`](https://github.com/cachix/git-hooks.nix/commit/11e7fbf782eec015600836938006bd635791bf2c) | `` feat: add cabal-gild ``         |
| [`0f6f5fd8`](https://github.com/cachix/git-hooks.nix/commit/0f6f5fd8deb35b9213397af6d0512e8f7fe5752d) | `` chore: update to nixos 24.05 `` |
| [`6283849b`](https://github.com/cachix/git-hooks.nix/commit/6283849b803cf115bc0bea4a69e456ced9def947) | `` fixed typstyle argument ``      |