### PR TITLE
chore(flake/nixvim): `6f7cf23b` -> `4d6d3bd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722763580,
-        "narHash": "sha256-LgYIYkNYzqCldWJ/xJRQ156WDp6P9hHb4EsIXsRa+u4=",
+        "lastModified": 1722837994,
+        "narHash": "sha256-WyLnA63P///8gUYCNW8OBrLxTOcVCtcjlPDGTCzFdR4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6f7cf23b226ceaee0a2d479c505652065dfe526f",
+        "rev": "4d6d3bd722520ab26b924210a25f67117afb1747",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`4d6d3bd7`](https://github.com/nix-community/nixvim/commit/4d6d3bd722520ab26b924210a25f67117afb1747) | `` plugins/spectre: set freeformType for engine options ``                          |
| [`0f781787`](https://github.com/nix-community/nixvim/commit/0f7817876adc5382cd2a42c5e5b9d14a928d8022) | `` plugins/luasnip: add tests ``                                                    |
| [`25da1220`](https://github.com/nix-community/nixvim/commit/25da1220ad977cd88445a055facadb4616fc9d0e) | `` plugins/luasnip: rename extraConfig to settings (more consistent with RFC-42) `` |