### PR TITLE
chore(flake/nixvim): `8024b044` -> `820f8d58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722458167,
-        "narHash": "sha256-ri87zBCPf5EaMOvpjU+tx+LgIgVE7HeudjLfVAYSiqs=",
+        "lastModified": 1722492816,
+        "narHash": "sha256-aZe7oSm/+GM1whS6bxZy+DJgbcy8rDIkygBA0owCvmU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8024b044d612a0aa354eafa6d111ddac56f097bd",
+        "rev": "820f8d58eafd7121989fea3ae9e71f29699d856b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`820f8d58`](https://github.com/nix-community/nixvim/commit/820f8d58eafd7121989fea3ae9e71f29699d856b) | `` tests/otter: add treesitter to avoid warning ``                                                        |
| [`bae46eaf`](https://github.com/nix-community/nixvim/commit/bae46eafd1dce8568042cbdee6226b1f0325a969) | `` tests/cmp-all-sources: disable the otter source as it triggers a warning when treesitter is missing `` |