### PR TITLE
chore(flake/nixpkgs): `dc14ed91` -> `5ad6a14c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -254,11 +254,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721743106,
-        "narHash": "sha256-adRZhFpBTnHiK3XIELA3IBaApz70HwCYfv7xNrHjebA=",
+        "lastModified": 1721924956,
+        "narHash": "sha256-Sb1jlyRO+N8jBXEX9Pg9Z1Qb8Bw9QyOgLDNMEpmjZ2M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc14ed91132ee3a26255d01d8fd0c1f5bff27b2f",
+        "rev": "5ad6a14c6bf098e98800b091668718c336effc95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`7b3ed2ec`](https://github.com/NixOS/nixpkgs/commit/7b3ed2ec699331a338699946e89d1638728ef7ad) | `` rabbit: 2.0.0 -> 2.1.0 ``                                                          |
| [`9e1f2727`](https://github.com/NixOS/nixpkgs/commit/9e1f27272aef75525c40709b403d3cf02ce7f39f) | `` klipper: add version info (#329140) ``                                             |
| [`ad5e2db9`](https://github.com/NixOS/nixpkgs/commit/ad5e2db9a67bf1a6b906f9343042b0d54790edc6) | `` python312Packages.osxphotos: init at 0.68.2 ``                                     |
| [`ef5cbcb4`](https://github.com/NixOS/nixpkgs/commit/ef5cbcb4eac4d8de18776bee71a4a0e96f6097bd) | `` pistol: 0.5 -> 0.5.1 ``                                                            |
| [`6176a3c9`](https://github.com/NixOS/nixpkgs/commit/6176a3c9865fa180eb255a884f4e89ca70736158) | `` ibus-engines.libpinyin: 1.15.7 -> 1.15.8 ``                                        |
| [`d0fd2e1a`](https://github.com/NixOS/nixpkgs/commit/d0fd2e1a41cd05a279e2e1b37a2e3ea24653c5b3) | `` kubescape: 3.0.14 -> 3.0.15 ``                                                     |
| [`7a90612f`](https://github.com/NixOS/nixpkgs/commit/7a90612f29779a72ceb85a5b0af417be8152df82) | `` python312Packages.govee-ble: 0.33.1 -> 0.40.0 ``                                   |
| [`6ae5cdb0`](https://github.com/NixOS/nixpkgs/commit/6ae5cdb0eaa5b683b4378ee2c507d827178be5bd) | `` renovate: 37.431.7 -> 37.440.7 ``                                                  |
| [`9cac7a74`](https://github.com/NixOS/nixpkgs/commit/9cac7a7475204ad62ce9a863f5e972224f8ddfc6) | `` fetch-yarn-deps: improve diagnostic messages ``                                    |
| [`84a75e94`](https://github.com/NixOS/nixpkgs/commit/84a75e9488894098ce8c51aabf23f10fa63fa67e) | `` fetchYarnDeps: fix broken fetching logic for github releases ``                    |
| [`53dede42`](https://github.com/NixOS/nixpkgs/commit/53dede428741013cfedae8c528e532e8082a3d0d) | `` charmcraft: 2.7.0 -> 3.1.1 ``                                                      |
| [`0905b34d`](https://github.com/NixOS/nixpkgs/commit/0905b34da67c145403f25fa09fb0fcc2b75c67e0) | `` python3Packages.craft-platforms: init at 0.1.1 ``                                  |
| [`103bd1c7`](https://github.com/NixOS/nixpkgs/commit/103bd1c7921f37a920c56351ea27f4eafaf506f9) | `` nixci: add rsrohitsingh682 as a maintainer ``                                      |
| [`ba55d2a0`](https://github.com/NixOS/nixpkgs/commit/ba55d2a08b11c9fb35942f4bba42d44f07d9ccc0) | `` bearer: 1.45.1 -> 1.45.2 ``                                                        |
| [`62464deb`](https://github.com/NixOS/nixpkgs/commit/62464debc9ef8862da5c73decf2a5c23a00dc2cc) | `` xemu: 0.7.128 -> 0.7.131 ``                                                        |
| [`894542ee`](https://github.com/NixOS/nixpkgs/commit/894542eecb7e62b572a830b168854d518954cee4) | `` codeium: 1.8.80 -> 1.10.0 ``                                                       |
| [`b52e1d82`](https://github.com/NixOS/nixpkgs/commit/b52e1d82de821d2edfcf237ad7da3b10a6604e58) | `` sploitscan: 0.10.3 -> 0.10.4 ``                                                    |
| [`1167f197`](https://github.com/NixOS/nixpkgs/commit/1167f1975340028b6146867115eb4bac4ae987c8) | `` numix-icon-theme-square: 24.04.22 -> 24.07.19 ``                                   |
| [`3de95c23`](https://github.com/NixOS/nixpkgs/commit/3de95c23b1184f1453b72cf727e71515bae62af8) | `` python311Packages.pylibjpeg-openjpeg: init at 2.3.0 ``                             |
| [`95af2702`](https://github.com/NixOS/nixpkgs/commit/95af2702bb99257ebd26b84de8c9587cc47269ef) | `` python311Packages.pylibjpeg-data: init at unstable-2024-03-24 ``                   |
| [`9bca10c7`](https://github.com/NixOS/nixpkgs/commit/9bca10c7214cf10ce8aa8d7be7566c5c713eecec) | `` mdbook-alerts: init at 0.6.0 ``                                                    |
| [`f5fd8730`](https://github.com/NixOS/nixpkgs/commit/f5fd8730397b9951d24de58f51a5e9cb327e2a85) | `` terraform: 1.9.2 -> 1.9.3 ``                                                       |
| [`06ed778c`](https://github.com/NixOS/nixpkgs/commit/06ed778c19b9d616fc593af576d9e2812ce0b561) | `` yt-dlp: 2024.7.16 -> 2024.7.25 ``                                                  |
| [`afd2f214`](https://github.com/NixOS/nixpkgs/commit/afd2f214b0387394bd4a5f4d339ceaf08f271a42) | `` llvmPackages_git.compiler-rt: fix darwin patch (#329796) ``                        |
| [`8aa86c46`](https://github.com/NixOS/nixpkgs/commit/8aa86c4650a34a33834dfc3ab406b03936f9d9ea) | `` emacsPackages.color-theme-solarized: remove color-theme dependency ``              |
| [`2f5fb56c`](https://github.com/NixOS/nixpkgs/commit/2f5fb56cb33f1c0a58fd2fe23c5bd0e8bf922835) | `` cargo-semver-checks: 0.32.0 -> 0.33.0 ``                                           |
| [`0bb31825`](https://github.com/NixOS/nixpkgs/commit/0bb31825c5f191b24ed5ee79c13b3205690445f1) | `` python3Packages.databricks-sql-connector: 3.2.0 -> 3.3.0, unbreak  (#329134) ``    |
| [`dc3b05d9`](https://github.com/NixOS/nixpkgs/commit/dc3b05d906ec6a4e24585bbae04c92a1379eaf36) | `` clboss: 0.13.1 -> 0.13.2 ``                                                        |
| [`94bc3c61`](https://github.com/NixOS/nixpkgs/commit/94bc3c61faf8e7b8e964a8392f7996d42dadce4c) | `` esphome: 2024.7.1 -> 2024.7.2 ``                                                   |
| [`b52e9d5d`](https://github.com/NixOS/nixpkgs/commit/b52e9d5dbdd3dfb87e01d595c4f5b34f767d452a) | `` zarf: add shell completion ``                                                      |
| [`7342b2ae`](https://github.com/NixOS/nixpkgs/commit/7342b2ae4d72ef1f75a1c20050f5aeafe484ca98) | `` python312Packages.aiosmtpd: add some key reverse-dependencies to passthru.tests `` |
| [`01a69e56`](https://github.com/NixOS/nixpkgs/commit/01a69e5619da6436a8c7ec852731e26db7bc454b) | `` pcsx2-bin: simplify updateScript ``                                                |
| [`d36c2dfd`](https://github.com/NixOS/nixpkgs/commit/d36c2dfd132a3ca26c17909850ef13711eac80c1) | `` python312Packages.publicsuffixlist: 1.0.1.20240713 -> 1.0.2.20240724 ``            |
| [`d19fb6b7`](https://github.com/NixOS/nixpkgs/commit/d19fb6b76706dec417c14e60ee50f7dad164d029) | `` python312Packages.std-uritemplate: 1.0.3 -> 1.0.5 ``                               |
| [`fbfbd547`](https://github.com/NixOS/nixpkgs/commit/fbfbd547fa40abd4238844e138167b207e819314) | `` coulr: init at 2.1.0 ``                                                            |
| [`76d0de1f`](https://github.com/NixOS/nixpkgs/commit/76d0de1fc45b731eceb3749b80fbcd4b47579c4d) | `` python311Packages.devito: 4.8.10 -> 4.8.11 ``                                      |
| [`45c1e0ab`](https://github.com/NixOS/nixpkgs/commit/45c1e0ab1637e205db02620dd1ee9d0300932bf0) | `` python312Packages.debian-inspector: modernize ``                                   |
| [`7d63921e`](https://github.com/NixOS/nixpkgs/commit/7d63921e596f247b3bf9339b540709e2bccfbd39) | `` python312Packages.commoncode: don't fail if there is no /etc/os-release ``         |
| [`86f0eda7`](https://github.com/NixOS/nixpkgs/commit/86f0eda71c32da0048eab26b45d78a80064e42f3) | `` python311Packages.transformers: 4.42.4 -> 4.43.2 ``                                |
| [`e461b158`](https://github.com/NixOS/nixpkgs/commit/e461b1584eb87289bfb1c957038ce7339835980c) | `` python311Packages.huggingface-hub: 0.23.5 -> 0.24.2 ``                             |
| [`3acda844`](https://github.com/NixOS/nixpkgs/commit/3acda844437146dbf1dd57eae962987e363e27ee) | `` tbls: 1.76.1 -> 1.77.0 ``                                                          |
| [`06cba1f8`](https://github.com/NixOS/nixpkgs/commit/06cba1f89ee582e0df3b8b6302e5b2d392759eaf) | `` cargo-cyclonedx: 0.5.3 -> 0.5.4 ``                                                 |
| [`084f6a3e`](https://github.com/NixOS/nixpkgs/commit/084f6a3e260a9576c955137ff44b2e6d4fac6891) | `` nixos/ollama: make `rocmOverrideGfx` backward compatible ``                        |
| [`339d0cd6`](https://github.com/NixOS/nixpkgs/commit/339d0cd68c5135bf6dbde360b46570324f8e3685) | `` nixos/ollama: update `.git-blame-ignore-revs` ``                                   |
| [`246d1ee5`](https://github.com/NixOS/nixpkgs/commit/246d1ee533810ac1946d863bbd9de9b525818d56) | `` nixos/ollama: reformat with `nixfmt-rfc-style` ``                                  |
| [`991fbf2f`](https://github.com/NixOS/nixpkgs/commit/991fbf2f1061b0f1dc1ee3ac7661a704bae4985a) | `` nixci: 0.5.0 -> 1.0.0 ``                                                           |
| [`a0e4fc38`](https://github.com/NixOS/nixpkgs/commit/a0e4fc38b60a7b41045a4e6eb42920d7e23caaf5) | `` noseyparker: 0.12.0 -> 0.18.1 ``                                                   |
| [`f01323e0`](https://github.com/NixOS/nixpkgs/commit/f01323e0b3c7ee9cc422f27a55dc6da781489a4f) | `` python312Packages.tencentcloud-sdk-python: 3.0.1195 -> 3.0.1196 ``                 |
| [`491caca6`](https://github.com/NixOS/nixpkgs/commit/491caca6862e826b480c7252040e0c3f9e9e6f43) | `` python312Packages.timetagger: 24.4.1 -> 24.07.1 ``                                 |
| [`92c68739`](https://github.com/NixOS/nixpkgs/commit/92c68739ef82131733cc1f4f045cef628f8e99f6) | `` timetagger: 24.4.1 -> 24.07.1 ``                                                   |
| [`6fd9741c`](https://github.com/NixOS/nixpkgs/commit/6fd9741c85cd7751d3d0e5e06173510c2caed358) | `` snapcraft: don't override pydantic ``                                              |
| [`3e051ced`](https://github.com/NixOS/nixpkgs/commit/3e051ceda2cbab6f4774387f32350eb0b47bd970) | `` python312Packages.inflect: 7.2.1 -> 7.3.1 ``                                       |
| [`3b3ed6c6`](https://github.com/NixOS/nixpkgs/commit/3b3ed6c66909b4ee5eb7092a941025c1eafe9d12) | `` multipass: add comments to explain patches ``                                      |
| [`1813159b`](https://github.com/NixOS/nixpkgs/commit/1813159b69ea4b232402b5d8a62b18f5bab856be) | `` add link to the project homepage ``                                                |
| [`f7f73482`](https://github.com/NixOS/nixpkgs/commit/f7f73482d1d33c7c1eff0e108f31b1b707c0615c) | `` skippy-xd: 0.7.2 -> 0.8.0 ``                                                       |
| [`33019e7e`](https://github.com/NixOS/nixpkgs/commit/33019e7ea94a6781d717c09e2b82ad0a13161ced) | `` python312Packages.launchpadlib: modernize ``                                       |
| [`7106b2bf`](https://github.com/NixOS/nixpkgs/commit/7106b2bf4a0ccd11cfbe3dec3b2a065d527125e1) | `` python312Packages.spdx: use pyproject=true ``                                      |
| [`c6aca413`](https://github.com/NixOS/nixpkgs/commit/c6aca4138323618e85f79de75fc3d53240a1a676) | `` python312Packages.spdx-lookup: use pyproject=true ``                               |
| [`2e5a44fb`](https://github.com/NixOS/nixpkgs/commit/2e5a44fb24dadb84d4d9079f16743addaf75ba09) | `` charmcraft: add setuptools to dependencies ``                                      |
| [`b9690543`](https://github.com/NixOS/nixpkgs/commit/b969054329041914713d30cf0f8bf74190d3b60f) | `` snapcraft: do catch conflicts ``                                                   |
| [`1ed734c6`](https://github.com/NixOS/nixpkgs/commit/1ed734c6c1aedbc958b1c41e83cf04c38d8ab856) | `` charmcraft: pin pydantic-yaml ``                                                   |
| [`85687388`](https://github.com/NixOS/nixpkgs/commit/85687388d683d6df1f915b6e12b8383b81537cac) | `` snapcraft: pin pydantic-yaml ``                                                    |
| [`06169afb`](https://github.com/NixOS/nixpkgs/commit/06169afb32a5a68bad7da241ef295e1e17052200) | `` rockcraft: pin pydantic-yaml ``                                                    |
| [`592ef728`](https://github.com/NixOS/nixpkgs/commit/592ef728e35c8600769a73ab31d67a09562910ca) | `` python312Packages.craft-parts: mark broken ``                                      |
| [`730a854f`](https://github.com/NixOS/nixpkgs/commit/730a854f9c98d83b9de1d6eec01aa319cf082a60) | `` python312Packages.pydantic-yaml: 0.11.2 -> 1.3.0 ``                                |
| [`ca44a001`](https://github.com/NixOS/nixpkgs/commit/ca44a00186cd85f2b448da7945c8c055376d3f1b) | `` python312Packages.craft-application-1: drop ``                                     |
| [`b2701cdf`](https://github.com/NixOS/nixpkgs/commit/b2701cdfbd714f65c7c4fd347ff5e6ab6e3fe8cf) | `` rockcraft: use packageOverrides ``                                                 |
| [`80056a63`](https://github.com/NixOS/nixpkgs/commit/80056a63dae1077a29c6b767df099379ea1d57ab) | `` python312Packages.pydantic-yaml: rename from pydantic-yaml-0 ``                    |
| [`451746aa`](https://github.com/NixOS/nixpkgs/commit/451746aa1200979aefe1c21245d00ded0a23fe9e) | `` snapcraft: 8.2.12 -> 8.3.1 ``                                                      |
| [`8985b03f`](https://github.com/NixOS/nixpkgs/commit/8985b03f5c19564ad9dd42504f854f959e8820e7) | `` python312Packages.craft-application: 2.8.0 -> 3.2.0 ``                             |
| [`a8e6c005`](https://github.com/NixOS/nixpkgs/commit/a8e6c00537681a8ba8f0959717a1482ee0c1da44) | `` python312Packages.craft-parts: 1.31.0 -> 1.33.0 ``                                 |
| [`bebf8e7e`](https://github.com/NixOS/nixpkgs/commit/bebf8e7e8cb7f480f8fa756f0ec4423dabb4a98c) | `` python312Packages.craft-cli: 2.5.1 -> 2.6.0 ``                                     |
| [`1c9b7f71`](https://github.com/NixOS/nixpkgs/commit/1c9b7f71b80da2bb657643c7faeb4a559ca69139) | `` python312Packages.python-apt: 2.7.6 -> 2.8.0 ``                                    |
| [`56fd5c06`](https://github.com/NixOS/nixpkgs/commit/56fd5c06a693bb43e86de89ba3e76963871c155f) | `` emacsPackages.notdeft: implement passthru.updateScript ``                          |
| [`d2c88473`](https://github.com/NixOS/nixpkgs/commit/d2c88473312aa02f2aa2d738749e9fdaffa14ece) | `` emacsPackages.emacs-conflict: implement passthru.updateScript ``                   |
| [`d1877bdc`](https://github.com/NixOS/nixpkgs/commit/d1877bdca487b8a6e13dc819f53800a2fc6c7484) | `` previewqt: init at 3.0 ``                                                          |
| [`0a63465e`](https://github.com/NixOS/nixpkgs/commit/0a63465eafb24a1928b47faf055571978ea9c97c) | `` python312Packages.snakemake-interface-executor-plugins: 9.1.1 -> 9.2.0 ``          |
| [`3ce21e8e`](https://github.com/NixOS/nixpkgs/commit/3ce21e8ea3175523135d0e035f04400024d43857) | `` python311Packages.dask-awkward: 2024.6.0 -> 2024.7.0 (#329656) ``                  |
| [`c24efe53`](https://github.com/NixOS/nixpkgs/commit/c24efe53ac3000f2ecf388e0027c4d143bc25cd4) | `` multipass: 1.13.1 -> 1.14.0 ``                                                     |
| [`6282c8d0`](https://github.com/NixOS/nixpkgs/commit/6282c8d0c66ff0304ed4fdeacffe9a899e24a497) | `` gnuradioMinimal: 3.10.10.0 -> 3.10.11.0 ``                                         |
| [`381d63b9`](https://github.com/NixOS/nixpkgs/commit/381d63b9f856c7256d7a3b95bae8445be43dca78) | `` gnuradio{,3_9,3_8}: don't overuse with lib; in meta ``                             |
| [`573be242`](https://github.com/NixOS/nixpkgs/commit/573be242982f863718159ec2cb98444aaa46b142) | `` gnuradio: don't use confusing `with python.pkgs;` (in 1 place) ``                  |
| [`5b48a7c0`](https://github.com/NixOS/nixpkgs/commit/5b48a7c09a4bac4aa547bbaa1e54da4f49c59fc2) | `` gnuradio3_9: don't use confusing `with python.pkgs;` (in 1 place) ``               |
| [`09ecd173`](https://github.com/NixOS/nixpkgs/commit/09ecd173ec7e60275a8860da38f5e339ca823457) | `` gnuradio3_8: don't use confusing `with python.pkgs;` (in 1 place) ``               |
| [`38ae7bec`](https://github.com/NixOS/nixpkgs/commit/38ae7bec50686a7b59956f13eec6e71d19ac02ed) | `` python312Packages.pyfwup: 0.4.0 -> 0.5.0 ``                                        |
| [`bc3df8de`](https://github.com/NixOS/nixpkgs/commit/bc3df8de047d829b8a20e1589d2b881d692e585c) | `` python312Packages.hidapi: 0.14.0 -> 0.14.0.post2 ``                                |
| [`5947fd23`](https://github.com/NixOS/nixpkgs/commit/5947fd237644a0413a555b3067f074e99e9260eb) | `` sysdig: 0.38.0 -> 0.38.1 ``                                                        |
| [`58bae181`](https://github.com/NixOS/nixpkgs/commit/58bae1819e47fd9cfc6955871e31766f32e31c39) | `` sysdig: patch 'main.c' to fix build for 6.10-kernel ``                             |
| [`dffdc50d`](https://github.com/NixOS/nixpkgs/commit/dffdc50d992686f5cd5f43498f9cef30d8cf691f) | `` protonmail-desktop: nixfmt (rfc-style) ``                                          |
| [`b745525f`](https://github.com/NixOS/nixpkgs/commit/b745525fea4d8a7bd6d1ddf00fed8be25208ad45) | `` protonmail-desktop: 1.0.4 -> 1.0.5 ``                                              |
| [`72a0348a`](https://github.com/NixOS/nixpkgs/commit/72a0348acbb6fb79d778efc9cbed98aa407747e3) | `` python312Packages.strpdatetime: init at 0.3.0 ``                                   |
| [`21bf36dd`](https://github.com/NixOS/nixpkgs/commit/21bf36dd0038eecabe8f8180a1ec9e7dd3b1c9e0) | `` python312Packages.rich-theme-manager: init at 0.11.0 ``                            |
| [`d6572b7c`](https://github.com/NixOS/nixpkgs/commit/d6572b7c222a087236f56ddb4f19fb9d36dcaf5f) | `` python312Packages.bpylist2: init at 3.0.3 ``                                       |
| [`66264352`](https://github.com/NixOS/nixpkgs/commit/66264352960e9160fb8f8af56405fe32d8b4af46) | `` hextazy: 0.2 -> 0.4, update github owner (#327591) ``                              |
| [`31aa0736`](https://github.com/NixOS/nixpkgs/commit/31aa0736861eb1db54c7f82a0b0c76d37ef4da3c) | `` emacsPackages.youtube-dl: implement passthru.updateScript ``                       |
| [`bd9b636c`](https://github.com/NixOS/nixpkgs/commit/bd9b636c50928720249d6182e25297be22e1d3db) | `` emacsPackages.git-undo: implement passthru.updateScript ``                         |
| [`8957ac63`](https://github.com/NixOS/nixpkgs/commit/8957ac63a2d11dcb4e8c171b24b955cb1dfde1fa) | `` emacsPackages.evil-markdown: implement passthru.updateScript ``                    |
| [`b164b90c`](https://github.com/NixOS/nixpkgs/commit/b164b90ca69cbe408109f07336ed1eea6e19c0f2) | `` emacsPackages.isearch-prop: 0-unstable-2019-05-01 -> 0-unstable-2022-12-30 ``      |