### PR TITLE
chore(flake/nixvim): `0f83298f` -> `facf6b2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725894854,
-        "narHash": "sha256-a/A4GcmmVIylmATnksKQCHiKtqZpVVI/BINzWOtxqtk=",
+        "lastModified": 1725921389,
+        "narHash": "sha256-RBpN0ToD8O3qniBjqUiB1d2/LQJt5kH5P3Gt6dF91L0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0f83298f2ca5d871ca2dbba0315974e79a8e7dcb",
+        "rev": "facf6b2d0c9e22d858956d1d458eac6baf155a08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`facf6b2d`](https://github.com/nix-community/nixvim/commit/facf6b2d0c9e22d858956d1d458eac6baf155a08) | `` plugins/rest: remove with lib ``                    |
| [`b7dea123`](https://github.com/nix-community/nixvim/commit/b7dea123751ba00a340661ea8c5e47a6bffcb9da) | `` plugins/rest: add dependencies ``                   |
| [`6c9d178e`](https://github.com/nix-community/nixvim/commit/6c9d178ecceb1321bb0a153355f00b8f1dbfd92d) | `` plugins/rest: add filetype association option ``    |
| [`9265d1ab`](https://github.com/nix-community/nixvim/commit/9265d1ab086c89f732ad842a0de0aa0742c4a127) | `` tests/rust-tools: add rust-analyzer-options test `` |
| [`b1d0959b`](https://github.com/nix-community/nixvim/commit/b1d0959bc9803729b6b62b77eb8a7387b8c8cdc3) | `` plugins/languages: move to by-name ``               |
| [`9d323f3e`](https://github.com/nix-community/nixvim/commit/9d323f3ec7aa28d25589f43fde16fa03aa17f8d9) | `` plugins/neotest: move to by-name ``                 |