### PR TITLE
chore(flake/flake-parts): `567b938d` -> `bcef6817`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                 |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`5766ecf9`](https://github.com/hercules-ci/flake-parts/commit/5766ecf987a46a651e7176a861bc2d24a9d26873) | `` Test unset extraInputsFlake ``                       |
| [`78bf03ce`](https://github.com/hercules-ci/flake-parts/commit/78bf03cea35debdeabe0f8d6ccd9ec8319cd1714) | `` Remove default value of `extraInputsFlake` ``        |
| [`3314f9c9`](https://github.com/hercules-ci/flake-parts/commit/3314f9c931ee7ee75abb21a043820febc7137033) | `` eval-tests: Remove getFlake calls ``                 |
| [`d50b490c`](https://github.com/hercules-ci/flake-parts/commit/d50b490ccc6308ef2d01def3362b86535e3284ba) | `` Add flakeModules.modules, declaring flake.modules `` |
| [`9c92fd15`](https://github.com/hercules-ci/flake-parts/commit/9c92fd1582b5b025c5c9ec86878618c662718288) | `` Set proper type for `flake.nixosModules` ``          |