### PR TITLE
chore(flake/nixvim): `d2f733ef` -> `6dc0bda4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721592379,
-        "narHash": "sha256-pJzkjy4+sM9+5IfrZMTWAiB0m/m4eiV4fmnqxtVNonI=",
+        "lastModified": 1721651056,
+        "narHash": "sha256-GOm1qWrT0MurD/84RzWj/E6GPmzPT5nH/hrSYohtlxs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d2f733efb4962903b77af330c4c03a63f2f72968",
+        "rev": "6dc0bda459bcfb2a38cf7b6ed1d6a5d6a8105f00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`6dc0bda4`](https://github.com/nix-community/nixvim/commit/6dc0bda459bcfb2a38cf7b6ed1d6a5d6a8105f00) | `` lib/to-lua: handle derivations as path strings ``                       |
| [`34aa3e00`](https://github.com/nix-community/nixvim/commit/34aa3e00e7f0b0ec44d036f5fbf1dd27825aa77b) | `` modules/filetype: ensure that the module does not set empty settings `` |