### PR TITLE
chore(flake/nixvim): `ab67ee7e` -> `0ac10f67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1721772245,
-        "narHash": "sha256-//9p3Qm8gLbPUTsSGN2EMYkDwE5Sqq9B9P2X/z2+npw=",
+        "lastModified": 1721832650,
+        "narHash": "sha256-naQCM5KqT+i8W/84aaXUsr/6oWR8fkjXDPdWCwLiCRQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ab67ee7e8b33e788fc53d26dc6f423f9358e3e66",
+        "rev": "0ac10f6776c6650b18ebe45913e06b7ce1a2e2b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`0ac10f67`](https://github.com/nix-community/nixvim/commit/0ac10f6776c6650b18ebe45913e06b7ce1a2e2b1) | `` modules/performance: refactor after code review ``                               |
| [`6e2ec5ed`](https://github.com/nix-community/nixvim/commit/6e2ec5ed02a60cf4c159bf923ae7566facd75e3d) | `` modules/performance: add plenary filetypes directory to default pathsToLink ``   |
| [`532b0044`](https://github.com/nix-community/nixvim/commit/532b0044d05ad93fd900a9a2283591514b19bac6) | `` plugins/telescope: add compatibility with `combinePlugins` ``                    |
| [`5c75cfac`](https://github.com/nix-community/nixvim/commit/5c75cfac13510bdda1f2cdb2037b4eb08620adb2) | `` plugins/telescope/fzy-native: add compatibility with `combinePlugins` ``         |
| [`61caa52f`](https://github.com/nix-community/nixvim/commit/61caa52fc582d7f07b1c22abc00db560a2671fb1) | `` plugins/telescope/fzf-native: add compatibility with `combinePlugins` ``         |
| [`ce93f172`](https://github.com/nix-community/nixvim/commit/ce93f1724f69d064ab3ee2ffd376193024776f6c) | `` plugins/treesitter: add workaround for `performance.combinePlugins` ``           |
| [`0c32f5bd`](https://github.com/nix-community/nixvim/commit/0c32f5bda54ef58f2c3f25bab3d9dbc18643e2a1) | `` modules/performance: don't combine `filesPlugin` into plugin pack ``             |
| [`e65c9590`](https://github.com/nix-community/nixvim/commit/e65c9590d0485410de0c091962ea27a72342b6dc) | `` modules/performance: add `combinePlugins.standalonePlugins` option ``            |
| [`d6bebcef`](https://github.com/nix-community/nixvim/commit/d6bebcefa3201812e91abcf7ae843fcbdbfe7902) | `` modules/performance: handle plugin configs when combining plugins ``             |
| [`27201add`](https://github.com/nix-community/nixvim/commit/27201addd787113c04e415f7fd81fcd887a06bae) | `` modules/performance: handle optional plugins when combining plugins ``           |
| [`f900dcd6`](https://github.com/nix-community/nixvim/commit/f900dcd6aabe6e74f3a0ab5b865472e18b42e888) | `` modules/performance: handle python3 dependencies when combining plugins ``       |
| [`fdb3950c`](https://github.com/nix-community/nixvim/commit/fdb3950c5905f8026e46a52dd73a17d7c49944f3) | `` modules/performance: add an option to combine plugins to a single plugin pack `` |
| [`119f12db`](https://github.com/nix-community/nixvim/commit/119f12db27293d1642a5af8908207e151f8fef8a) | `` modules/output: avoid using global `with lib;` ``                                |
| [`63872993`](https://github.com/nix-community/nixvim/commit/638729936455e26dcd2a13e25b96ac79891bc9af) | `` plugins/cmake-tools: init ``                                                     |
| [`a1bd7aeb`](https://github.com/nix-community/nixvim/commit/a1bd7aebc69ffbf4239667d035bfb523affa0c23) | `` maintainers: add NathanFelber ``                                                 |