### PR TITLE
chore(flake/nixvim): `2de406d9` -> `68aeb57a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725792944,
-        "narHash": "sha256-8koegiii1xpr24cbyW2ohukw+zv06CVxR4YMC1aq7kE=",
+        "lastModified": 1725841817,
+        "narHash": "sha256-7OE2bJDI7ZT+y3YYySDgIqep/dBhTT+G4Fmwh5hMg8s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2de406d9722fd2c69641e8347641c4a655586956",
+        "rev": "68aeb57a3500c609852157ba4283137da7a2bac7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`68aeb57a`](https://github.com/nix-community/nixvim/commit/68aeb57a3500c609852157ba4283137da7a2bac7) | `` tests/one: fix deprecation warning ``                         |
| [`4e6bb696`](https://github.com/nix-community/nixvim/commit/4e6bb696809ba80c3c82b59f363a4326e1e8b573) | `` plugins/none-ls: fix pkg names ``                             |
| [`5330427e`](https://github.com/nix-community/nixvim/commit/5330427e2bac6cea0be59e8de0d1b1c119306073) | `` plugins/none-ls: fix pkg names ``                             |
| [`e1a5e39e`](https://github.com/nix-community/nixvim/commit/e1a5e39eb9d863f2ba8ec7d00eaa7f4ea29f688c) | `` tests/issues: fix deprecation warning ``                      |
| [`d50ee5dd`](https://github.com/nix-community/nixvim/commit/d50ee5dd2f30dfa0a2d77c798d547aec12af9179) | `` plugins/lsp: add basedpyright ``                              |
| [`475dca68`](https://github.com/nix-community/nixvim/commit/475dca6895ed1e7f370f3a0c83df7cddc98c543a) | `` plugins/autosource: `mkBoolInt` -> `mkFlagInt` ``             |
| [`93448470`](https://github.com/nix-community/nixvim/commit/934484709a9afd07c7d9a4ebed9bbd06850091eb) | `` colorschemes/everforest: `mkEverforestBool` -> `mkFlagInt` `` |
| [`ec61ca9b`](https://github.com/nix-community/nixvim/commit/ec61ca9b086b1bdfc45f78effbd34d2ce8a91b9c) | `` plugins: fix "int flag" style options ``                      |
| [`555035ef`](https://github.com/nix-community/nixvim/commit/555035ef798183ce384078c20cd7d3383541fdfd) | `` lib: add `types.flagInt` + `defaultNullOpts.mkIntFlag` ``     |