### PR TITLE
chore(flake/nixvim): `78fc4be6` -> `7a11b66f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1723923888,
-        "narHash": "sha256-w+/PG6KqB8en0x1JH5aMuf0QC78Nfei208EaaaRuYG4=",
+        "lastModified": 1724017104,
+        "narHash": "sha256-1pMyOYqBx7L/w1I/HEa8L01Wx7mZH3QrhDk/8XvDSSw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "78fc4be6a830e8dc01f3e66ddbe3243b4bfe8560",
+        "rev": "7a11b66f11d292b59571dad85fd1501dbd9bd0c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`7a11b66f`](https://github.com/nix-community/nixvim/commit/7a11b66f11d292b59571dad85fd1501dbd9bd0c1) | `` lib/keymap: allow extra options/modules in `mkMapOptionSubmodule` ``              |
| [`7fb1f9dd`](https://github.com/nix-community/nixvim/commit/7fb1f9dd9de4e94cb80f18d12e140e7cd5977183) | `` modules/keymap: improve `lua` deprecation ``                                      |
| [`c52ba678`](https://github.com/nix-community/nixvim/commit/c52ba6785661f095221aa1e1eb24f57e89d7b2de) | `` Revert "tests: Allow to test multiple derivations in a single test derivation" `` |
| [`9688ef72`](https://github.com/nix-community/nixvim/commit/9688ef723f53cdc62506a86981359a4bc8421716) | `` tests: use a link-farm again, but only per-file ``                                |
| [`379ae77a`](https://github.com/nix-community/nixvim/commit/379ae77a76ba2818b0c7876e97636f7064b84db6) | `` plugins/todo-comments: migrate to mkNeovimPlugin ``                               |