### PR TITLE
chore(flake/nixvim): `caefb266` -> `e3f57964`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725139609,
-        "narHash": "sha256-tjMrSaxGXC7JQkENchdPPxWv4gPbelPwSoPs5A5e0vU=",
+        "lastModified": 1725201374,
+        "narHash": "sha256-IXTiRv3QWyR+P6Rj4GBCJTKH23TSsgzARN222/G8GmE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "caefb266bee301922a4cf4d4564b1b000a0a21c3",
+        "rev": "e3f57964038381c6822a2c2b61ca469ccc5797d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`e3f57964`](https://github.com/nix-community/nixvim/commit/e3f57964038381c6822a2c2b61ca469ccc5797d0) | `` plugins/lualine: support custom extensions ``         |
| [`5241c9f8`](https://github.com/nix-community/nixvim/commit/5241c9f83ea1bcec9879585b7bd2da572924f5e1) | `` plugins/TEMPLATE: drop helpers and adopt new style `` |