### PR TITLE
chore(flake/nixvim): `f823d010` -> `4eb2ad7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1723460395,
-        "narHash": "sha256-KxPw+HVYphxCEnkE/KicgY46WlggCZH0HRSDNJPlpbk=",
+        "lastModified": 1723591559,
+        "narHash": "sha256-zHipVBLNpHrynWD/HejkKXV+c4uXGvPR9q4qaEeyC3M=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f823d01002acd7e1adab01680e42e31b8edc50f5",
+        "rev": "4eb2ad7db7ff0cb76a296b5af23b072418ad5be7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`4eb2ad7d`](https://github.com/nix-community/nixvim/commit/4eb2ad7db7ff0cb76a296b5af23b072418ad5be7) | `` lib/lua: support nixpkg's "lua-inline" type ``                              |
| [`dbf6f7bc`](https://github.com/nix-community/nixvim/commit/dbf6f7bc997dc3a9ab1f014ea075600357226950) | `` update-script/rust-analyzer: Filter out headers from option descriptions `` |
| [`ad704ddb`](https://github.com/nix-community/nixvim/commit/ad704ddba70415a982a686257563609c25a22101) | `` generated,rust-analyzer: Handle objects with defined properties ``          |