### PR TITLE
chore(flake/nixvim): `b9ed9000` -> `55bda0cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721042250,
-        "narHash": "sha256-CEOGzI9WFGezwJ3lok0F//1UEq5crzE2kZDLQK2EtfE=",
+        "lastModified": 1721224205,
+        "narHash": "sha256-W0+l7HNzZfEmIx/1Yp3Tow/GZILVjrMjWfTt1Mos7mI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b9ed90003273f0a75151b32948e16b44891f403c",
+        "rev": "55bda0cc3b230255d271e5eef82f3279dae9f859",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`55bda0cc`](https://github.com/nix-community/nixvim/commit/55bda0cc3b230255d271e5eef82f3279dae9f859) | `` plugins/none-ls/sources: structured "with" settings `` |
| [`ff6ad12a`](https://github.com/nix-community/nixvim/commit/ff6ad12a7d9e6c37a272c1ab6cf253dfabc14d79) | `` readme: Simplify flakes instructions ``                |