### PR TITLE
chore(flake/nixvim): `2b30ee87` -> `18b7597e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725223906,
-        "narHash": "sha256-f6wliEr+oLzKxgJxgkf1bCebmDosq2l8RujIueQK3Qk=",
+        "lastModified": 1725269752,
+        "narHash": "sha256-AtZ9fSo2q6UeMoDy6kw6solM1B+BCABbKgCyUclsctg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2b30ee87031fb40f0f894de00c23ea41714d940e",
+        "rev": "18b7597e6ca4b98a6c3f20ddc9783165d5998018",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`18b7597e`](https://github.com/nix-community/nixvim/commit/18b7597e6ca4b98a6c3f20ddc9783165d5998018) | `` lib/neovim-plugin: drop `config` arg `` |
| [`2a054b03`](https://github.com/nix-community/nixvim/commit/2a054b039e172d4f1cc5469dfbd5a02d21a4902f) | `` lib/vim-plugin: drop `config` arg ``    |
| [`9b0e2ba7`](https://github.com/nix-community/nixvim/commit/9b0e2ba7e5b7f5c75557f910694290241845c5f9) | `` plugins/scope: init ``                  |
| [`204f1aec`](https://github.com/nix-community/nixvim/commit/204f1aecf201c442d6c8ec1976d459cf4fa93247) | `` maintainers: add insipx ``              |