### PR TITLE
chore(flake/nixvim): `fab51138` -> `4852f94f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1723156179,
-        "narHash": "sha256-rqdhRPPtxi/Mi73YC5mz/XAi/r8AJfH0Smhz6ZeS2nI=",
+        "lastModified": 1723230145,
+        "narHash": "sha256-FyjcuYZMqXdiKOXkHaIC2ubag+TPV9Z12urC/sdVI6A=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "fab51138b7f8d2196b359d1a0986eaf0b69a9b9e",
+        "rev": "4852f94f8ccae551514df0092a077014bafb95ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`4852f94f`](https://github.com/nix-community/nixvim/commit/4852f94f8ccae551514df0092a077014bafb95ca) | `` plugins/yazi: init ``                                       |
| [`c46bd820`](https://github.com/nix-community/nixvim/commit/c46bd820adabaf23acbccbbd226b1941566acb51) | `` plugins/firenvim: fix aliasing `settings` into `globals` `` |