### PR TITLE
chore(flake/nixvim): `79010edc` -> `fc7e9b29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1725972384,
-        "narHash": "sha256-fisKqOwkpx/hnAJNXOHVZ2s+ZUUvzLuHszZSpqZZ/SI=",
+        "lastModified": 1726000537,
+        "narHash": "sha256-Y1dEuf2wZkg2rhE8sf73x9K0zknUald4Ia6zXnGEfjg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "79010edc14353e5815bd0e0375001daeb87c2e1a",
+        "rev": "fc7e9b29271a03459191955f78d4128451b7cd81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`fc7e9b29`](https://github.com/nix-community/nixvim/commit/fc7e9b29271a03459191955f78d4128451b7cd81) | `` colorschemes/modus: add new configuration option ``   |
| [`d0c08212`](https://github.com/nix-community/nixvim/commit/d0c082124535acd6f0f786be42b38c32abe89d64) | `` docs: patch nixos-render-docs to output GFM alerts `` |