### PR TITLE
chore(flake/nixvim): `9c11b540` -> `35788bbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725416975,
-        "narHash": "sha256-45MxLDwi36cRkDzKByHwq6ASglhZtUBZgtGu19TzJmg=",
+        "lastModified": 1725419553,
+        "narHash": "sha256-FSswXypinl4leeR0G2FTqsuG6/Dhlcu2sED9ZnYqwvk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9c11b54065a554d9976089cfc8a08dee35cabcaa",
+        "rev": "35788bbc5ab247563e13bad3ce64acd897bca043",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`35788bbc`](https://github.com/nix-community/nixvim/commit/35788bbc5ab247563e13bad3ce64acd897bca043) | `` lib: cleanup with lib ``         |
| [`c76e5070`](https://github.com/nix-community/nixvim/commit/c76e5070b9715c98006f40e7708d2dc676d91bc9) | `` wrappers: cleanup with lib ``    |
| [`1c9ba58a`](https://github.com/nix-community/nixvim/commit/1c9ba58aef721bbd2216e19ab44ff4bef1cec07f) | `` modules: cleanup with lib ``     |
| [`ff042dfc`](https://github.com/nix-community/nixvim/commit/ff042dfc938467aceddcd4ddd4c96d372ea7d4fe) | `` docs/mdbook: cleanup with lib `` |