### PR TITLE
chore(flake/nixvim): `7c39d77b` -> `0bc16990`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722531900,
-        "narHash": "sha256-COtoy+Y/j2QLX818mRI7BweRJOltf0bndxbps/eoH0s=",
+        "lastModified": 1722605918,
+        "narHash": "sha256-eWVY6hM2IlxRIVUgKBlPCX4pJ1Nmh3Nvw/Io2LaE0Y4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7c39d77b9f1fbcbd8f2a575c4f2948dd54efc5c1",
+        "rev": "0bc169903705c94fda7934ecc27dd9038ad5f0e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`0bc16990`](https://github.com/nix-community/nixvim/commit/0bc169903705c94fda7934ecc27dd9038ad5f0e9) | `` docs: call `evalModules` in one place ``         |
| [`27c4c9c2`](https://github.com/nix-community/nixvim/commit/27c4c9c2105b6544fe3b88a3620430199ecdc953) | `` lib/modules: init with `specialArgs` helpers ``  |
| [`491ca5cf`](https://github.com/nix-community/nixvim/commit/491ca5cf51814c4b456eaac303510157136400da) | `` lib: provide an "extended lib" to our modules `` |