### PR TITLE
chore(flake/nixvim): `b7f419a7` -> `1854d591`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723803910,
-        "narHash": "sha256-yezvUuFiEnCFbGuwj/bQcqg7RykIEqudOy/RBrId0pc=",
+        "lastModified": 1724227338,
+        "narHash": "sha256-TuSaYdhOxeaaE9885mFO1lZHHax33GD5A9dczJrGUjw=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba",
+        "rev": "6cedaa7c1b4f82a266e5d30f212273e60d62cb0d",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723859949,
-        "narHash": "sha256-kiaGz4deGYKMjJPOji/JVvSP/eTefrIA3rAjOnOpXl4=",
+        "lastModified": 1724299755,
+        "narHash": "sha256-P5zMA17kD9tqiqMuNXwupkM7buM3gMNtoZ1VuJTRDE4=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "076b9a905af8a52b866c8db068d6da475839d97b",
+        "rev": "a8968d88e5a537b0491f68ce910749cd870bdbef",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724222231,
-        "narHash": "sha256-IFlMn1lgVsZQZC9WklY9YKcCdI0mUxSYZ7EfkaKCsQU=",
+        "lastModified": 1724340365,
+        "narHash": "sha256-SFJuLI6FpuLHI0PdZAIOAJoeR6Z+cRkbTUQ5TuqJw5s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b7f419a759f70126e220533b724cc17e8528b184",
+        "rev": "1854d591cb0e5be6ad97f5091766cdf28e948265",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`1854d591`](https://github.com/nix-community/nixvim/commit/1854d591cb0e5be6ad97f5091766cdf28e948265) | `` tests/plugins/lsp: re-enable tests ``                            |
| [`77cbd031`](https://github.com/nix-community/nixvim/commit/77cbd0313d5b294bcc5bdcc48c052b6382c6e249) | `` plugins/colorschemes: remove with lib; ``                        |
| [`fba168ab`](https://github.com/nix-community/nixvim/commit/fba168aba758c7caa68d826deb141dd8b3aed171) | `` plugins/colorschemes: migrate helpers -> lib.nixvim ``           |
| [`b4708002`](https://github.com/nix-community/nixvim/commit/b470800240926a6b5262fc9030477b7e8fc17453) | `` plugins/bufferlines/barbar: migrate helpers -> lib.nixvim ``     |
| [`fe12a092`](https://github.com/nix-community/nixvim/commit/fe12a092f6507da22d90a01254d5b6588dc858ed) | `` tests: general cleanup ``                                        |
| [`087f70cb`](https://github.com/nix-community/nixvim/commit/087f70cb0ab56fb49f87c148a1c39bf8852bacb2) | `` tests: remove special case for efmls-configs ``                  |
| [`06419627`](https://github.com/nix-community/nixvim/commit/06419627e2172cf457b21e09bb5ee3a5cc21294f) | `` tests/plugins/nvim-osc52: use new `test.checkWarnings` option `` |
| [`00418181`](https://github.com/nix-community/nixvim/commit/004181813fa6e28688e396255474f632aa5709d8) | `` tests/plugins/schemastore: don't check warnings ``               |
| [`088e584e`](https://github.com/nix-community/nixvim/commit/088e584e5407d99fc4b2bd86e8dcc16e53309235) | `` modules/test: check warnings/assertions ``                       |
| [`83c2844b`](https://github.com/nix-community/nixvim/commit/83c2844bec202d074c2afb8eb74db9e02bab6dde) | `` plugins/telescope: migrate helpers -> lib.nixvim ``              |
| [`d7b506ef`](https://github.com/nix-community/nixvim/commit/d7b506efddb97f24a33831d071b8b957c79f8533) | `` plugins/neotest: migrate helpers -> lib.nixvim ``                |
| [`511a328a`](https://github.com/nix-community/nixvim/commit/511a328aa307032775710db5993d3b8bc83e1113) | `` wrappers: add our lib to the host's `_module.args` ``            |
| [`e555ba13`](https://github.com/nix-community/nixvim/commit/e555ba13b165f0c3fb462370068000bf63b7fec8) | `` docs/helpers: document the "extended" lib ``                     |
| [`e41696e5`](https://github.com/nix-community/nixvim/commit/e41696e5027a5419fdbd7e07dacb71b77085f25f) | `` flake.lock: Update ``                                            |