### PR TITLE
chore(flake/nixvim): `7a11b66f` -> `312db6b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724017104,
-        "narHash": "sha256-1pMyOYqBx7L/w1I/HEa8L01Wx7mZH3QrhDk/8XvDSSw=",
+        "lastModified": 1724036242,
+        "narHash": "sha256-/+gGF0tsAg2dF7Ds9Yt9Sne7ETmILKz1QVnDr+T2S2g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7a11b66f11d292b59571dad85fd1501dbd9bd0c1",
+        "rev": "312db6b6e2d98dd8d22223fe383c7e0b4bab60c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`312db6b6`](https://github.com/nix-community/nixvim/commit/312db6b6e2d98dd8d22223fe383c7e0b4bab60c6) | `` flake-modules/devshell: update tests command with link-farm support `` |
| [`69c2fa86`](https://github.com/nix-community/nixvim/commit/69c2fa866ea6c63ef85333f1ece96ffe58327547) | `` tests: group tests by 10 ``                                            |
| [`8f99c395`](https://github.com/nix-community/nixvim/commit/8f99c3953c6bea7b23ec04c60a658dd11ea8bdb4) | `` lib/util: add `groupListBySize` ``                                     |
| [`693e749e`](https://github.com/nix-community/nixvim/commit/693e749edbea55b8dc8f422ebe3b623f7bf61dd7) | `` tests/lib-test: correctly print expected/result ``                     |