### PR TITLE
chore(flake/nixvim): `35788bbc` -> `810eacf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725419553,
-        "narHash": "sha256-FSswXypinl4leeR0G2FTqsuG6/Dhlcu2sED9ZnYqwvk=",
+        "lastModified": 1725744583,
+        "narHash": "sha256-bzJ5iUPaEjSt24fIoQihBGN+Q7mye73hd/jbubHhyZA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "35788bbc5ab247563e13bad3ce64acd897bca043",
+        "rev": "810eacf5163b16b666ca70b6617c6a85ce412e0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`810eacf5`](https://github.com/nix-community/nixvim/commit/810eacf5163b16b666ca70b6617c6a85ce412e0a) | `` tests: set `_file` to avoid `<unknown-file>` messages ``                 |
| [`ce4c3a72`](https://github.com/nix-community/nixvim/commit/ce4c3a72c146a253f4f032bbe8a3bf8dd553ff7e) | `` tests/fetch-test: tweak signature ``                                     |
| [`d12045e0`](https://github.com/nix-community/nixvim/commit/d12045e057c2a183d60ef098f7530fb9440233a0) | `` plugins/lualine: migrate to mkNeovimPlugin ``                            |
| [`c4135d72`](https://github.com/nix-community/nixvim/commit/c4135d720a5a57b7ddbd7ee918544c26b2c6f732) | `` flake/pre-commit: check maintainers when modified ``                     |
| [`5c929a16`](https://github.com/nix-community/nixvim/commit/5c929a161f1ef339ff3e8c7d339f4eb2074a6235) | `` flake: remove pre-commit from `checks` output ``                         |
| [`86a40215`](https://github.com/nix-community/nixvim/commit/86a4021597c860a6cd1953305a9995f44e60d4d5) | `` plugins: add top-level `deprecation` file ``                             |
| [`9a156ae6`](https://github.com/nix-community/nixvim/commit/9a156ae60cacce99bdec4d94275f38e7d5ca12fe) | `` plugins/mini-icons: add mockDevIcons ``                                  |
| [`84249a9d`](https://github.com/nix-community/nixvim/commit/84249a9dabdf930d968d248024c4d6240ee14548) | `` plugins/vim-numbertoggle: init ``                                        |
| [`4df57466`](https://github.com/nix-community/nixvim/commit/4df5746694560ac05fe9ab9625447e92e522449c) | `` plugins/vim-autosource: init ``                                          |
| [`9248da3c`](https://github.com/nix-community/nixvim/commit/9248da3c3b27c7b5a7677fbf58daef0c51ef73ce) | `` plugins/vim-repeat: init ``                                              |
| [`83aed0e6`](https://github.com/nix-community/nixvim/commit/83aed0e6a331a95f7948a29ffe9b9f34d224f620) | `` plugins/nvim-web-devicons: init ``                                       |
| [`8ae9e4d8`](https://github.com/nix-community/nixvim/commit/8ae9e4d8a1e111e8532131362992debcdc8a9d98) | `` plugins/mini: migrate to mkNeovimPlugin ``                               |
| [`ac4629ee`](https://github.com/nix-community/nixvim/commit/ac4629eecc81fcb80e9671d88bcf525943b85e98) | `` plugins/codeium-nvim: move to plulgins/completion ``                     |
| [`b072a4a6`](https://github.com/nix-community/nixvim/commit/b072a4a68fcec3eee693781cbf0244e62ceaa4b0) | `` plugins/codeium-nvim: migrate to mkNeovimPlugin ``                       |
| [`c8328e6d`](https://github.com/nix-community/nixvim/commit/c8328e6d5938fe02fa7859d1aa88b96012c5c8c4) | `` contributing: update plugin declaration docs ``                          |
| [`e48da949`](https://github.com/nix-community/nixvim/commit/e48da949cf41597d43f8e3880fc1389129ad7427) | `` tests/package-options: init ``                                           |
| [`fd923a3d`](https://github.com/nix-community/nixvim/commit/fd923a3dd3aedd9b11419335951d7bbde49235fd) | `` lib/options: remove deprecated package option helpers ``                 |
| [`7409e80b`](https://github.com/nix-community/nixvim/commit/7409e80bd2dbbc5d653b27170d2fb33082150df3) | `` plugins: remove all uses of `lib.nixvim.mkPluginPackageOption` ``        |
| [`ae3a2c9d`](https://github.com/nix-community/nixvim/commit/ae3a2c9d106b4acc793c46b92def586a21c838a4) | `` plugins: remove all use of `lib.nixvim.mkPackageOption` ``               |
| [`84676128`](https://github.com/nix-community/nixvim/commit/84676128f8e6b3175d4736f2422944c10a73389f) | `` plugins/dap/extensions: use `lib.mkPackageOption` ``                     |
| [`bf1d22e6`](https://github.com/nix-community/nixvim/commit/bf1d22e65cc96ff2afe741e8a1b4288c34fce06b) | `` plugins/neotest/adapters: use `lib.mkPackageOption` ``                   |
| [`37165453`](https://github.com/nix-community/nixvim/commit/37165453a964310ff6d76baa677aa1b802095206) | `` plugins/lsp: use `mkPackageOption` for pylsp + rust-analyzer ``          |
| [`848246bc`](https://github.com/nix-community/nixvim/commit/848246bc64f01f679f5862d2fbd56931827ace80) | `` plugins/telescope/media-files: use `mkPackageOption` for dependencies `` |
| [`80150aba`](https://github.com/nix-community/nixvim/commit/80150abad6d9f0a51f83fb527b6efbe95acd1344) | `` plugins/spectre: cleanup package options ``                              |
| [`e26f0443`](https://github.com/nix-community/nixvim/commit/e26f044339ff3b042f565ee19efdf3bb688279e6) | `` plugins/treesitter: use `mkPackageOption` ``                             |
| [`2132702a`](https://github.com/nix-community/nixvim/commit/2132702a470e492fb8921b22cc393d516519de32) | `` plugins: use `mkPackageOption` for `iconsPackage` options ``             |
| [`c4a54da4`](https://github.com/nix-community/nixvim/commit/c4a54da4a50769279b6add0b0f831aaade5e1159) | `` modules/output: use `mkPackageOption` for `package` option ``            |
| [`cdb2e79e`](https://github.com/nix-community/nixvim/commit/cdb2e79e5179029a99a7e1e0d4bb450861ef7c29) | `` lib/pkg-lists: move to common location ``                                |
| [`d2aad107`](https://github.com/nix-community/nixvim/commit/d2aad1071fa0da286abba5f4fbc3d42ea56bea2b) | `` plugins/none-ls: use `defaultText` in package options ``                 |
| [`a8a7e405`](https://github.com/nix-community/nixvim/commit/a8a7e405f413708ce42dca436105e6210a15278a) | `` plugins/efmls: use `mkPackageOption` ``                                  |
| [`2ef97418`](https://github.com/nix-community/nixvim/commit/2ef974182ef62a6a6992118f0beb54dce812ae9b) | `` plugins/efmls: minor cleanup ``                                          |