### PR TITLE
chore(flake/nixvim): `312db6b6` -> `cb413995`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723202784,
-        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
+        "lastModified": 1723803910,
+        "narHash": "sha256-yezvUuFiEnCFbGuwj/bQcqg7RykIEqudOy/RBrId0pc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
+        "rev": "bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723399884,
-        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
+        "lastModified": 1723986931,
+        "narHash": "sha256-Fy+KEvDQ+Hc8lJAV3t6leXhZJ2ncU5/esxkgt3b8DEY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
+        "rev": "2598861031b78aadb4da7269df7ca9ddfc3e1671",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722924007,
-        "narHash": "sha256-+CQDamNwqO33REJLft8c26NbUi2Td083hq6SvAm2xkU=",
+        "lastModified": 1723859949,
+        "narHash": "sha256-kiaGz4deGYKMjJPOji/JVvSP/eTefrIA3rAjOnOpXl4=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "91010a5613ffd7ee23ee9263213157a1c422b705",
+        "rev": "076b9a905af8a52b866c8db068d6da475839d97b",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724036242,
-        "narHash": "sha256-/+gGF0tsAg2dF7Ds9Yt9Sne7ETmILKz1QVnDr+T2S2g=",
+        "lastModified": 1724127528,
+        "narHash": "sha256-fKtsvNQeLhPuz1O53x6Xxkd/yYecpolNXRq7mfvnXQk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "312db6b6e2d98dd8d22223fe383c7e0b4bab60c6",
+        "rev": "cb413995e1e101c76d755b7f131ce60c7ea3985d",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723367906,
-        "narHash": "sha256-v1qA4WBGDI2uH/TVqRwuXSBP341W681psbzYJ8zrjog=",
+        "lastModified": 1723969429,
+        "narHash": "sha256-BuewfNEXEf11MIkJY+uvWsdLu1dIvgJqntWChvNdALg=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "6ca2c3ae05a915c160512bd41f6810f456c9b30d",
+        "rev": "a05d1805f2a2bc47d230e5e92aecbf69f784f3d0",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723454642,
-        "narHash": "sha256-S0Gvsenh0II7EAaoc9158ZB4vYyuycvMGKGxIbERNAM=",
+        "lastModified": 1723808491,
+        "narHash": "sha256-rhis3qNuGmJmYC/okT7Dkc4M8CeUuRCSvW6kC2f3hBc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "349de7bc435bdff37785c2466f054ed1766173be",
+        "rev": "1d07739554fdc4f8481068f1b11d6ab4c1a4167a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                              |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`cb413995`](https://github.com/nix-community/nixvim/commit/cb413995e1e101c76d755b7f131ce60c7ea3985d) | `` plugins/todo-comments: migrate keymaps to mkMapOptionSubmodule ``                 |
| [`39081a41`](https://github.com/nix-community/nixvim/commit/39081a41067a7bdb66f6f85a3fee9693ff8a21b1) | `` tests/plugins/lsp: re-enable vala-ls on linux ``                                  |
| [`9a218fed`](https://github.com/nix-community/nixvim/commit/9a218fed3127d5c3da8a0f081be81a66dd7429b5) | `` tests/plugins/none-ls: re-enable d2_fmt and yamlfix ``                            |
| [`366f2559`](https://github.com/nix-community/nixvim/commit/366f25598a4f35f590a6b5887628e763df0eb939) | `` tests/plugins/lsp: re-enable omnisharp on darwin ``                               |
| [`ec9d2991`](https://github.com/nix-community/nixvim/commit/ec9d29918321173c57a5fa8ca5a93106c373d12c) | `` tests/plugins/openscad: re-enable on darwin ``                                    |
| [`a1a34887`](https://github.com/nix-community/nixvim/commit/a1a34887791489d571fd996bbdd772899757a49c) | `` tests/plugins/lsp: disable vscode-langservers-extracted tests (broken package) `` |
| [`f7cdecba`](https://github.com/nix-community/nixvim/commit/f7cdecbad86da43ed1a85586a3e0a50143b60505) | `` tests/plugins/none-ls: disable prisma_format test (broken package) ``             |
| [`a9ffb6c9`](https://github.com/nix-community/nixvim/commit/a9ffb6c9582caacc7a0367f34a16f56f77b105ed) | `` tests/plugins/lsp: disable prismals test (broken package) ``                      |
| [`f62d77d3`](https://github.com/nix-community/nixvim/commit/f62d77d3fa88622ed2ea82a2727756b5b7fea3fd) | `` plugins/lsp: python3Packages.ruff-lsp -> ruff-lsp fallback ``                     |
| [`ec9e5c07`](https://github.com/nix-community/nixvim/commit/ec9e5c071ade143b59cadd885b5b96aa142ef7ef) | `` plugins/markview: remove unnecessary extraPlugin ``                               |
| [`94fb980f`](https://github.com/nix-community/nixvim/commit/94fb980f352fd8c2701faa3a811a9004a5b93691) | `` plugins/yazi: remove unnecessary extraPlugin ``                                   |
| [`460b4799`](https://github.com/nix-community/nixvim/commit/460b47997f534a5c452068b46287bcd5a67d227e) | `` tests/plugins/lsp: disable typst-lsp test (broken package) ``                     |
| [`fc6d40d7`](https://github.com/nix-community/nixvim/commit/fc6d40d798518218bb934e255b62cedd465bd048) | `` tests/plugins/lsp: typst-lsp -> tinymist ``                                       |
| [`b4065751`](https://github.com/nix-community/nixvim/commit/b4065751768e12edf5ca760453f51c799758ad79) | `` plugins/lsp/astro: remove unnecessary alternative package path ``                 |
| [`d3cb90aa`](https://github.com/nix-community/nixvim/commit/d3cb90aa6e1d117270a1c4479a168bff2d5e0348) | `` generated: Updated rust-analyzer.nix ``                                           |
| [`907c249a`](https://github.com/nix-community/nixvim/commit/907c249abad4cd57d74d98411c9e3aef3b88bac7) | `` flake.lock: Update ``                                                             |
| [`123a55ed`](https://github.com/nix-community/nixvim/commit/123a55ed6f8ae2daec76af5a0ee7e495ccb7e884) | `` tests: remove special treatment of `module` ``                                    |
| [`7b2a6cd9`](https://github.com/nix-community/nixvim/commit/7b2a6cd9e62b4c797508104d7f2904468892c63d) | `` tests: `tests.dontRun` -> `test.runNvim` ``                                       |
| [`f47374fd`](https://github.com/nix-community/nixvim/commit/f47374fd268e2c8842dde8cc08f4ab06a6026745) | `` modules/test: init, replacing `dontRun` arg ``                                    |