### PR TITLE
chore(flake/nixvim): `8eb5763b` -> `d2f733ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721571110,
-        "narHash": "sha256-W4KLBlN3g5fABz1Hv/O9Vwq0mFwY3XYuAyGLege1tVM=",
+        "lastModified": 1721592379,
+        "narHash": "sha256-pJzkjy4+sM9+5IfrZMTWAiB0m/m4eiV4fmnqxtVNonI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8eb5763bbbb414c432ced741c5fe8052154d0816",
+        "rev": "d2f733efb4962903b77af330c4c03a63f2f72968",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`d2f733ef`](https://github.com/nix-community/nixvim/commit/d2f733efb4962903b77af330c4c03a63f2f72968) | `` systemModules should be systemPackages in README example ``              |
| [`06261fc4`](https://github.com/nix-community/nixvim/commit/06261fc4720bb88fbaf646a1b2ac8f1c9da51f20) | `` modules/lsp/servers/vls: do not add filetype extension if not enabled `` |