### PR TITLE
chore(flake/nixpkgs): `feb2849f` -> `7e7c39ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -250,11 +250,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720542800,
-        "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
+        "lastModified": 1720768451,
+        "narHash": "sha256-EYekUHJE2gxeo2pM/zM9Wlqw1Uw2XTJXOSAO79ksc4Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "feb2849fdeb70028c70d73b848214b00d324a497",
+        "rev": "7e7c39ea35c5cdd002cd4588b03a3fb9ece6fad9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`95c40a6f`](https://github.com/NixOS/nixpkgs/commit/95c40a6faec32f126c1ffc9b4cf8882689f7a9bc) | `` jasmin-compiler: 2023.06.4 → 2024.07.0 ``                               |
| [`3e894f85`](https://github.com/NixOS/nixpkgs/commit/3e894f85c03bbf114f5d48be0afcf722591f3c38) | `` nextcloud29Packages: update ``                                          |
| [`fd69af0f`](https://github.com/NixOS/nixpkgs/commit/fd69af0fe90094fe0a4d5139ff27f631d77f1215) | `` nextcloud28Packages: update ``                                          |
| [`4b97f227`](https://github.com/NixOS/nixpkgs/commit/4b97f227b9cda94e52605b103a746bc608b73c88) | `` nc4nix: 0-unstable-2024-03-01 -> 0-unstable-2024-05-24 ``               |
| [`de635cbc`](https://github.com/NixOS/nixpkgs/commit/de635cbcf19d04d669c34646999cfb6fc0c4500d) | `` simdutf: 5.2.8 -> 5.3.0 ``                                              |
| [`c5dd09be`](https://github.com/NixOS/nixpkgs/commit/c5dd09be8784bf6c2ff167252fe7ef403178be5e) | `` nix-health: 0.3.0 -> 0.4.0 ``                                           |
| [`20ea2663`](https://github.com/NixOS/nixpkgs/commit/20ea2663062b7a8410476748634d09e5e31e0062) | `` cdimgtools: sha256 -> hash ``                                           |
| [`6af5cd05`](https://github.com/NixOS/nixpkgs/commit/6af5cd05bb2e166feb29d1dca8aaf2b0f8b88481) | `` emacs.pkgs.consult-gh: modernize according to new melpaBuild ``         |
| [`8dc2a5db`](https://github.com/NixOS/nixpkgs/commit/8dc2a5dbea24bcf833769ae86c0a20c4012c9aed) | `` php82Packages.phpstan: 1.11.6 -> 1.11.7 ``                              |
| [`7c437a5e`](https://github.com/NixOS/nixpkgs/commit/7c437a5e9a5a67cbde807b4b33758c529f421c91) | `` garnet: used combined dotnet-sdk ``                                     |
| [`f6385867`](https://github.com/NixOS/nixpkgs/commit/f6385867612f5abd3e156bcca56af9681614e11f) | `` go-ethereum: migrate to pkgs/by-name ``                                 |
| [`95c5a17c`](https://github.com/NixOS/nixpkgs/commit/95c5a17c26fa53523da924eae2f95f6a65f263d1) | `` go-ethereum: set `meta.mainProgram = "geth"` ``                         |
| [`44209e4e`](https://github.com/NixOS/nixpkgs/commit/44209e4e639b9c24b31e6217d80e72acb4df3c47) | `` erlang: 25.3.2.12 -> 25.3.2.13 ``                                       |
| [`49a8e45b`](https://github.com/NixOS/nixpkgs/commit/49a8e45bb053f771dac2505ff7c3e808a7f24a78) | `` erlang_27: 27.0 -> 27.0.1 ``                                            |
| [`4a46bb94`](https://github.com/NixOS/nixpkgs/commit/4a46bb94a41bac268fbf95d522573ac40ea3c3b5) | `` masari: drop ``                                                         |
| [`68750208`](https://github.com/NixOS/nixpkgs/commit/687502080f5f5a1cd4c6aa302c15a750848c557b) | `` qodem: add patches ``                                                   |
| [`187349ba`](https://github.com/NixOS/nixpkgs/commit/187349ba0bcf05c2f77c19fe47849ac0d4d59ec6) | `` qodem: 1.0.1 -> 1.0.1-unstable-2022-02-12 ``                            |
| [`8dd4be41`](https://github.com/NixOS/nixpkgs/commit/8dd4be41db740052762e9c5c94f2c4b43439ae65) | `` qodem: fix build on Darwin ``                                           |
| [`b78f96a5`](https://github.com/NixOS/nixpkgs/commit/b78f96a5d8152bfb67ce56458b0a97ad8695be58) | `` qodem: modernize ``                                                     |
| [`956487c2`](https://github.com/NixOS/nixpkgs/commit/956487c28ba8aba31c71aa045728031d6ea2dc02) | `` qodem: format with `nixfmt-rfc-style` ``                                |
| [`953b05c0`](https://github.com/NixOS/nixpkgs/commit/953b05c022ccef49d1f9fce1086cc91354bc1dfd) | `` qodem: move to `pkgs/by-name` ``                                        |
| [`f67cebe1`](https://github.com/NixOS/nixpkgs/commit/f67cebe1cf6cba5beb5b4d3a0bc7b81c321519c7) | `` pshs: 0.3.4 -> 0.4.3 ``                                                 |
| [`4d9b5993`](https://github.com/NixOS/nixpkgs/commit/4d9b59932d35a35cbe83ae9a576734e6ff19b031) | `` pshs: support all Unix platforms ``                                     |
| [`5bc8c698`](https://github.com/NixOS/nixpkgs/commit/5bc8c6988fd5c532d60eb2e725386f55e3196155) | `` pshs: modernize ``                                                      |
| [`f5b70e5d`](https://github.com/NixOS/nixpkgs/commit/f5b70e5d819cf5b9e8909ce1c1804187b6a3d517) | `` pshs: format with `nixfmt-rfc-style` ``                                 |
| [`38d971a4`](https://github.com/NixOS/nixpkgs/commit/38d971a4a31a2297b30e7b607f499f78f21008b4) | `` pshs: move to `pkgs/by-name` ``                                         |
| [`defe4ae2`](https://github.com/NixOS/nixpkgs/commit/defe4ae28870856f3ad12624bcab3a1501c6c991) | `` gridcoin-research: 5.4.8.0 -> 5.4.8.0-hotfix-1 ``                       |
| [`fcf6c25a`](https://github.com/NixOS/nixpkgs/commit/fcf6c25a63fd49d3d49c5551ed315b7fdcce7ee0) | `` particl-core: add patch for miniupnpc 2.2.8 ``                          |
| [`9511ce95`](https://github.com/NixOS/nixpkgs/commit/9511ce9566579adb53b24c61dbbae6cdd8b0c54c) | `` elements: add patch for miniupnpc 2.2.8 ``                              |
| [`ca39d29f`](https://github.com/NixOS/nixpkgs/commit/ca39d29fca2b0ccb22142a1947b229acdc3e5930) | `` chiaki4deck: add patch for miniupnpc 2.2.8 ``                           |
| [`c5ff2043`](https://github.com/NixOS/nixpkgs/commit/c5ff20436ef4483e4bf903ff51bff16e82c09560) | `` dante: add patch for miniupnpc 2.2.8 ``                                 |
| [`7e443446`](https://github.com/NixOS/nixpkgs/commit/7e443446ead90a5881ae4236d1b7a73cde284cc8) | `` yaup: add patch for miniupnpc 2.2.8 ``                                  |
| [`b9f0aa80`](https://github.com/NixOS/nixpkgs/commit/b9f0aa8062dffdec37c1a50b2519a2fa6f204bcb) | `` zeroad: add patch for miniupnpc 2.2.8 ``                                |
| [`de9db75c`](https://github.com/NixOS/nixpkgs/commit/de9db75cb098b859655b020aa0ee9caf9574eec9) | `` alephone: add patch for miniupnpc 2.2.8 ``                              |
| [`5a149dad`](https://github.com/NixOS/nixpkgs/commit/5a149dad3470ff21e116aa5dfa2d84d5b7b61a59) | `` haven-cli: use patches from monero-cli ``                               |
| [`f96b9b94`](https://github.com/NixOS/nixpkgs/commit/f96b9b949fe1a41f73d32ae7422a9c2d1747c61b) | `` haven-cli: build with Ninja ``                                          |
| [`497259f9`](https://github.com/NixOS/nixpkgs/commit/497259f95bc1be10883462717358f7f7eee971d0) | `` monero-cli: add patch for miniupnpc 2.2.8 ``                            |
| [`0539f86a`](https://github.com/NixOS/nixpkgs/commit/0539f86a556de1a58832905e2a7a048435f56104) | `` monero-cli: build with Ninja ``                                         |
| [`77fbc57f`](https://github.com/NixOS/nixpkgs/commit/77fbc57f5391344aedb8c00422b4b61186d4c806) | `` litecoin: add patch for miniupnpc 2.2.8 ``                              |
| [`2e46cc8a`](https://github.com/NixOS/nixpkgs/commit/2e46cc8aed3425df5b4f12e3dea8ab649847461f) | `` eiskaltdcpp: add upstream patch for miniupnpc 2.2.8 ``                  |
| [`c9ba7936`](https://github.com/NixOS/nixpkgs/commit/c9ba793618eeb9bb8494cdc7f05a6d8d8100558b) | `` groestlcoind: add upstream patch for miniupnpc 2.2.8 ``                 |
| [`0abdd648`](https://github.com/NixOS/nixpkgs/commit/0abdd6485c0936dbc729efb83ce04373a0541223) | `` namecoind: add upstream patch for miniupnpc 2.2.8 ``                    |
| [`edc7668a`](https://github.com/NixOS/nixpkgs/commit/edc7668a6c2468f3f4adaf44e5eb962940389777) | `` retroshare: add upstream patch for miniupnpc 2.2.8 ``                   |
| [`416aae70`](https://github.com/NixOS/nixpkgs/commit/416aae70fed24b0a3aed14fb2d06752fd759f2d3) | `` retroshare: 0.6.6 -> 0.6.7.2 ``                                         |
| [`58b9ac89`](https://github.com/NixOS/nixpkgs/commit/58b9ac895cacfb74cba9968f5e56ecb938f24714) | `` bitcoind-knots: add upstream patch for miniupnpc 2.2.8 ``               |
| [`5b540501`](https://github.com/NixOS/nixpkgs/commit/5b54050136016972de795ae8bff95fff60b2f425) | `` python312Packages.pip-chill: init at 1.0.3 ``                           |
| [`e453c65a`](https://github.com/NixOS/nixpkgs/commit/e453c65ac93f5728f2ac8ed288e17c212a0f1d73) | `` skia: init at 124-unstable-2024-05-22 ``                                |
| [`fbcc06d6`](https://github.com/NixOS/nixpkgs/commit/fbcc06d6466eb8a5b12bfb9411e6a1f4228ecf0d) | `` Revert "mypy: 1.10.0 → 1.10.1" ``                                       |
| [`669466bb`](https://github.com/NixOS/nixpkgs/commit/669466bbc63ce7ba8e111809b83893f8cb8f2475) | `` discord: updates (#326186) ``                                           |
| [`da4cefba`](https://github.com/NixOS/nixpkgs/commit/da4cefba503e145d0871716c72eb5d94daa55264) | `` gleam: 1.3.0 -> 1.3.2 ``                                                |
| [`72446c10`](https://github.com/NixOS/nixpkgs/commit/72446c109a1dc263908835015d4297f4ca7f93e0) | `` flycast: add upstream patch for miniupnpc 2.2.8 ``                      |
| [`2bf72c41`](https://github.com/NixOS/nixpkgs/commit/2bf72c41dfc401b7083c8caccc30550592d2ce91) | `` sunshine: add upstream patch for miniupnpc 2.2.8 ``                     |
| [`22574208`](https://github.com/NixOS/nixpkgs/commit/2257420818a64e9fa4d1a82ce588445d29395800) | `` i2pd: add upstream patch for miniupnpc 2.2.8 ``                         |
| [`37087ef8`](https://github.com/NixOS/nixpkgs/commit/37087ef836ab38a901e3cbec889d641a278499f3) | `` bitcoin-abc: add upstream patch for miniupnpc 2.2.8 ``                  |
| [`314f1691`](https://github.com/NixOS/nixpkgs/commit/314f16916cbbf11e2121541a6cc1538c781dfa8a) | `` bitcoin: add upstream patch for miniupnpc 2.2.8 ``                      |
| [`579e16b0`](https://github.com/NixOS/nixpkgs/commit/579e16b06136f9ef047e2b6b43d8195771accd21) | `` transmission_3: add patch for miniupnpc 2.2.8 ``                        |
| [`b0ee42d2`](https://github.com/NixOS/nixpkgs/commit/b0ee42d215263af8a45faf55eafa031b0323ea3e) | `` transmission_4: fix build error with our miniupnp ``                    |
| [`4b9186a1`](https://github.com/NixOS/nixpkgs/commit/4b9186a1f77920ce3b04f6160ec304e2b9e676e3) | `` Reapply "miniupnpc: 2.2.7 -> 2.2.8 , support static build" ``           |
| [`579a3436`](https://github.com/NixOS/nixpkgs/commit/579a3436204692de9239990c3f1eb14be73bf2aa) | `` home-assistant: support eq3btsmart component ``                         |
| [`7d25ea49`](https://github.com/NixOS/nixpkgs/commit/7d25ea49df743f18f60c20f318f9cf1183784cfa) | `` python312Packages.eq3btsmart: init at 1.1.9 ``                          |
| [`f29cef3b`](https://github.com/NixOS/nixpkgs/commit/f29cef3b47516c9534854f8dcbd90847c8804092) | `` python312Packages.construct-typing: init at 0.6.2 ``                    |
| [`035f0e69`](https://github.com/NixOS/nixpkgs/commit/035f0e6936acc392398ecbe827421d8f9f60bc5f) | `` kdePackages.kup: init at 0.10.0 ``                                      |
| [`9a517fb2`](https://github.com/NixOS/nixpkgs/commit/9a517fb2f248d1ee8f855087865f6c1fe7d2c329) | `` python312Packages.scalene: fix build on Darwin ``                       |
| [`9cf6ffd4`](https://github.com/NixOS/nixpkgs/commit/9cf6ffd4bb257162a2ecd3ea573fe7c79352ae5d) | `` aliases/mesa_drivers: convert to throw ``                               |
| [`94b35a21`](https://github.com/NixOS/nixpkgs/commit/94b35a21e34232889c4ed604c8b20c845701f512) | `` key-rack: init at 0.4.0 ``                                              |
| [`e68f57a4`](https://github.com/NixOS/nixpkgs/commit/e68f57a43499e4873a94d541b29e1a48cd35621c) | `` xwayland: 24.1.0 -> 24.1.1 ``                                           |
| [`0f8c498f`](https://github.com/NixOS/nixpkgs/commit/0f8c498f9663f21fcd12e352c800b3f708f44975) | `` linuxKernel.kernels.linux_zen: sync config with upstream ``             |
| [`1991bfd7`](https://github.com/NixOS/nixpkgs/commit/1991bfd73de94c1c006db9fb4554dcd05c9b5da4) | `` markdownlint-cli2: 0.9.0 -> 0.13.0 (#317966) ``                         |
| [`3f8e3846`](https://github.com/NixOS/nixpkgs/commit/3f8e3846c6d05c2d2281bea1d087934df46f1d21) | `` pom: 0-unstable-2024-04-29 -> 0.1.0-unstable-2024-05-17 ``              |
| [`70db6560`](https://github.com/NixOS/nixpkgs/commit/70db6560b15015420ada3038a1a912521dd1ce35) | `` xdelta: change meta.homepage (#325491) ``                               |
| [`3bd2c770`](https://github.com/NixOS/nixpkgs/commit/3bd2c770bd5b36555463b2da2ec5c4fb8a211a4d) | `` lief: 0.13.2 -> 0.14.1 ``                                               |
| [`ebabfbf1`](https://github.com/NixOS/nixpkgs/commit/ebabfbf18d6154b6b81db15f571c62deea40f10b) | `` oxidized: 0.29.1 -> 0.30.1 ``                                           |
| [`9b429bf2`](https://github.com/NixOS/nixpkgs/commit/9b429bf2be7157c72e63d3c3f93fa2e2bce5a9be) | `` ib-{controller,tws}: mark as broken (#324591) ``                        |
| [`2c4196f6`](https://github.com/NixOS/nixpkgs/commit/2c4196f6a7378d2b1d01bf017ae1632436f8ecb0) | `` livebook: 0.12.1 -> 0.13.3 ``                                           |
| [`90380269`](https://github.com/NixOS/nixpkgs/commit/90380269a1ca811c8e1bbc13346cf0753644bc49) | `` sssd: fallback to python 3.11 to fix build ``                           |
| [`c734673f`](https://github.com/NixOS/nixpkgs/commit/c734673fef56864c7d0d2a70e66b344472f3456e) | `` binwalk: switch to fork, 2.3.4 -> 2.4.1 ``                              |
| [`c9998d08`](https://github.com/NixOS/nixpkgs/commit/c9998d08693c680857e567d034c2bf0de661c10b) | `` binwalk: migrate to pep517 builder ``                                   |
| [`161aa16c`](https://github.com/NixOS/nixpkgs/commit/161aa16c6d292122f7b55647ae9b39381e1aff43) | `` linux/hardened: fix syntax in update-script ``                          |
| [`c63531f9`](https://github.com/NixOS/nixpkgs/commit/c63531f954b6cd76c298d09aebdb52e10d0b0f0a) | `` linux_latest-libre: 19584 -> 19597 ``                                   |
| [`6210e328`](https://github.com/NixOS/nixpkgs/commit/6210e32854001bfefb414e73dddc52cf43b708fd) | `` linux-rt_5_10: 5.10.219-rt111 -> 5.10.220-rt112 ``                      |
| [`3e77292c`](https://github.com/NixOS/nixpkgs/commit/3e77292ce15c7c9181fe88ea355ca246dbb4a1b0) | `` linux_6_1: 6.1.97 -> 6.1.98 ``                                          |
| [`232f3042`](https://github.com/NixOS/nixpkgs/commit/232f3042f28dcb1e1e9db05c09e515c994df9d0d) | `` linux_6_6: 6.6.37 -> 6.6.39 ``                                          |
| [`a7135630`](https://github.com/NixOS/nixpkgs/commit/a7135630ba7f4e6f00acf34ba480617088823a79) | `` linux_6_9: 6.9.8 -> 6.9.9 ``                                            |
| [`8ee0a2c4`](https://github.com/NixOS/nixpkgs/commit/8ee0a2c46c9129974697225a2546152ba193c356) | `` linux_testing: 6.10-rc6 -> 6.10-rc7 ``                                  |
| [`6e3246b7`](https://github.com/NixOS/nixpkgs/commit/6e3246b7dd677cccb6720970474879b2c970bd4c) | `` exploitdb: 2024-07-02 -> 2024-07-05 ``                                  |
| [`d1b9f91d`](https://github.com/NixOS/nixpkgs/commit/d1b9f91d139d87c23e2bdf65b913ac919a0d0a76) | `` ayatana-webmail: fix runtime by using Python 3.11 ``                    |
| [`5259c004`](https://github.com/NixOS/nixpkgs/commit/5259c004b65065df94b7dadfce9e53b96eda0d29) | `` python312Packages.capstone_4: enable, add distutils patch ``            |
| [`d77fb467`](https://github.com/NixOS/nixpkgs/commit/d77fb467f5c8642a7a48ca7f72fde6ee237001f3) | `` python312Packages.pyuv: use pep517 builder ``                           |
| [`d23ef650`](https://github.com/NixOS/nixpkgs/commit/d23ef65021cd1d77b2e2a281e443b07e68da871f) | `` getmail6: 6.19.02 -> 6.19.03 ``                                         |
| [`199a76ea`](https://github.com/NixOS/nixpkgs/commit/199a76eaf7e5d157e14f77094a74394bb5ec88d3) | `` terraform: 1.8.5 -> 1.9.2 (#326158) ``                                  |
| [`6e9c397b`](https://github.com/NixOS/nixpkgs/commit/6e9c397b70dd9c765e6f8705dc43cbef74a99f2a) | `` python312Packages.sentry-sdk_2: 2.7.1 -> 2.9.0 ``                       |
| [`138cca55`](https://github.com/NixOS/nixpkgs/commit/138cca553f9798e7fc1bf24c4da4e7c537a58b12) | `` gnuradio3_8: fix evaluation by using python311 ``                       |
| [`e82e4a21`](https://github.com/NixOS/nixpkgs/commit/e82e4a218bda3d46fe16369a353b8235f531f188) | `` gnuradio3_9: fix evaluation by using python311 ``                       |
| [`b8d36032`](https://github.com/NixOS/nixpkgs/commit/b8d36032d806fd993e9e5a5aa88e67632c249871) | `` gnuradio: fix evaluation by using python311 ``                          |
| [`dcd6d929`](https://github.com/NixOS/nixpkgs/commit/dcd6d929fc42e978a7f57b0dba47ab2dc25d19a3) | `` python3Packages.pyuv: remove disabled, it builds fine on python 3.12 `` |
| [`6ac1f552`](https://github.com/NixOS/nixpkgs/commit/6ac1f552bae09bbf4c19eccf47583a58cc2738bd) | `` pt2-clone: fix NixOS test failure due to whitespace in icon name ``     |
| [`bd77a57b`](https://github.com/NixOS/nixpkgs/commit/bd77a57b8dd19ecb1b48a7f11f37865fdf93e297) | `` autotools-language-server: fix evaluation by using python311 ``         |
| [`4bcaef80`](https://github.com/NixOS/nixpkgs/commit/4bcaef80a3d08c68b6e55e39b65eb701179a7960) | `` openshot-qt: fix build by pinning python to 3.11, update sip ``         |
| [`7d156f6a`](https://github.com/NixOS/nixpkgs/commit/7d156f6a5cc040b63a1c802e44d33d379bf482a2) | `` buildNimPackage: add windows to platforms ``                            |
| [`a341e62e`](https://github.com/NixOS/nixpkgs/commit/a341e62e78cb1bf57759bea338f220a723cb3067) | `` buildNimPackage: drop dynlib patch on win builds ``                     |
| [`6eca4da1`](https://github.com/NixOS/nixpkgs/commit/6eca4da1ea0bba587d6c1742f39e6782a79f179c) | `` thin-provisioning-tools: fix build on tmpfs ``                          |
| [`456ab7dd`](https://github.com/NixOS/nixpkgs/commit/456ab7dd695cf830849c271ab505f782f2647c41) | `` mysql-workbench: 8.0.36 -> 8.0.38 ``                                    |