### PR TITLE
chore(flake/nixvim): `18b7597e` -> `d928d6de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725269752,
-        "narHash": "sha256-AtZ9fSo2q6UeMoDy6kw6solM1B+BCABbKgCyUclsctg=",
+        "lastModified": 1725408484,
+        "narHash": "sha256-Q8OPrs2IVpo+9jpCtdbd8yF6EhC3AYscCkCAalpyvHg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "18b7597e6ca4b98a6c3f20ddc9783165d5998018",
+        "rev": "d928d6deb18274b12edfc10681e52e50b51c3e35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`d928d6de`](https://github.com/nix-community/nixvim/commit/d928d6deb18274b12edfc10681e52e50b51c3e35) | `` colorschemes/dracula-nvim: fixes `` |
| [`3f9cf9f9`](https://github.com/nix-community/nixvim/commit/3f9cf9f961ba734d85021248c01b38cd8f2aa173) | `` Remove config ``                    |
| [`f3a811cf`](https://github.com/nix-community/nixvim/commit/f3a811cf250c4ec562eb4e03e9cd728e6c1b6660) | `` plugins/dracula.nvim: init ``       |