### PR TITLE
chore(flake/nixvim): `d928d6de` -> `9c11b540`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725408484,
-        "narHash": "sha256-Q8OPrs2IVpo+9jpCtdbd8yF6EhC3AYscCkCAalpyvHg=",
+        "lastModified": 1725416975,
+        "narHash": "sha256-45MxLDwi36cRkDzKByHwq6ASglhZtUBZgtGu19TzJmg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d928d6deb18274b12edfc10681e52e50b51c3e35",
+        "rev": "9c11b54065a554d9976089cfc8a08dee35cabcaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`9c11b540`](https://github.com/nix-community/nixvim/commit/9c11b54065a554d9976089cfc8a08dee35cabcaa) | `` plugins/lsp/servers: use `lib.mkPackageOption` ``          |
| [`0b86bf51`](https://github.com/nix-community/nixvim/commit/0b86bf519b5c04279074751b99d3e701e7ce47ea) | `` plugins/cmp/sources: use `lib.mkPackageOption` ``          |
| [`dfb754cd`](https://github.com/nix-community/nixvim/commit/dfb754cdc4544ddb66f0e258f4f86d798bf6fab4) | `` plugins/telescope/extensions: use `lib.mkPackageOption` `` |
| [`1fd4b6c7`](https://github.com/nix-community/nixvim/commit/1fd4b6c7399ca85ea8184699141ff9f9e98a678f) | `` plugins: migrate `defaultPackage` -> `package` ``          |
| [`285f6cbd`](https://github.com/nix-community/nixvim/commit/285f6cbd7b2f37c56f57c9fa3e24a59236f9b1ad) | `` lib/*-plugin: use `lib.mkPackageOption` internally ``      |
| [`c8bb7880`](https://github.com/nix-community/nixvim/commit/c8bb7880bf518670547616d5c5849beaa09ff4a6) | `` plugins/barbecue: migrate to mkNeovimPlugin ``             |
| [`27925829`](https://github.com/nix-community/nixvim/commit/279258294b1aeb0457e4830e49f918440806473b) | `` plugins/navic: migrate to mkNeovimPlugin ``                |
| [`0d73ab93`](https://github.com/nix-community/nixvim/commit/0d73ab939cb46547ba38607faf9d2796801cb43e) | `` plugins/project-nvim: migrate to mkNeovimPlugin ``         |