### PR TITLE
chore(flake/nixvim): `8945b3b5` -> `8024b044`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722119539,
-        "narHash": "sha256-2kU90liMle0vKR8exJx1XM4hZh9CdNgZGHCTbeA9yzY=",
+        "lastModified": 1722407237,
+        "narHash": "sha256-wcpVHUc2nBSSgOM7UJSpcRbyus4duREF31xlzHV5T+A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0240a064db3987eb4d5204cf2400bc4452d9922",
+        "rev": "58cef3796271aaeabaed98884d4abaab5d9d162d",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722431209,
-        "narHash": "sha256-qBxvnoQuzhCHTej5JMw1EpjavufRgpMNP9klpO7mbI4=",
+        "lastModified": 1722458167,
+        "narHash": "sha256-ri87zBCPf5EaMOvpjU+tx+LgIgVE7HeudjLfVAYSiqs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8945b3b5e336a42972448e2f07ed5bc465a40c83",
+        "rev": "8024b044d612a0aa354eafa6d111ddac56f097bd",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721769617,
-        "narHash": "sha256-6Pqa0bi5nV74IZcENKYRToRNM5obo1EQ+3ihtunJ014=",
+        "lastModified": 1722330636,
+        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8db8970be1fb8be9c845af7ebec53b699fe7e009",
+        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`8024b044`](https://github.com/nix-community/nixvim/commit/8024b044d612a0aa354eafa6d111ddac56f097bd) | `` tests/plugins/efmls: disable dmd test on x86_64-darwin ``          |
| [`5c149963`](https://github.com/nix-community/nixvim/commit/5c149963c03bbb45f63ff58e48c0af7e7418a34e) | `` tests/colorschemes/cyberdream: remove invalid attribute 'style' `` |
| [`fef6001b`](https://github.com/nix-community/nixvim/commit/fef6001b5db9ea4109683e09e6d948c92fee41a6) | `` flake.nix: devshell no longer uses flake-utils, unpin it ``        |
| [`1e761b11`](https://github.com/nix-community/nixvim/commit/1e761b11bc406b109a7f89abc5d544129dd30af0) | `` generated: Update ``                                               |
| [`3cd3913d`](https://github.com/nix-community/nixvim/commit/3cd3913d451e3f8b8c14944c49bcf17f05f738d2) | `` flake.lock: Update ``                                              |