### PR TITLE
chore(flake/nixvim): `820f8d58` -> `7c39d77b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722492816,
-        "narHash": "sha256-aZe7oSm/+GM1whS6bxZy+DJgbcy8rDIkygBA0owCvmU=",
+        "lastModified": 1722531900,
+        "narHash": "sha256-COtoy+Y/j2QLX818mRI7BweRJOltf0bndxbps/eoH0s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "820f8d58eafd7121989fea3ae9e71f29699d856b",
+        "rev": "7c39d77b9f1fbcbd8f2a575c4f2948dd54efc5c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`7c39d77b`](https://github.com/nix-community/nixvim/commit/7c39d77b9f1fbcbd8f2a575c4f2948dd54efc5c1) | `` lib/helpers: scope each subsection, but offer aliases `` |
| [`bc84fda2`](https://github.com/nix-community/nixvim/commit/bc84fda2b8f7277f350f60000f31bad0676305e5) | `` lib/options: remove `with helpers` ``                    |