### PR TITLE
chore(flake/nixvim): `55bda0cc` -> `c9a6912b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721224205,
-        "narHash": "sha256-W0+l7HNzZfEmIx/1Yp3Tow/GZILVjrMjWfTt1Mos7mI=",
+        "lastModified": 1721389534,
+        "narHash": "sha256-2/HMbB2TazAGpfIGmzjElwxxPQScJQG/bmMBQMTnWlA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "55bda0cc3b230255d271e5eef82f3279dae9f859",
+        "rev": "c9a6912be575ffa83512c4dcdd9918f794ac401e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`c9a6912b`](https://github.com/nix-community/nixvim/commit/c9a6912be575ffa83512c4dcdd9918f794ac401e) | `` modules/files: fix creating configs of vim type ``                       |
| [`daa94bd6`](https://github.com/nix-community/nixvim/commit/daa94bd6c236538a71aa0c12216afd138dd517ed) | `` tests: Disable coq-nvim defaults on x86_64 darwin ``                     |
| [`50d86527`](https://github.com/nix-community/nixvim/commit/50d865275d29e23e01a8d914da281cc6ee197e3c) | `` tests: Reduce the number of calls to mkTestDerivationFromNixvimModule `` |
| [`71126bfe`](https://github.com/nix-community/nixvim/commit/71126bfebeae32cd731d70705295804f3da3f158) | `` tests: Allow to test multiple derivations in a single test derivation `` |