### PR TITLE
chore(flake/nixvim): `cb413995` -> `851edc8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724127528,
-        "narHash": "sha256-fKtsvNQeLhPuz1O53x6Xxkd/yYecpolNXRq7mfvnXQk=",
+        "lastModified": 1724188973,
+        "narHash": "sha256-JaP6B9kjXccjRp/7CY2QPSSMarjPJMB0vytfqBdJU7E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cb413995e1e101c76d755b7f131ce60c7ea3985d",
+        "rev": "851edc8df1347aef556a646c80d469a3137331ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`851edc8d`](https://github.com/nix-community/nixvim/commit/851edc8df1347aef556a646c80d469a3137331ba) | `` lib/modules: add `evalNixvim` ``                          |
| [`bc7a7ad1`](https://github.com/nix-community/nixvim/commit/bc7a7ad1d674a332555c8fc299adf194804c49ed) | `` module/outputs: use `mkIf` for `wrapRc` ``                |
| [`6975ee09`](https://github.com/nix-community/nixvim/commit/6975ee09f55b4a1518b76a31e3c9fe5b7618d3f3) | `` modules/outputs: make `type` readOnly at the top-level `` |
| [`c4fcbb0d`](https://github.com/nix-community/nixvim/commit/c4fcbb0dcf153a8bac18d5aced9f8c025c74a66d) | `` modules/context: add `isTopLevel` option ``               |