### PR TITLE
chore(flake/nixvim): `4acf12c4` -> `2704133f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1724936278,
-        "narHash": "sha256-Uog/PtUbrxE8S2LgT5ip/yYAWrMNu2n5zUaChKPiAJ4=",
+        "lastModified": 1724968633,
+        "narHash": "sha256-eb2NCdLwfXL1MuTAkoDncSl2lCJwyylV5/NM1Ws2P/U=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4acf12c49d5514d58f78b7ebda8838f5e988fd2a",
+        "rev": "2704133fe3ca616b22ed6685cc67180456eb4160",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`2704133f`](https://github.com/nix-community/nixvim/commit/2704133fe3ca616b22ed6685cc67180456eb4160) | `` contributing: document `plugins/default.nix` `` |
| [`c96b46f4`](https://github.com/nix-community/nixvim/commit/c96b46f44b81b897d18e5185125ce23fbe1af87d) | `` plugins/fugitive: use gitPackage ``             |
| [`82b899ab`](https://github.com/nix-community/nixvim/commit/82b899ab6de60d40c80aec05837bf1568b17e50c) | `` plugins/committia: use gitPackage ``            |
| [`38bc0b88`](https://github.com/nix-community/nixvim/commit/38bc0b88e996087f4ea955ff4f2860e4b6684294) | `` plugins/neo-tree: use gitPackage ``             |
| [`6945c6c1`](https://github.com/nix-community/nixvim/commit/6945c6c17ffb3584ad7e054dc22899bfff3e5d3a) | `` plugins/nvim-tree: use gitPackage ``            |
| [`efb004a6`](https://github.com/nix-community/nixvim/commit/efb004a61fb0173a2e5625c401ef6738ff2bea55) | `` plugins/gitgutter: use gitPackage ``            |
| [`710f3472`](https://github.com/nix-community/nixvim/commit/710f3472ec281675830eff8578f9d03d4bd6ceca) | `` plugins/packer: use gitPackage ``               |
| [`4fe95d45`](https://github.com/nix-community/nixvim/commit/4fe95d450271549c066840fcd7f5c98ba9c75e6d) | `` plugins/lazy: use gitPackage ``                 |
| [`ce657342`](https://github.com/nix-community/nixvim/commit/ce6573424d949513650d4d7bc2dacc17a0462377) | `` plugins/lualine: use gitPackage ``              |
| [`831c814b`](https://github.com/nix-community/nixvim/commit/831c814bb3af1d78f90ef1175b94622df2874f8d) | `` plugins/git-worktree: use gitPackage ``         |
| [`d4bcebc7`](https://github.com/nix-community/nixvim/commit/d4bcebc7cae10e1338ecde7653b27288c761c6f0) | `` plugins/neogit: use gitPackage ``               |
| [`98dc0aab`](https://github.com/nix-community/nixvim/commit/98dc0aabe29554b0f2f8ffdf6fed0b23c5218c64) | `` plugins/alpha: fix iconsPackage ``              |
| [`6eb21520`](https://github.com/nix-community/nixvim/commit/6eb21520772140e644e98fce2bb44eed8869884d) | `` plugins/fzf-lua: fix iconsPackage ``            |
| [`0db6e86e`](https://github.com/nix-community/nixvim/commit/0db6e86e8dd9468be40472ba647d87a71ac6ab63) | `` plugins/alpha: use iconsPackage ``              |
| [`f2ef2929`](https://github.com/nix-community/nixvim/commit/f2ef2929ad7e842d4cac5c9d5d3dd47a29b9d23d) | `` plugins/diffview: use iconsPackage ``           |
| [`e122f465`](https://github.com/nix-community/nixvim/commit/e122f465a96a00e3960435387e9a42804fba1397) | `` plugins/fzf-lua: use iconsPackage ``            |
| [`6f4eced1`](https://github.com/nix-community/nixvim/commit/6f4eced1ca280a844ce9515cfa584c1e098ab100) | `` plugins/chadtree: use iconsPackage ``           |
| [`86d66e41`](https://github.com/nix-community/nixvim/commit/86d66e410ac8ca3e58578c8e4d5f61c340231883) | `` plugins/lspsaga: use iconsPackage ``            |
| [`46cf3dad`](https://github.com/nix-community/nixvim/commit/46cf3dad9f38a87300308d4fbc081bc21749e3cd) | `` plugins/bufferline: use iconsPackage ``         |
| [`f59a3c70`](https://github.com/nix-community/nixvim/commit/f59a3c70aafa3318792e37b3ce00b25e9036af3d) | `` plugins/barbar: use iconsPackage ``             |
| [`4ab24e77`](https://github.com/nix-community/nixvim/commit/4ab24e77a57667e5be39186fc241d8ae364ca8d5) | `` plugins/neo-tree: use iconsPackage ``           |
| [`d3e38789`](https://github.com/nix-community/nixvim/commit/d3e387899fee7980ddfca1a413bb74de3b8afe58) | `` plugins/nvim-tree: use iconsPackage ``          |
| [`150c5f45`](https://github.com/nix-community/nixvim/commit/150c5f454b3128140aca5e29e9e522929188cd41) | `` plugins/trouble: use iconsPackage ``            |