### PR TITLE
chore(flake/nixvim): `bb8ecad1` -> `eac092c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724469941,
-        "narHash": "sha256-+U5152FwmDD9EUOiFi5CFxCK6/yFESyDei9jEIlmUtI=",
+        "lastModified": 1724561770,
+        "narHash": "sha256-zv8C9RNa86CIpyHwPIVO/k+5TfM8ZbjGwOOpTe1grls=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "ea319a737939094b48fda9063fa3201ef2479aac",
+        "rev": "ac5694a0b855a981e81b4d9f14052e3ff46ca39e",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724598705,
-        "narHash": "sha256-/oaK6niVP0wezfXoJcKAP2Ho887hKza7y1n8HazCkKA=",
+        "lastModified": 1724710305,
+        "narHash": "sha256-qotbY/mgvykExLqRLAKN4yeufPfIjnMaK6hQQFhE2DE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "bb8ecad13c229e1c89301055c8e54d8d0e33e839",
+        "rev": "eac092c876e4c4861c6df0cff93e25b972b1842c",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723969429,
-        "narHash": "sha256-BuewfNEXEf11MIkJY+uvWsdLu1dIvgJqntWChvNdALg=",
+        "lastModified": 1724584782,
+        "narHash": "sha256-7FfHv7b1jwMPSu9SPY9hdxStk8E6EeSwzqdvV69U4BM=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "a05d1805f2a2bc47d230e5e92aecbf69f784f3d0",
+        "rev": "5a08d691de30b6fc28d58ce71a5e420f2694e087",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`eac092c8`](https://github.com/nix-community/nixvim/commit/eac092c876e4c4861c6df0cff93e25b972b1842c) | `` readme: fix incorrect demo configuration ``               |
| [`7e3ed24e`](https://github.com/nix-community/nixvim/commit/7e3ed24e52e2d400b84b22524cba987a495a3f24) | `` plugins/lint: fix inconsistent description + examples ``  |
| [`9af4c397`](https://github.com/nix-community/nixvim/commit/9af4c3970c13c4508f5f724e2a6a315ba5ba88e3) | `` tests: fix tests by enabling `wrapRc` ``                  |
| [`fa205897`](https://github.com/nix-community/nixvim/commit/fa2058970c90bc636454e8d172aed5b43547507c) | `` lib/tests.nix: fix infinite recursion in args ``          |
| [`665680a5`](https://github.com/nix-community/nixvim/commit/665680a5caeb57ff73e0a112ac805f5456f2a91d) | `` plugins/lint: fix conform incorrect option description `` |
| [`aa1f5a74`](https://github.com/nix-community/nixvim/commit/aa1f5a74ffa348d4cf4ffc32792b901a0699da00) | `` plugins/comment-box-nvim: init ``                         |
| [`45bb6636`](https://github.com/nix-community/nixvim/commit/45bb6636e5e3d4903c321cd8019bb403570a68ee) | `` tests/lsp: re-enable typst-lsp ``                         |
| [`d0564ce4`](https://github.com/nix-community/nixvim/commit/d0564ce4cfd3d9eff700de66b86b943326b41946) | `` tests/example-configuration: re-enable jsonls ``          |
| [`9673ea70`](https://github.com/nix-community/nixvim/commit/9673ea70f429ba396e7f2e1fef27b6647ed86b88) | `` flake.lock: Update ``                                     |