### PR TITLE
chore(flake/nixvim): `ac9a1cbf` -> `b9ed9000`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1720910388,
-        "narHash": "sha256-gCudumUXHH+o0KFemXecDYySVCzjz7jYDGjdJbrN7gA=",
+        "lastModified": 1721042250,
+        "narHash": "sha256-CEOGzI9WFGezwJ3lok0F//1UEq5crzE2kZDLQK2EtfE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ac9a1cbf9c7145687e66a1c033d68fc72eca3fd8",
+        "rev": "b9ed90003273f0a75151b32948e16b44891f403c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b9ed9000`](https://github.com/nix-community/nixvim/commit/b9ed90003273f0a75151b32948e16b44891f403c) | `` github/update: remove broken team-reviewers ``          |
| [`c1feceda`](https://github.com/nix-community/nixvim/commit/c1feceda64aaa767c0c0c19871b28264e2c530c7) | `` dev: fix `--commit` when the worktree is dirty ``       |
| [`cff06c85`](https://github.com/nix-community/nixvim/commit/cff06c8570d9f14c4c98abe4d90ca15d95ab3951) | `` github/update: improve summary for generated files ``   |
| [`bd1dddaf`](https://github.com/nix-community/nixvim/commit/bd1dddaf503a7bb40fdf52816ee8bf907a4d2c9a) | `` github/update: run `update` on the respective branch `` |
| [`433d2f21`](https://github.com/nix-community/nixvim/commit/433d2f213c76945ae108d7a7c93e7b499d58680e) | `` plugins/treesitter: disable folding by default ``       |