### PR TITLE
chore(flake/pre-commit-hooks): `6cedaa7c` -> `c8a54057`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724227338,
-        "narHash": "sha256-TuSaYdhOxeaaE9885mFO1lZHHax33GD5A9dczJrGUjw=",
+        "lastModified": 1724440431,
+        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "6cedaa7c1b4f82a266e5d30f212273e60d62cb0d",
+        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`c08fc07f`](https://github.com/cachix/git-hooks.nix/commit/c08fc07fee0184930287843b7d2e4ba36c858f0b) | `` docs: rename pre-commit-hooks.nix instances to git-hooks.nix `` |