### PR TITLE
chore(flake/nixvim): `1181535e` -> `b10ccc52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724460949,
-        "narHash": "sha256-s0c45Uf6cxJ2gzSrktC+DHrjpYBTC7I3SGMRVgC5qOk=",
+        "lastModified": 1724477034,
+        "narHash": "sha256-fqquiKbI8iX23JRs/nRmSToRh2PE8P/mO4kK7zfhd5s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1181535e34e433775ec3dbe962e50b1ebf85d44e",
+        "rev": "b10ccc5250c17d3f48e6226ed56d8641eb4f3c6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`b10ccc52`](https://github.com/nix-community/nixvim/commit/b10ccc5250c17d3f48e6226ed56d8641eb4f3c6f) | `` docs: fix markdown issue with tree-sitter docs ``            |
| [`f4dd8924`](https://github.com/nix-community/nixvim/commit/f4dd8924b189f2ec1c00577b4168ed9c5919d65e) | `` docs: document how to install custom tree-sitter grammars `` |