### PR TITLE
chore(flake/nixvim): `e3f57964` -> `2b30ee87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725201374,
-        "narHash": "sha256-IXTiRv3QWyR+P6Rj4GBCJTKH23TSsgzARN222/G8GmE=",
+        "lastModified": 1725223906,
+        "narHash": "sha256-f6wliEr+oLzKxgJxgkf1bCebmDosq2l8RujIueQK3Qk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e3f57964038381c6822a2c2b61ca469ccc5797d0",
+        "rev": "2b30ee87031fb40f0f894de00c23ea41714d940e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`2b30ee87`](https://github.com/nix-community/nixvim/commit/2b30ee87031fb40f0f894de00c23ea41714d940e) | `` plugins/nvim-orgmode: init ``                                    |
| [`f3362d2e`](https://github.com/nix-community/nixvim/commit/f3362d2e9d11fcde9e41431d9e10aa05ea6285b0) | `` lib/maintainers: add refaelsh ``                                 |
| [`433673a7`](https://github.com/nix-community/nixvim/commit/433673a7b8b439b77a35ca4db53becdd1a0d0c7d) | `` plugins/cmp: add description to elevate autoEnableSource info `` |
| [`b993182f`](https://github.com/nix-community/nixvim/commit/b993182f1533db7ef2d49081fcf57ae888ef1498) | `` readme: fix installation link ``                                 |