### PR TITLE
chore(flake/nixvim): `851edc8d` -> `b7f419a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724188973,
-        "narHash": "sha256-JaP6B9kjXccjRp/7CY2QPSSMarjPJMB0vytfqBdJU7E=",
+        "lastModified": 1724222231,
+        "narHash": "sha256-IFlMn1lgVsZQZC9WklY9YKcCdI0mUxSYZ7EfkaKCsQU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "851edc8df1347aef556a646c80d469a3137331ba",
+        "rev": "b7f419a759f70126e220533b724cc17e8528b184",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b7f419a7`](https://github.com/nix-community/nixvim/commit/b7f419a759f70126e220533b724cc17e8528b184) | `` lib: migrate `helpers.nixvimTypes` -> `lib.types` `` |
| [`b414a536`](https://github.com/nix-community/nixvim/commit/b414a5364969cdbfbb5c2f588bada446510103ec) | `` lib/types: merge into `extendedLib` ``               |
| [`38b09c16`](https://github.com/nix-community/nixvim/commit/38b09c1621b07518b8ba51d68ea4153216a09569) | `` modules/test: remove docker dependency ``            |
| [`19d5f4b1`](https://github.com/nix-community/nixvim/commit/19d5f4b134839c69c65eb2f0f5e06a2ade335b3c) | `` lib/test: move from tests/test-derivation ``         |
| [`cbd1003d`](https://github.com/nix-community/nixvim/commit/cbd1003d9d3dcc371f0602a66ff32af9f8c14490) | `` modules/test: move test derivation to an option ``   |