### PR TITLE
chore(flake/nixvim): `4d6d3bd7` -> `5922a480`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722837994,
-        "narHash": "sha256-WyLnA63P///8gUYCNW8OBrLxTOcVCtcjlPDGTCzFdR4=",
+        "lastModified": 1722857280,
+        "narHash": "sha256-b5Bal3cElLrS9UtDN81ljQpOsbqBe/7CdWlTKhlswus=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4d6d3bd722520ab26b924210a25f67117afb1747",
+        "rev": "5922a48008e5759acb63a12b2de8348ec512760f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`5922a480`](https://github.com/nix-community/nixvim/commit/5922a48008e5759acb63a12b2de8348ec512760f) | `` plugins/luasnip: add filetypeExtend option `` |
| [`c0a8bfcc`](https://github.com/nix-community/nixvim/commit/c0a8bfcc525dbf2aec81694d524d1b11464b48b2) | `` Make url in doc link ``                       |