### PR TITLE
chore(flake/nixvim): `e80a8874` -> `8eb5763b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721421992,
-        "narHash": "sha256-4Mu+O2/S5XU1D8HLTU53pv20hEH6aiTkUqjLHowYdY8=",
+        "lastModified": 1721571110,
+        "narHash": "sha256-W4KLBlN3g5fABz1Hv/O9Vwq0mFwY3XYuAyGLege1tVM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e80a8874accd45cac90616a7b5faa49c5a68e6b9",
+        "rev": "8eb5763bbbb414c432ced741c5fe8052154d0816",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`8eb5763b`](https://github.com/nix-community/nixvim/commit/8eb5763bbbb414c432ced741c5fe8052154d0816) | `` modules/lua-loader: make enable option nullable ``                 |
| [`79087297`](https://github.com/nix-community/nixvim/commit/7908729711351b596160ddcdc138bb925d846f87) | `` dev: Make the tests command able to select which test to launch `` |
| [`b1576362`](https://github.com/nix-community/nixvim/commit/b1576362a735e06f22445f1b44d17447fdaebbf1) | `` tests: Remove the test link farm ``                                |