### PR TITLE
chore(flake/nixvim): `4eb2ad7d` -> `cb398ce4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1723591559,
-        "narHash": "sha256-zHipVBLNpHrynWD/HejkKXV+c4uXGvPR9q4qaEeyC3M=",
+        "lastModified": 1723634417,
+        "narHash": "sha256-5M5fjJn02iOZN5z3zM/95l28kC0zjKCkId5JJ9J63fE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4eb2ad7db7ff0cb76a296b5af23b072418ad5be7",
+        "rev": "cb398ce4ba243c7a3a8d1fbfea1b56a44de6b3c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`cb398ce4`](https://github.com/nix-community/nixvim/commit/cb398ce4ba243c7a3a8d1fbfea1b56a44de6b3c9) | `` plugins/bufferline: migrate to mkNeovimPlugin ``                     |
| [`db4c4e5b`](https://github.com/nix-community/nixvim/commit/db4c4e5b1707f334a3e11530cb253d2f41051a3f) | `` lib/deprecation: expose `mkSettingsRenamedOptionModules` publicly `` |
| [`e3ec1c4a`](https://github.com/nix-community/nixvim/commit/e3ec1c4a468f046595d0d3657b3bab5f00d776ff) | `` plugins/which-key: move listOfLen to lib.types ``                    |