### PR TITLE
chore(flake/nixvim): `9033f1cf` -> `1181535e`

### DIFF
--- a/config/visuals/lightline.nix
+++ b/config/visuals/lightline.nix
@@ -1,6 +1,8 @@
 {
   plugins.lightline = {
     enable = true;
-    colorscheme = "selenized_black";
+    settings = {
+      colorscheme = "selenized_black";
+    };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724428221,
-        "narHash": "sha256-4rPf+K59pqQeWSf5pBeuuvMBJ6XrF7x84Ezinzb8C0I=",
+        "lastModified": 1724460949,
+        "narHash": "sha256-s0c45Uf6cxJ2gzSrktC+DHrjpYBTC7I3SGMRVgC5qOk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9033f1cf2d46da308cb38e258f82fed2e6da7310",
+        "rev": "1181535e34e433775ec3dbe962e50b1ebf85d44e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`1181535e`](https://github.com/nix-community/nixvim/commit/1181535e34e433775ec3dbe962e50b1ebf85d44e) | `` plugins/lsp/extensions: remove `with lib` + fix `mkRaw` reference `` |
| [`4c8d3559`](https://github.com/nix-community/nixvim/commit/4c8d3559ac4548723eeba9861a94ab63219b0d43) | `` plugins/lightline: migrate to mkNeovimPlugin ``                      |
| [`052ee66d`](https://github.com/nix-community/nixvim/commit/052ee66dbb975960cc151db0b5db6a893503582a) | `` docs/mdbook: move description to bottom ``                           |