### PR TITLE
chore(flake/nixvim): `901e8760` -> `ab67ee7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720524665,
-        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720734513,
-        "narHash": "sha256-neWQ8eNtLTd+YMesb7WjKl1SVCbDyCm46LUgP/g/hdo=",
+        "lastModified": 1721534365,
+        "narHash": "sha256-XpZOkaSJKdOsz1wU6JfO59Rx2fqtcarQ0y6ndIOKNpI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
+        "rev": "635563f245309ef5320f80c7ebcb89b2398d2949",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720845312,
-        "narHash": "sha256-yPhAsJTpyoIPQZJGC8Fw8W2lAXyhLoTn+HP20bmfkfk=",
+        "lastModified": 1721655289,
+        "narHash": "sha256-eJQQwXOKWjom9gtb7HvHd3+Wj5Sp+WrYR44r0EnaO5w=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "5ce8503cf402cf76b203eba4b7e402bea8e44abc",
+        "rev": "2ae24bcafdb88fdf70b061cc8b18d070dbd9013a",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721683528,
-        "narHash": "sha256-MbVWB/LsMxQ0VOi/ghyAM0LrhlDp3rdynIB+zYifp78=",
+        "lastModified": 1721772245,
+        "narHash": "sha256-//9p3Qm8gLbPUTsSGN2EMYkDwE5Sqq9B9P2X/z2+npw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "901e8760d02b64e83c852d019a8599fea1c376ad",
+        "rev": "ab67ee7e8b33e788fc53d26dc6f423f9358e3e66",
         "type": "github"
       },
       "original": {
@@ -395,11 +395,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720818892,
-        "narHash": "sha256-f52x9srIcqQm1Df3T+xYR5P6VfdnDFa2vkkcLhlTp6U=",
+        "lastModified": 1721458737,
+        "narHash": "sha256-wNXLQ/ATs1S4Opg1PmuNoJ+Wamqj93rgZYV3Di7kxkg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5b002f8a53ed04c1a4177e7b00809d57bd2c696f",
+        "rev": "888bfb10a9b091d9ed2f5f8064de8d488f7b7c97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`ab67ee7e`](https://github.com/nix-community/nixvim/commit/ab67ee7e8b33e788fc53d26dc6f423f9358e3e66) | `` plugins/lsp/openscad-lsp: init ``                           |
| [`10cc58d4`](https://github.com/nix-community/nixvim/commit/10cc58d497ab422801b68ec8cde036b521f76a50) | `` plugins/lsp/pylsp: propagatedBuildInputs -> dependencies `` |
| [`3b6d403f`](https://github.com/nix-community/nixvim/commit/3b6d403f3972a1e8f9f283a35a88bdfcf2e924a4) | `` plugins/better-escape: switch to mkNeovimPlugin + update `` |
| [`95dade62`](https://github.com/nix-community/nixvim/commit/95dade6292ee19d1f3dc937ed0e69f9c720056a4) | `` flake.lock: Update ``                                       |
| [`26b9647e`](https://github.com/nix-community/nixvim/commit/26b9647ed74215b60313739cdafabee4126edfe7) | `` dev: Introduce an editorconfig file for shfmt ``            |
| [`53f76f76`](https://github.com/nix-community/nixvim/commit/53f76f76b070ccc19cb82a1874c5c5e2368c8374) | `` dev: Re-evaluate direnv when a flake-module changes ``      |
| [`f1eaf5b6`](https://github.com/nix-community/nixvim/commit/f1eaf5b617828a8c8c244d2d8248858ab1e400ab) | `` dev: Allow to pass arguments to nix in `tests` ``           |
| [`1c75b414`](https://github.com/nix-community/nixvim/commit/1c75b414cb8b124f24c935d113a066b9dd685827) | `` dev: Allow to choose the system in `tests` ``               |