### PR TITLE
chore(flake/nixvim): `1b135ded` -> `fab51138`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1723123215,
-        "narHash": "sha256-PZbdO1N8zpmkFsGWk3rLUal/TnpqAXgItsIj6IUCswY=",
+        "lastModified": 1723156179,
+        "narHash": "sha256-rqdhRPPtxi/Mi73YC5mz/XAi/r8AJfH0Smhz6ZeS2nI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1b135dedc4b6256faad9dae2f625e821425a60dd",
+        "rev": "fab51138b7f8d2196b359d1a0986eaf0b69a9b9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`fab51138`](https://github.com/nix-community/nixvim/commit/fab51138b7f8d2196b359d1a0986eaf0b69a9b9e) | `` plugins/lsp/bufls: init ``                      |
| [`1adbf119`](https://github.com/nix-community/nixvim/commit/1adbf11900ff11e3d2c4cf9473a8aba23225a50a) | `` plugins/which-key: migrate to mkNeovimPlugin `` |