### PR TITLE
chore(flake/nixvim): `c9a6912b` -> `e80a8874`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721389534,
-        "narHash": "sha256-2/HMbB2TazAGpfIGmzjElwxxPQScJQG/bmMBQMTnWlA=",
+        "lastModified": 1721421992,
+        "narHash": "sha256-4Mu+O2/S5XU1D8HLTU53pv20hEH6aiTkUqjLHowYdY8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c9a6912be575ffa83512c4dcdd9918f794ac401e",
+        "rev": "e80a8874accd45cac90616a7b5faa49c5a68e6b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`e80a8874`](https://github.com/nix-community/nixvim/commit/e80a8874accd45cac90616a7b5faa49c5a68e6b9) | `` docs: Add a section of *Package options ``       |
| [`8a4dc239`](https://github.com/nix-community/nixvim/commit/8a4dc239d62cf5cec319038848bf3d12e6bb7337) | `` plugins/{lsp,none-ls}: remove package aliases `` |