### PR TITLE
chore(flake/nixvim): `6dc0bda4` -> `901e8760`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721651056,
-        "narHash": "sha256-GOm1qWrT0MurD/84RzWj/E6GPmzPT5nH/hrSYohtlxs=",
+        "lastModified": 1721683528,
+        "narHash": "sha256-MbVWB/LsMxQ0VOi/ghyAM0LrhlDp3rdynIB+zYifp78=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6dc0bda459bcfb2a38cf7b6ed1d6a5d6a8105f00",
+        "rev": "901e8760d02b64e83c852d019a8599fea1c376ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`901e8760`](https://github.com/nix-community/nixvim/commit/901e8760d02b64e83c852d019a8599fea1c376ad) | `` flake-modules/dev: format launch-test.sh ``                     |
| [`93175378`](https://github.com/nix-community/nixvim/commit/9317537848307271e536c6f28d355880515102d3) | `` modules: avoid setting empty strings to extraConfig* options `` |
| [`299d0406`](https://github.com/nix-community/nixvim/commit/299d0406bb339283969907d1f171f0eec7d84c43) | `` modules/output: refactor config generation ``                   |