### PR TITLE
chore(flake/pre-commit-hooks): `f451c193` -> `06939f6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1722857853,
+        "narHash": "sha256-3Zx53oz/MSIyevuWO/SumxABkrIvojnB7g9cimxkhiE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "06939f6b7ec4d4f465bf3132a05367cccbbf64da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`54ac8605`](https://github.com/cachix/git-hooks.nix/commit/54ac86058e30d476ae0ff4c428d40a8c3eb2581e) | `` fix: change ruff format hook name ``    |
| [`2d366523`](https://github.com/cachix/git-hooks.nix/commit/2d366523b68afee27c0ddb40cd0f46c7c51ef563) | `` docs: add ruff-format to python list `` |
| [`509f5059`](https://github.com/cachix/git-hooks.nix/commit/509f50596bd654cbf4c124589d3a608879978341) | `` feat: add ruff-format ``                |