### PR TITLE
chore(flake/nixvim): `48141474` -> `70e9532e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724800090,
-        "narHash": "sha256-7KxGFZ40pidca5gcdI2weGanfB74yDxrErFNElOZWqA=",
+        "lastModified": 1724820329,
+        "narHash": "sha256-jXaDebjRjcUgZcMNXkvA99s/tTUvZfLLJxLwf1e/qwE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4814147442cd3f12f8160ecad9e36751f68cdc22",
+        "rev": "70e9532ec290769e4d671747b0f65b1c29a3c14e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`70e9532e`](https://github.com/nix-community/nixvim/commit/70e9532ec290769e4d671747b0f65b1c29a3c14e) | `` docs: fix typo in `pkgs` arg default value ``           |
| [`975af6a4`](https://github.com/nix-community/nixvim/commit/975af6a498b916683c3a1e0125f5e3260ca5a5bf) | `` tests: simplify fetch-tests slightly ``                 |
| [`1c879ec3`](https://github.com/nix-community/nixvim/commit/1c879ec3aa6ab92d5700ec417dc1958354b8cf87) | `` tests: add regression test for warnings + assertions `` |