### PR TITLE
chore(flake/nixvim): `60ea38d2` -> `48141474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724727283,
-        "narHash": "sha256-F7AUWC2p20zbQuymca1jB70OH/MQ0MYgkhUsY+7K0cg=",
+        "lastModified": 1724800090,
+        "narHash": "sha256-7KxGFZ40pidca5gcdI2weGanfB74yDxrErFNElOZWqA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "60ea38d2c450537eb2adadff9527c8d0db6f9fea",
+        "rev": "4814147442cd3f12f8160ecad9e36751f68cdc22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`48141474`](https://github.com/nix-community/nixvim/commit/4814147442cd3f12f8160ecad9e36751f68cdc22) | `` modules/test: add `config` and `options` passthrus `` |
| [`af310635`](https://github.com/nix-community/nixvim/commit/af31063538fa20d0bbd9460a1147a69e75032909) | `` modules/test: switch to `runCommand` ``               |
| [`1085bcd7`](https://github.com/nix-community/nixvim/commit/1085bcd7ccf561577ff52dba76b1cb8d35f2c124) | `` plugins/which-key: fix icon examples ``               |