### PR TITLE
chore(flake/nixvim): `593f5215` -> `1b135ded`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1723064649,
-        "narHash": "sha256-J7p/kv0GHAnvg2HH3vJ3JVz1LEzCtdhcH0prmdYfRog=",
+        "lastModified": 1723123215,
+        "narHash": "sha256-PZbdO1N8zpmkFsGWk3rLUal/TnpqAXgItsIj6IUCswY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "593f5215cb1df010451675c19f2ad5c5481ccee3",
+        "rev": "1b135dedc4b6256faad9dae2f625e821425a60dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`1b135ded`](https://github.com/nix-community/nixvim/commit/1b135dedc4b6256faad9dae2f625e821425a60dd) | `` plugins/neotest: add neotest-golang `` |
| [`78abafe2`](https://github.com/nix-community/nixvim/commit/78abafe280b1ea102fda879799b590da5d84725f) | `` plugins/lz-n: init ``                  |