### PR TITLE
chore(flake/nixvim): `2089eb40` -> `8945b3b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722248209,
-        "narHash": "sha256-yYoxx5hVrI7JaiPy44sgnr5YIRXWY7ttNoN/l5fJOgI=",
+        "lastModified": 1722431209,
+        "narHash": "sha256-qBxvnoQuzhCHTej5JMw1EpjavufRgpMNP9klpO7mbI4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2089eb407d8c5dbd6ca6e93d4988a439ca6446fd",
+        "rev": "8945b3b5e336a42972448e2f07ed5bc465a40c83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`8945b3b5`](https://github.com/nix-community/nixvim/commit/8945b3b5e336a42972448e2f07ed5bc465a40c83) | `` flake/generate-files: fix `--commit` line count ``                          |
| [`9314cd46`](https://github.com/nix-community/nixvim/commit/9314cd46f0f1ff756bae1ae1718c116be894930d) | `` modules/performance: add ability to byte compile nvim runtime directory ``  |
| [`55ca9d23`](https://github.com/nix-community/nixvim/commit/55ca9d235b114353af7921076aa3fb7d0acd37f5) | `` modules/performance: add ability to byte compile lua plugins ``             |
| [`44849233`](https://github.com/nix-community/nixvim/commit/44849233e00811f319976a6c88bc76612067c8a1) | `` modules/performance: add ability to byte compile lua configuration files `` |
| [`17e89049`](https://github.com/nix-community/nixvim/commit/17e89049927e72b055e082464c1eabc8983791ac) | `` modules/performance: add `performance.byteCompileLua` option ``             |
| [`3789c696`](https://github.com/nix-community/nixvim/commit/3789c696584406fdfd5e9bfcc13d41c45ae5715c) | `` flake/generate-files: use nixfmt directly ``                                |
| [`0b23a4ce`](https://github.com/nix-community/nixvim/commit/0b23a4ce853d07985955b072dd8dc6ffd3c4bb68) | `` flake/generate-files: do all builds in one eval ``                          |
| [`fc8155b5`](https://github.com/nix-community/nixvim/commit/fc8155b5fab453c4a585a18cf1b1d9810ee97df7) | `` tests/generated: init by checking declared tools ``                         |
| [`a8eceddd`](https://github.com/nix-community/nixvim/commit/a8eceddd07f25a5eacec06b874b4c3af0cad24cc) | `` plugins/lsp/efmls: remove unused tool declarations ``                       |
| [`ee89f743`](https://github.com/nix-community/nixvim/commit/ee89f7437b48c4f2823facc0695428b33a85bc49) | `` typo ``                                                                     |