### PR TITLE
chore(flake/nixpkgs): `9f918d61` -> `d0495308`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -249,11 +249,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722421184,
-        "narHash": "sha256-/DJBI6trCeVnasdjUo9pbnodCLZcFqnVZiLUfqLH4jA=",
+        "lastModified": 1722630782,
+        "narHash": "sha256-hMyG9/WlUi0Ho9VkRrrez7SeNlDzLxalm9FwY7n/Noo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f918d616c5321ad374ae6cb5ea89c9e04bf3e58",
+        "rev": "d04953086551086b44b6f3c6b7eeb26294f207da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`57d30c7a`](https://github.com/NixOS/nixpkgs/commit/57d30c7a61d8fb3d8964a1f60c37f8f9c0b34a9c) | `` nixos/wg-quick: add generatePrivateKeyFile option (#331253) ``                  |
| [`12955826`](https://github.com/NixOS/nixpkgs/commit/129558261d9f1fb92c99f93ef259c698bc93db20) | `` buildkite-agent: 3.59.0 -> 3.76.1 (#331340) ``                                  |
| [`a18c10b8`](https://github.com/NixOS/nixpkgs/commit/a18c10b8c1dd6eeea5eaf413625de34044eb2356) | `` wavebox: 10.124.17-2 -> 10.127.10-2 (#324822) ``                                |
| [`a5952658`](https://github.com/NixOS/nixpkgs/commit/a595265893b36c0927d474fbb74d583538b5fcf5) | `` sttr: 0.2.22 -> 0.2.23 ``                                                       |
| [`49de6926`](https://github.com/NixOS/nixpkgs/commit/49de6926407dd583edaabcceed8b068be7fb0142) | `` python312Packages.weconnect: 0.60.3 -> 0.60.4 ``                                |
| [`7e6aa644`](https://github.com/NixOS/nixpkgs/commit/7e6aa6441a99d0bfe4caa39c1c1da35137ba8114) | `` jcli: migrate to by-name ``                                                     |
| [`2ccadf20`](https://github.com/NixOS/nixpkgs/commit/2ccadf206746c1f8cbeef6494035d9da5465f437) | `` jcli: install shell completions ``                                              |
| [`de2ebd24`](https://github.com/NixOS/nixpkgs/commit/de2ebd24b0b3659179206f25b008ca4aff27eab9) | `` restic-integrity: 1.3.0 -> 1.3.1 ``                                             |
| [`cc6fa17c`](https://github.com/NixOS/nixpkgs/commit/cc6fa17c0074790af5480d271960ede6c389dab5) | `` translatelocally-models: update ``                                              |
| [`956b068e`](https://github.com/NixOS/nixpkgs/commit/956b068eaf776ec937bf833cfecc30521db70a71) | `` translatelocally: unstable-2023-09-20 -> 0-unstable-2024-05-12 ``               |
| [`6fc72f65`](https://github.com/NixOS/nixpkgs/commit/6fc72f65d18c74a402673969a76aad5e585ee9d4) | `` translatelocally: enable wayland support ``                                     |
| [`8d8ab8ca`](https://github.com/NixOS/nixpkgs/commit/8d8ab8cabf3a297c2904e6297701bcaa93a73bb3) | `` python312Packages.patch-ng: 1.17.4 -> 1.18.0 ``                                 |
| [`7c908d40`](https://github.com/NixOS/nixpkgs/commit/7c908d40bb7eb6674e3e5edb672aef77bfee0b70) | `` gobgp: 3.28.0 -> 3.29.0 ``                                                      |
| [`e263600b`](https://github.com/NixOS/nixpkgs/commit/e263600b33b6de6245e642fab9b92bb2323b836e) | `` gobgpd: 3.28.0 -> 3.29.0 ``                                                     |
| [`6c1956f2`](https://github.com/NixOS/nixpkgs/commit/6c1956f2af1ea6a42996e29377c7defae69a9467) | `` wayneko: init at 0-unstable-2024-03-29 ``                                       |
| [`ab2c4b7a`](https://github.com/NixOS/nixpkgs/commit/ab2c4b7afbf747bce275e797474e257729189287) | `` ollama: update hash for 0.3.1 ``                                                |
| [`06b85385`](https://github.com/NixOS/nixpkgs/commit/06b853859ff5f26af9d2b93cb7aa18c51380b576) | `` kubectl-view-secret: 0.12.0 -> 0.12.1 ``                                        |
| [`300c7e6c`](https://github.com/NixOS/nixpkgs/commit/300c7e6cc380b03330070906e41d0d448521c076) | `` coldsnap: 0.6.1 -> 0.6.2 ``                                                     |
| [`861eee7e`](https://github.com/NixOS/nixpkgs/commit/861eee7e2b5a2dffe68b93082be6a43ad4aebc0d) | `` clickhouse-backup: 2.5.20 -> 2.5.21 ``                                          |
| [`9578e706`](https://github.com/NixOS/nixpkgs/commit/9578e7064f5fd8f33b9a5eb9d4168daa8d3b5b03) | `` python312Packages.airgradient: 0.7.0 -> 0.7.1 ``                                |
| [`91b406a0`](https://github.com/NixOS/nixpkgs/commit/91b406a073f91e4ce408053648997ef3b6b074d0) | `` nss_latest: 3.102.1 -> 3.103 ``                                                 |
| [`4ccb94d2`](https://github.com/NixOS/nixpkgs/commit/4ccb94d239ca55cc7d5a1833a64f20a494042023) | `` zigbee2mqtt: 1.39.0 -> 1.39.1 ``                                                |
| [`7d1134ba`](https://github.com/NixOS/nixpkgs/commit/7d1134ba7d46a730ad995b467804a8b310aeafaa) | `` spotify: 1.2.40.599.g606b7f29 -> 1.2.42.290.g242057a2 ``                        |
| [`0e33ef9a`](https://github.com/NixOS/nixpkgs/commit/0e33ef9a30ee0c717934dc82bf1e03c3568ab5d0) | `` werf: 2.8.0 -> 2.9.3 ``                                                         |
| [`8426bb23`](https://github.com/NixOS/nixpkgs/commit/8426bb23b4dac27dbae234b684f32e7bd0fa59b7) | `` libretro.dosbox-pure: unstable-2024-07-20 -> unstable-2024-08-01 ``             |
| [`06815290`](https://github.com/NixOS/nixpkgs/commit/06815290ce626fcdc142627a98e11ba75b6fdddd) | `` ffmpeg_7-full: Enable xev{d,e} on all Darwin system ``                          |
| [`cfa3e57c`](https://github.com/NixOS/nixpkgs/commit/cfa3e57cd9accf657ed8933295fc8717ad3d2476) | `` bitwarden-cli: 2024.7.1 -> 2024.7.2 ``                                          |
| [`e09e81ff`](https://github.com/NixOS/nixpkgs/commit/e09e81ff278d3cf070872e190a56023d4a4b86cf) | `` libretro.swanstation: unstable-2024-07-15 -> unstable-2024-07-24 ``             |
| [`119103de`](https://github.com/NixOS/nixpkgs/commit/119103deda9878a150e539975e0b3b31bc8326ec) | `` libretro.gambatte: unstable-2024-07-19 -> unstable-2024-07-26 ``                |
| [`e34f0306`](https://github.com/NixOS/nixpkgs/commit/e34f03060e394a7812d8a4b9ced35a4f8978bee4) | `` libretro.genesis-plus-gx: unstable-2024-07-20 -> unstable-2024-07-26 ``         |
| [`41c45172`](https://github.com/NixOS/nixpkgs/commit/41c4517239f357b7c7e99c332b5bec0ec2d6481c) | `` Revert "pebble: 2.4.0 -> 2.6.0 and fix version info" ``                         |
| [`befba320`](https://github.com/NixOS/nixpkgs/commit/befba32076c33e50320437a5a043bc5386fd0365) | `` libretro.flycast: unstable-2024-07-19 -> unstable-2024-07-29 ``                 |
| [`4c77c39e`](https://github.com/NixOS/nixpkgs/commit/4c77c39e127a1edb38d39f066ea736785df64a05) | `` libretro.bsnes: unstable-2024-07-19 -> unstable-2024-07-26 ``                   |
| [`8ea37d03`](https://github.com/NixOS/nixpkgs/commit/8ea37d03085f647e9d7220ca44499a534282405c) | `` libretro.atari800: unstable-2024-05-18 -> unstable-2024-07-25 ``                |
| [`d79b03a5`](https://github.com/NixOS/nixpkgs/commit/d79b03a59c448b31bef79fd156337cb2baae898d) | `` fix netboot image ``                                                            |
| [`3de47145`](https://github.com/NixOS/nixpkgs/commit/3de4714572e31844922990e05f2654d3c2b4a19f) | `` make-initrd-ng: also print json itself if it fails to parse ``                  |
| [`dbe537c0`](https://github.com/NixOS/nixpkgs/commit/dbe537c0c4f426a472879154e182f7b479008ac3) | `` powerpipe: 0.4.0 -> 0.4.1 ``                                                    |
| [`de65c45a`](https://github.com/NixOS/nixpkgs/commit/de65c45a4b8b491bc6217b4865e6c2c9199a3ade) | `` emscripten: pin to LLVM 19 ``                                                   |
| [`1cb3083b`](https://github.com/NixOS/nixpkgs/commit/1cb3083bb456b191a2c59769d54f2b34fd188adb) | `` rye: 0.37.0 -> 0.38.0 ``                                                        |
| [`aa1fde65`](https://github.com/NixOS/nixpkgs/commit/aa1fde65aff7f209ccaf3255e080e7458f06a56f) | `` avml: init at 0.14.0 ``                                                         |
| [`a0f9d3e7`](https://github.com/NixOS/nixpkgs/commit/a0f9d3e709152fdf5f1d83323f300fc2ee446853) | `` linux-wifi-hotspot: add johnrtitor as maintainer ``                             |
| [`8a1ea7dd`](https://github.com/NixOS/nixpkgs/commit/8a1ea7ddd1adc0ee6d61934945e6c6433bde8ec6) | `` linux-wifi-hotspot: move to pkgs/by-name ``                                     |
| [`0c019c4c`](https://github.com/NixOS/nixpkgs/commit/0c019c4ca6478c78fc5359e41e2a6e904e4a74dc) | `` linux-wifi-hotspot: format with nixfmt-rfc-style ``                             |
| [`1989ea18`](https://github.com/NixOS/nixpkgs/commit/1989ea1826e2748bac93d5e9fcb18fd94034a734) | `` libretro.fbneo: unstable-2024-07-12 -> unstable-2024-07-27 ``                   |
| [`066bc7b3`](https://github.com/NixOS/nixpkgs/commit/066bc7b35200244a198d5c80f9de4f6c56f0b06b) | `` micromdm: init at 1.12.1 ``                                                     |
| [`fc3190f6`](https://github.com/NixOS/nixpkgs/commit/fc3190f6f14df825ba50ed90019c67757bec0836) | `` libretro.ppsspp: unstable-2024-07-20 -> unstable-2024-07-29 ``                  |
| [`affaf77b`](https://github.com/NixOS/nixpkgs/commit/affaf77b398f56cbc62942fa8deeebf596a970e1) | `` libretro.mame2003-plus: unstable-2024-07-20 -> unstable-2024-07-28 ``           |
| [`770c5028`](https://github.com/NixOS/nixpkgs/commit/770c5028f938cb79c22342c7ee5aee71b03dae3a) | `` libretro.smsplus-gx: unstable-2024-07-20 -> unstable-2024-07-22 ``              |
| [`24e26f7a`](https://github.com/NixOS/nixpkgs/commit/24e26f7ade2bc390dda095beb4256854b8561bc0) | `` libretro.beetle-supergrafx: unstable-2024-06-28 -> unstable-2024-07-26 ``       |
| [`0a4a62d3`](https://github.com/NixOS/nixpkgs/commit/0a4a62d31d39ddb3f5e9287a60db65377c6b453f) | `` libretro.beetle-pce: unstable-2024-07-19 -> unstable-2024-07-26 ``              |
| [`1d14cfac`](https://github.com/NixOS/nixpkgs/commit/1d14cfac70c9d537ccb11ea66aec61e020c14740) | `` libretro.beetle-pce-fast: unstable-2024-07-19 -> unstable-2024-07-26 ``         |
| [`a94d03b0`](https://github.com/NixOS/nixpkgs/commit/a94d03b049b959ceecda040f6536128be293c50f) | `` libretro.stella: unstable-2024-06-30 -> unstable-2024-07-30 ``                  |
| [`3d50ff5d`](https://github.com/NixOS/nixpkgs/commit/3d50ff5d5ebcfeac31cc29157b4970fc9f7f2916) | `` libretro.pcsx-rearmed: unstable-2024-07-16 -> unstable-2024-07-24 ``            |
| [`09a8321a`](https://github.com/NixOS/nixpkgs/commit/09a8321a0d0b9f290ba16f7dbc65d45fae4d50b1) | `` libretro.beetle-psx-hw: unstable-2024-07-19 -> unstable-2024-07-26 ``           |
| [`71c908fd`](https://github.com/NixOS/nixpkgs/commit/71c908fdddcb697172019a18be2f5156f111bd49) | `` libretro.snes9x: unstable-2024-07-14 -> unstable-2024-07-29 ``                  |
| [`c8db5787`](https://github.com/NixOS/nixpkgs/commit/c8db5787109b6c082866c63fac9a0bd486474c93) | `` ocamlPackages.digestif: 1.1.4 → 1.2.0 ``                                        |
| [`08aff56c`](https://github.com/NixOS/nixpkgs/commit/08aff56c8004a09e378121f875d59ca621fa7017) | `` libretro.play: unstable-2024-07-19 -> unstable-2024-07-29 ``                    |
| [`bba5e3f4`](https://github.com/NixOS/nixpkgs/commit/bba5e3f4e0cb6937a214fbf8f1fd0b1ec4d136f1) | `` python312Packages.rioxarray: extend disabled failing tests to aarch64-darwin `` |
| [`814b1e82`](https://github.com/NixOS/nixpkgs/commit/814b1e820ab861c880a011bc8118882f252d16a1) | `` biome: 1.8.1 -> 1.8.3 ``                                                        |
| [`32c4daf0`](https://github.com/NixOS/nixpkgs/commit/32c4daf047f25348d80eca559dc054278f3a1493) | `` python312Packages.wagtail: 6.1.3 -> 6.2 ``                                      |
| [`b2e490a5`](https://github.com/NixOS/nixpkgs/commit/b2e490a586b0270c2994ce885b9018aa88084b4d) | `` python312Packages.yolink-api: 0.4.5 -> 0.4.6 ``                                 |
| [`a9e94032`](https://github.com/NixOS/nixpkgs/commit/a9e94032782cc6f89c5fabcf5d9433b45578cad1) | `` vmagent: 1.102.0 -> 1.102.1 ``                                                  |
| [`58c53477`](https://github.com/NixOS/nixpkgs/commit/58c534774a82a62394bf1c401ae70b9f5268d8c8) | `` python312Packages.plantuml-markdown: 3.9.8 -> 3.10.0 ``                         |
| [`dd3d68af`](https://github.com/NixOS/nixpkgs/commit/dd3d68af7c97d8ee42d18c4e4cf579d687ccf74e) | `` python312Packages.asteval: 1.0.1 -> 1.0.2 ``                                    |
| [`8062f55e`](https://github.com/NixOS/nixpkgs/commit/8062f55e7ea3eee2049aa9a3bddc6f3c4aa1a5de) | `` python312Packages.pyinstrument: 4.6.0 -> 4.7.0 ``                               |
| [`73cf5e40`](https://github.com/NixOS/nixpkgs/commit/73cf5e4073bb95a4016123b960dcd2a0bc17dafc) | `` cri-o-unwrapped: 1.30.3 -> 1.30.4 ``                                            |
| [`d0d88e73`](https://github.com/NixOS/nixpkgs/commit/d0d88e7376df237ac89b9a43293fcbb9cf19d263) | `` spire: 1.10.0 -> 1.10.1 ``                                                      |
| [`bbb9f070`](https://github.com/NixOS/nixpkgs/commit/bbb9f070f6493e939ce2ed501fb32c448a683829) | `` gotify-cli: 2.2.4 -> 2.3.2 ``                                                   |
| [`be324846`](https://github.com/NixOS/nixpkgs/commit/be32484672e66f8356daea9806b08923c78ae649) | `` oxker: 0.6.4 -> 0.7.0 ``                                                        |
| [`00a6ef35`](https://github.com/NixOS/nixpkgs/commit/00a6ef358ae4a46735955626cd7a707ab82be707) | `` txtpbfmt: 0-unstable-2024-04-16 -> 0-unstable-2024-06-11 ``                     |
| [`b93ae5ca`](https://github.com/NixOS/nixpkgs/commit/b93ae5ca502e62d26ced54d42717ee4d5496d9a7) | `` ctlptl: 0.8.29 -> 0.8.30 ``                                                     |
| [`db33d1e6`](https://github.com/NixOS/nixpkgs/commit/db33d1e689ea5af55825df4ce1c03eba7bc0c4ff) | `` stirling-pdf: 0.25.1 -> 0.26.1 ``                                               |
| [`2f3e77e1`](https://github.com/NixOS/nixpkgs/commit/2f3e77e1f28336e8446168d521e20aeded6b98fe) | `` kakoune: add philiptaron as maintainer to most kakoune-related things ``        |
| [`64a5d559`](https://github.com/NixOS/nixpkgs/commit/64a5d55941360967cd3991381c7b566e59faeb46) | `` pythonPackages.abjad: mark disabled for Python 3.12 ``                          |
| [`9c3ca939`](https://github.com/NixOS/nixpkgs/commit/9c3ca939a8d36edabeed0148e37f95888b947fd2) | `` snyk: 1.1292.1 -> 1.1292.2 ``                                                   |
| [`0dbf5b7b`](https://github.com/NixOS/nixpkgs/commit/0dbf5b7b90b8af129895b6b9ffef12019fea8ee6) | `` processing: fix build ``                                                        |
| [`2570854a`](https://github.com/NixOS/nixpkgs/commit/2570854a2a5a1dac7c5f2d1b4316797831c558c8) | `` processing: format with nixfmt ``                                               |
| [`4ec6a07a`](https://github.com/NixOS/nixpkgs/commit/4ec6a07ad35b17e084b032f208782c32d4d00046) | `` newsflash: 3.3.0 -> 3.3.2 ``                                                    |
| [`25d11dfb`](https://github.com/NixOS/nixpkgs/commit/25d11dfb27b1f2f24f6b87e12d68f0a9e2fe7205) | `` python312Packages.sse-starlette: 2.1.2 -> 2.1.3 ``                              |
| [`0793d3ec`](https://github.com/NixOS/nixpkgs/commit/0793d3ec355fb761a9164b58aba2535117d03436) | `` harvid: fix on Darwin ``                                                        |
| [`9075e930`](https://github.com/NixOS/nixpkgs/commit/9075e930bb3df8ac97a2598ea18a2a767994ff41) | `` python312Packages.xdoctest: 1.1.5 -> 1.1.6 ``                                   |
| [`9eb2dbb7`](https://github.com/NixOS/nixpkgs/commit/9eb2dbb737084d854b62992cf817277584b7e84d) | `` vscode: 1.91.1 -> 1.92.0 ``                                                     |
| [`6c6085f2`](https://github.com/NixOS/nixpkgs/commit/6c6085f2c22f8fbd90a3d3ce127e9f05bd5c91c3) | `` woodpecker: fix typo in shebang and missing text in warning ``                  |
| [`8b4cd01f`](https://github.com/NixOS/nixpkgs/commit/8b4cd01f9081b08b8ad8ca5d7b6938ae4c460cd1) | `` nixos/networkd: allow specifying FirewallMark mask ``                           |
| [`fc662c6f`](https://github.com/NixOS/nixpkgs/commit/fc662c6f93c26bf41b00f233b9d206d57f406f0e) | `` graphite-cli: 1.3.10 -> 1.4.1 ``                                                |
| [`6ae6635e`](https://github.com/NixOS/nixpkgs/commit/6ae6635e54f64b20c3ba6ce4ddd7a941156a4cdb) | `` zed-editor: 0.146.3 -> 0.146.4 ``                                               |