### PR TITLE
chore(flake/nixpkgs): `c3aa7b89` -> `c374d94f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -249,11 +249,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "lastModified": 1724224976,
+        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`c374d94f`](https://github.com/NixOS/nixpkgs/commit/c374d94f1536013ca8e92341b540eba4c22f9c62) | `` pt2-clone: 1.69.2 -> 1.70 ``                                                 |
| [`e17cc248`](https://github.com/NixOS/nixpkgs/commit/e17cc248e778b811c8e64151116b72a317f71259) | `` organicmaps: 2024.07.29-2 -> 2024.08.16-5 ``                                 |
| [`286305c1`](https://github.com/NixOS/nixpkgs/commit/286305c13488847d9f13ec983e1921f2f35c923c) | `` hydra_unstable: 2024-07-09 -> 2024-08-20 ``                                  |
| [`ad8d3bf7`](https://github.com/NixOS/nixpkgs/commit/ad8d3bf7f5748a6b9abf4751cc5adac3c8330d39) | `` terraform: 1.9.4 -> 1.9.5 ``                                                 |
| [`706ad5f1`](https://github.com/NixOS/nixpkgs/commit/706ad5f180c61732f35b918ca82e435d4d13ed85) | `` syft: 1.11.0 -> 1.11.1 ``                                                    |
| [`908882d4`](https://github.com/NixOS/nixpkgs/commit/908882d485cc7e910fba6de9d802ac07d438ef16) | `` gh: 2.54.0 -> 2.55.0 ``                                                      |
| [`945f7bc1`](https://github.com/NixOS/nixpkgs/commit/945f7bc19e3cd012d51b02f0d98d22412d485b6f) | `` python312Packages.pyomo: 6.7.3 -> 6.8.0 ``                                   |
| [`95dc1d6a`](https://github.com/NixOS/nixpkgs/commit/95dc1d6afc26ff60c77661ced10e37bbede5f22b) | `` python312Packages.apycula: 0.12 -> 0.13 ``                                   |
| [`94c9be25`](https://github.com/NixOS/nixpkgs/commit/94c9be259dc780eff78cd82a5c5e6ee7baa16296) | `` gamemode: 1.8.1 -> 1.8.2 ``                                                  |
| [`6c289736`](https://github.com/NixOS/nixpkgs/commit/6c28973683417f384313814cb4e308906d593929) | `` codux: 15.32.0 -> 15.33.0 ``                                                 |
| [`f20b4e15`](https://github.com/NixOS/nixpkgs/commit/f20b4e15f7a66fa9c9526748b2445bd73707c1e0) | `` Revert "bun: 1.1.20 -> 1.1.24" ``                                            |
| [`15d89da4`](https://github.com/NixOS/nixpkgs/commit/15d89da46aa1c80facec4319e3b3e767f1dac315) | `` asn: 0.77.0 -> 0.78.0 ``                                                     |
| [`3a831099`](https://github.com/NixOS/nixpkgs/commit/3a831099452985732c8725c6b693bb0f93522294) | `` treewide: change `${pname}` to string literal, pt2 (#336195) ``              |
| [`09b3126d`](https://github.com/NixOS/nixpkgs/commit/09b3126d1f18a2405ec6814c5b369b4ecd9f83e7) | `` buildMozillaMach: backport patches to fix explicit sync on nvidia gpus ``    |
| [`3ea1895a`](https://github.com/NixOS/nixpkgs/commit/3ea1895a743223c7f4c2a0616a8d3709f8c55685) | `` buildMozillaMach: backport cbindgen 0.27.0 compat ``                         |
| [`a7ca8656`](https://github.com/NixOS/nixpkgs/commit/a7ca8656884bf103b5dbab8d89b34cc53fbdd273) | `` buildMozillaMach: prune patches ``                                           |
| [`9077add2`](https://github.com/NixOS/nixpkgs/commit/9077add27c1bf96fb48cae368964890a97d7a9fa) | `` wdt: 1.27.1612021-unstable-2024-06-26 -> 1.27.1612021-unstable-2024-08-14 `` |
| [`2ba03a63`](https://github.com/NixOS/nixpkgs/commit/2ba03a6384d87afc525402a3f66e15abd2a78e66) | `` civo: 1.0.88 -> 1.0.89 ``                                                    |
| [`7de6ca1d`](https://github.com/NixOS/nixpkgs/commit/7de6ca1d76cf26b08ed58215ee7d461a4dfa1d46) | `` typstyle: 0.11.31 -> 0.11.32 ``                                              |
| [`fcdecc25`](https://github.com/NixOS/nixpkgs/commit/fcdecc256adcdf46ec77d26f60421c8dcfa69fcc) | `` treewide: change `${pname}` to string literal (#336172) ``                   |
| [`e55ca537`](https://github.com/NixOS/nixpkgs/commit/e55ca5377613a8c251b3db32a3a676ee7341eab2) | `` oven-media-engine: add Arch patch for FFmpeg 7 ``                            |
| [`d2f3b99a`](https://github.com/NixOS/nixpkgs/commit/d2f3b99a6b7b74a6fecaac280d88ecb4b5b28c5a) | `` luaPackages.lz.n: 1.4.4 -> 2.0.0 ``                                          |
| [`330d94ee`](https://github.com/NixOS/nixpkgs/commit/330d94ee5a0eec31f129f7b110f17167bcbd74a0) | `` python312Packages.qtile-extras: disable flaky test ``                        |
| [`b1b5f190`](https://github.com/NixOS/nixpkgs/commit/b1b5f1905e16cf0f948c718f1fc7c14e567a5aa4) | `` golangci-lint: 1.60.1 -> 1.60.2 ``                                           |
| [`c9dd6079`](https://github.com/NixOS/nixpkgs/commit/c9dd6079083c2836cfc58ca4167c2ac30198b2f1) | `` python312Packages.py-nextbusnext: 2.0.4 -> 2.0.5 ``                          |
| [`728a5e58`](https://github.com/NixOS/nixpkgs/commit/728a5e58a400be05eef89563459abc2880fb2a8f) | `` snappymail: 2.36.4 -> 2.37.2 ``                                              |
| [`8031eccf`](https://github.com/NixOS/nixpkgs/commit/8031eccf5c0d2489817eb76e6e7ba83773b70736) | `` uv: 0.2.37 -> 0.3.0 ``                                                       |
| [`ad938385`](https://github.com/NixOS/nixpkgs/commit/ad938385453836eba5829f8cbec458e57c846899) | `` python312Packages.homeassistant-stubs: 2024.8.1 -> 2024.8.2 ``               |
| [`f351a043`](https://github.com/NixOS/nixpkgs/commit/f351a043b913607cd5cfed0e7fa99078f7bad5ed) | `` Revert "auth0-cli: 1.4.0 -> 1.5.0" ``                                        |
| [`dc7379e0`](https://github.com/NixOS/nixpkgs/commit/dc7379e04f7fa74da6a19364994467e94db61381) | `` nixos/ups: restart upsdrv.service on config changes ``                       |
| [`9f58544a`](https://github.com/NixOS/nixpkgs/commit/9f58544a2573ae0aca6c7231a44626d5114515a6) | `` Revert "thorium-browser: init at 120.0.6099.235" ``                          |
| [`40024302`](https://github.com/NixOS/nixpkgs/commit/40024302ff08fec4afd2ea92557b0b723fa8e95b) | `` zed-editor: 0.148.1 -> 0.149.3 ``                                            |
| [`21ce51cc`](https://github.com/NixOS/nixpkgs/commit/21ce51cca3b612024cc9653eecf58b589894b24a) | `` phpactor: switch to `buildComposerProject2` ``                               |
| [`711c7c82`](https://github.com/NixOS/nixpkgs/commit/711c7c827f9a2d1f844bced7ea53213c3f4a2271) | `` python312Packages.withings-sync: refactor ``                                 |
| [`cc3c7ed9`](https://github.com/NixOS/nixpkgs/commit/cc3c7ed91d6dd246ed9a44f108281a75e4d3daf0) | `` python312Packages.qbittorrent-api: 2024.7.64 -> 2024.8.65 ``                 |
| [`845e89f3`](https://github.com/NixOS/nixpkgs/commit/845e89f31d35c6a5bfcdf40aea11574d5ca54276) | `` rasm: 2.2.5 -> 2.2.6 ``                                                      |
| [`bceb4c8c`](https://github.com/NixOS/nixpkgs/commit/bceb4c8c8cfe1ee710c729d5411d6cdb9514f0c8) | `` php.packages.deployer: switch to `buildComposerProject2` ``                  |
| [`6315afab`](https://github.com/NixOS/nixpkgs/commit/6315afab1b8ed70c6a80e017d5c5a483ccb5c6fc) | `` php.packages.castor: switch to `buildComposerProject2` ``                    |
| [`15ef46e1`](https://github.com/NixOS/nixpkgs/commit/15ef46e148d036bc1e131a1ff7c81031d5c4a6d0) | `` python312Packages.sismic: init at 1.6.6 ``                                   |
| [`08d4eb09`](https://github.com/NixOS/nixpkgs/commit/08d4eb0924a7bcb352c717cd310075d906924c4d) | `` gitlab-container-registry: 4.6.0 -> 4.7.0 ``                                 |
| [`a4ea8e70`](https://github.com/NixOS/nixpkgs/commit/a4ea8e7033e1bd234f2552790e0b987f4507aac7) | `` gitlab: 17.2.1 -> 17.2.2 ``                                                  |
| [`e81c8b13`](https://github.com/NixOS/nixpkgs/commit/e81c8b13bfd27afac2602ae656b467185f3221e1) | `` gitlab: 17.2.0 -> 17.2.1 ``                                                  |
| [`628f796c`](https://github.com/NixOS/nixpkgs/commit/628f796c5a22b111b0b96957f078fb78ac0cbe7d) | `` python312Packages.withings-sync: 4.2.4 -> 4.2.5 ``                           |
| [`8e8472a8`](https://github.com/NixOS/nixpkgs/commit/8e8472a8e0f9700939617239e35100ea0f307bed) | `` python312Packages.meilisearch: 0.31.4 -> 0.31.5 ``                           |
| [`80f5ff18`](https://github.com/NixOS/nixpkgs/commit/80f5ff1862a8f9f29abf751ad7adb4b2711d1c13) | `` python312Packages.blebox-uniapi: 2.4.2 -> 2.5.0 ``                           |
| [`6bd20c45`](https://github.com/NixOS/nixpkgs/commit/6bd20c45887f2bb347c592e3a16616140cd52f84) | `` python312Packages.aiolifx: 1.0.6 -> 1.0.8 ``                                 |
| [`e3b1986b`](https://github.com/NixOS/nixpkgs/commit/e3b1986b0b18bdb0729bc821da735d6883b572ed) | `` qdiskinfo: change pname to lowercase ``                                      |
| [`f39985a8`](https://github.com/NixOS/nixpkgs/commit/f39985a8bd199607272e437bd39dc15e7b305ed1) | `` pylyzer: 0.0.59 -> 0.0.61 ``                                                 |
| [`0669be90`](https://github.com/NixOS/nixpkgs/commit/0669be90824575c6dde136f52032538b6ae19a69) | `` nixVersions.nix_2_24: 2.24.2 -> 2.24.3 ``                                    |
| [`31d6f780`](https://github.com/NixOS/nixpkgs/commit/31d6f7806b07b235f34f835ce178e065af140d53) | `` maintainers: update information for e1mo ``                                  |
| [`8fb69d99`](https://github.com/NixOS/nixpkgs/commit/8fb69d99c0d34f479096613440895367a05cc8eb) | `` zed-editor: disable auto-updates ``                                          |
| [`de456377`](https://github.com/NixOS/nixpkgs/commit/de456377fe524480d8318233cef5e1f250a7f4d5) | `` mdbook-d2: 0.3.0 -> 0.3.1 ``                                                 |
| [`20a57578`](https://github.com/NixOS/nixpkgs/commit/20a57578242cb89dfe1f145da12920c150bc1835) | `` element-desktop: 1.11.74 -> 1.11.75 ``                                       |
| [`1693e372`](https://github.com/NixOS/nixpkgs/commit/1693e37254ac5717f14bdef6b842449812e44794) | `` helm-ls: 0.0.20 -> 0.0.21 ``                                                 |
| [`9f14bbaf`](https://github.com/NixOS/nixpkgs/commit/9f14bbaf957c5e56d68f866b3725d246d2a002d3) | `` firefox-bin-unwrapped: 129.0.1 -> 129.0.2 ``                                 |
| [`1014b836`](https://github.com/NixOS/nixpkgs/commit/1014b8361377cd381b5d14da1d7d67d375f731b3) | `` firefox-unwrapped: 129.0.1 -> 129.0.2 ``                                     |
| [`b3a97d4e`](https://github.com/NixOS/nixpkgs/commit/b3a97d4e1fe197b5ce864fe01ea08f886a07f545) | `` coqPackages.compcert: use external MenhirLib ``                              |
| [`5a3fe0fa`](https://github.com/NixOS/nixpkgs/commit/5a3fe0fa465717c02234d4b06842acc66efd0005) | `` coqPackages.MenhirLib: init at 20240715 ``                                   |
| [`7995a227`](https://github.com/NixOS/nixpkgs/commit/7995a227735997e12c1caef72dbc370ee6d8a288) | `` dmenu-rs: 5.5.3 -> 5.5.4 ``                                                  |
| [`ce825ce2`](https://github.com/NixOS/nixpkgs/commit/ce825ce25ddf283961424c294cace737578036fa) | `` dbmate: 2.19.0 -> 2.20.0 ``                                                  |
| [`b19db05d`](https://github.com/NixOS/nixpkgs/commit/b19db05d452e765e641ce20cdea773329879fe8e) | `` home-assistant-custom-components.somweb: init at 1.1.0 ``                    |
| [`e64ca20d`](https://github.com/NixOS/nixpkgs/commit/e64ca20dd9a9a369dfa86e4ce045d2f6c870c943) | `` python312Packages.pyeapi: update changelog URL ``                            |
| [`92760d40`](https://github.com/NixOS/nixpkgs/commit/92760d40cf26749cc4ce8b05ed7bafca1872ae86) | `` chamber: 3.0.0 -> 3.0.1 ``                                                   |
| [`0cfa06cf`](https://github.com/NixOS/nixpkgs/commit/0cfa06cf273f0937d24608fdab8c135133a8d1f6) | `` kubesec: 2.14.0 -> 2.14.1 ``                                                 |
| [`a6e60736`](https://github.com/NixOS/nixpkgs/commit/a6e60736655ad01cfc308197e2487a6600e174a7) | `` librenms: 24.7.0 -> 24.8.0 ``                                                |
| [`474418fb`](https://github.com/NixOS/nixpkgs/commit/474418fbd3a8a4c434f8a1e5adfbdec2ff744975) | `` dracula-theme: 4.0.0-unstable-2024-08-06 -> 4.0.0-unstable-2024-08-14 ``     |
| [`14f0757f`](https://github.com/NixOS/nixpkgs/commit/14f0757fcc72194dc61185e7fa6c5c757c5d5dc9) | `` kubefirst: 2.4.10 -> 2.4.17 ``                                               |
| [`9570ff34`](https://github.com/NixOS/nixpkgs/commit/9570ff34b7b3ea6fed5c4536bf241886c7c5d13e) | `` cirrus-cli: 0.122.0 -> 0.122.2 ``                                            |
| [`a80ece9f`](https://github.com/NixOS/nixpkgs/commit/a80ece9fe36626b885c4cf5682c4813df2e4a126) | `` nwg-look: remove unreferenced go.mod ``                                      |
| [`e959525e`](https://github.com/NixOS/nixpkgs/commit/e959525e1547b54b96c454ad023d0cde53789ab5) | `` lsh: drop ``                                                                 |
| [`8e333221`](https://github.com/NixOS/nixpkgs/commit/8e333221fcc8d91e21d4554d64d2dcae2e17c575) | `` opensnitch: remove vendored go.mod ``                                        |
| [`e6d9b787`](https://github.com/NixOS/nixpkgs/commit/e6d9b787ed594b654dd5af3f680c2a85d5a61b76) | `` evmdis: remove vendored go.mod ``                                            |
| [`ca419fa7`](https://github.com/NixOS/nixpkgs/commit/ca419fa7559912e0bbe39145f0c4e7f1518c868f) | `` nasmfmt: remove vendored go.mod ``                                           |
| [`3739608c`](https://github.com/NixOS/nixpkgs/commit/3739608c179a161f2a15ada2e32397b82f5e0cdb) | `` firebase-tools: 13.15.1 -> 13.15.2 ``                                        |
| [`7f52761c`](https://github.com/NixOS/nixpkgs/commit/7f52761cff2034e3a6d5821f2a9d39f82ae48748) | `` netease-cloud-music-gtk: 2.4.0 -> 2.4.1 ``                                   |
| [`7a4b2649`](https://github.com/NixOS/nixpkgs/commit/7a4b2649f02153bb50309226d7d565c9701d774f) | `` tar2ext4: 0.12.5 -> 0.12.6 ``                                                |
| [`acf70fe8`](https://github.com/NixOS/nixpkgs/commit/acf70fe8d2ebfc68d6751c84a3d6a60cf32c09dd) | `` wastebin: 2.4.3 -> 2.5.0 ``                                                  |
| [`8ce923e5`](https://github.com/NixOS/nixpkgs/commit/8ce923e5c28bd5142e3d2970dcc53801bdfd8ad5) | `` azure-cli-extensions.ssh: init at 2.0.5 ``                                   |