### PR TITLE
chore(flake/nixvim): `e48ce785` -> `c9a855fe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1722925425,
-        "narHash": "sha256-BXUYNBaG5KF+h8aU7p/4HUxGK1G42Ji/GK+KkC3bntU=",
+        "lastModified": 1722996297,
+        "narHash": "sha256-DgRM/DK9XScK0ArrEwHvWt9i5m92hPm3QuO19UZY/tM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e48ce785d9e72c0106319d93e23c5579336ffe33",
+        "rev": "c9a855fe680a62ed25d848d5a8f80cb5479cd0ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`c9a855fe`](https://github.com/nix-community/nixvim/commit/c9a855fe680a62ed25d848d5a8f80cb5479cd0ae) | `` plugins/nvim-snippets: init `` |
| [`6c1e8767`](https://github.com/nix-community/nixvim/commit/6c1e87676c374b91f1cadd77a94b857a92e7582b) | `` maintainers: add psfloyd ``    |