### PR TITLE
chore(flake/nixvim): `11c133e8` -> `27a0dd43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1726027257,
-        "narHash": "sha256-hsdIfpIB5wzEehgOSaifBJwY3Tn0P0wiU9pTf8nRBQc=",
+        "lastModified": 1726148694,
+        "narHash": "sha256-bR7LFVtMjiVlO2OpmDSuLQ2XQr+h+JtVFYObAbThZSs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "11c133e89e4090c43445a2c3b5af2322831d7219",
+        "rev": "27a0dd435dd3563f4cf9d788601fadfce8c59db6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`27a0dd43`](https://github.com/nix-community/nixvim/commit/27a0dd435dd3563f4cf9d788601fadfce8c59db6) | `` lib/types: simplify `eitherRecursive` by defining it only once `` |
| [`a5152c2f`](https://github.com/nix-community/nixvim/commit/a5152c2f8e7516a71951ee65b1700cf31913d3da) | `` docs: remove unused `oneOfRecursive` ``                           |
| [`4697b96a`](https://github.com/nix-community/nixvim/commit/4697b96a0124944929ecefa09d488c7997419e43) | `` mergify: fix "update PR" logic ``                                 |
| [`6cbcac1d`](https://github.com/nix-community/nixvim/commit/6cbcac1d435d979cc45ca479c58b48ca0ea0c9b2) | `` mergify: use @nix-infra-bot to update queued PRs ``               |