### PR TITLE
chore(flake/nixvim): `162ae635` -> `59941a53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722016645,
-        "narHash": "sha256-YQA4oenJwjWVzX+we6Zzv08im5q2n7dVhJ12Nw8wQio=",
+        "lastModified": 1722111246,
+        "narHash": "sha256-5ikGEPb8oqup5tTWpvmC8V/ts9ss0VXsPNtlbz7IAYU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "162ae6354bbf2af5c33b09aa90e9d8d11f14462e",
+        "rev": "59941a5300b1b13d6aac0a5115c8fc5b955b5405",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`59941a53`](https://github.com/nix-community/nixvim/commit/59941a5300b1b13d6aac0a5115c8fc5b955b5405) | `` config-examples: fix typo ``       |
| [`686507a4`](https://github.com/nix-community/nixvim/commit/686507a4cb4e77643bcbabda260ee317e874d2f1) | `` config-examples: add khanelivim `` |