### PR TITLE
chore(flake/nixvim): `2f85c012` -> `6f7cf23b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722720144,
-        "narHash": "sha256-YWZGpQxrq1NjNNrCP/xyYKShzHpHrYM2ITsM5ObuK/g=",
+        "lastModified": 1722763580,
+        "narHash": "sha256-LgYIYkNYzqCldWJ/xJRQ156WDp6P9hHb4EsIXsRa+u4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2f85c012ced350ccdb84561c91fbf59b0838ee67",
+        "rev": "6f7cf23b226ceaee0a2d479c505652065dfe526f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`6f7cf23b`](https://github.com/nix-community/nixvim/commit/6f7cf23b226ceaee0a2d479c505652065dfe526f) | `` plugins/gitblame: completely drop helpers ``     |
| [`f38400d9`](https://github.com/nix-community/nixvim/commit/f38400d95978fba42adc8609ad4aa381f05a7535) | `` flake: disable `allow-import-from-derivation` `` |
| [`3d1224a0`](https://github.com/nix-community/nixvim/commit/3d1224a039d70098c78d263b0867352d95f2194b) | `` tests/modules/output: remove IFD ``              |