### PR TITLE
chore(flake/nixvim): `27a0dd43` -> `0b665b20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1725513492,
+        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1726036828,
+        "narHash": "sha256-ZQHbpyti0jcAKnwQY1lwmooecLmSG6wX1JakQ/eZNeM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "8a1671642826633586d12ac3158e463c7a50a112",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724561770,
-        "narHash": "sha256-zv8C9RNa86CIpyHwPIVO/k+5TfM8ZbjGwOOpTe1grls=",
+        "lastModified": 1726032244,
+        "narHash": "sha256-3VvRGPkpBJobQrFD3slQzMAwZlo4/UwxT8933U5tRVM=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "ac5694a0b855a981e81b4d9f14052e3ff46ca39e",
+        "rev": "f4f18f3d7229845e1c9d517457b7a0b90a38b728",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1726148694,
-        "narHash": "sha256-bR7LFVtMjiVlO2OpmDSuLQ2XQr+h+JtVFYObAbThZSs=",
+        "lastModified": 1726244180,
+        "narHash": "sha256-NgoWSJuT/wG4stAsuNLZsEJNyQan9q3cVEMprTLiRMQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "27a0dd435dd3563f4cf9d788601fadfce8c59db6",
+        "rev": "0b665b200b4935aed7f525bf04abf87e91ea4c83",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724584782,
-        "narHash": "sha256-7FfHv7b1jwMPSu9SPY9hdxStk8E6EeSwzqdvV69U4BM=",
+        "lastModified": 1725953301,
+        "narHash": "sha256-4DDSCLE4+5mT7HEt7OqBWVBKpY5d+jRPmaobHzEoSas=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "5a08d691de30b6fc28d58ce71a5e420f2694e087",
+        "rev": "9eaa0246f803758c26f00d21188de00098b79c8b",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724833132,
-        "narHash": "sha256-F4djBvyNRAXGusJiNYInqR6zIMI3rvlp6WiKwsRISos=",
+        "lastModified": 1725271838,
+        "narHash": "sha256-VcqxWT0O/gMaeWTTjf1r4MOyG49NaNxW4GHTO3xuThE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3ffd842a5f50f435d3e603312eefa4790db46af5",
+        "rev": "9fb342d14b69aefdf46187f6bb80a4a0d97007cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`0b665b20`](https://github.com/nix-community/nixvim/commit/0b665b200b4935aed7f525bf04abf87e91ea4c83) | `` plugins/lsp/harper-ls: init ``                                |
| [`aa15c244`](https://github.com/nix-community/nixvim/commit/aa15c244371ac3090486e7c1294efc090832f2eb) | `` tests/lsp: disable swift ``                                   |
| [`5143afee`](https://github.com/nix-community/nixvim/commit/5143afeebcef0cdc206e970e46552ad82be9fa09) | `` tests/efmls: disable swift ``                                 |
| [`6e22c9e8`](https://github.com/nix-community/nixvim/commit/6e22c9e8dbd98606fdf306241ecb1b782672b36d) | `` tests/none-ls: disable swift ``                               |
| [`890cc143`](https://github.com/nix-community/nixvim/commit/890cc1438ea80d4bdd9495a9bbd76ea7fe136cff) | `` tests/neoclip: disable sqlite test ``                         |
| [`1107a528`](https://github.com/nix-community/nixvim/commit/1107a52878fe224c5f8a0a9b4bbe86fcd1197145) | `` tests/yanky: disable sqlite test ``                           |
| [`3d3bf1e4`](https://github.com/nix-community/nixvim/commit/3d3bf1e4b3d9f61c4855bd2ebc323dc09fb3b879) | `` tests/lsp: disable taplo ``                                   |
| [`1310eaf6`](https://github.com/nix-community/nixvim/commit/1310eaf606c0c5a63162208f337940e5a0e9c404) | `` flake/treefmt: disable taplo for now ``                       |
| [`3c9af619`](https://github.com/nix-community/nixvim/commit/3c9af6191e6a0a9b888b5ee5f52bec362fa12d04) | `` plugins/efmls: move `eslint` pkg ref to top-level ``          |
| [`46c3048a`](https://github.com/nix-community/nixvim/commit/46c3048a61df3d3ec284d0a9f06532a0e4925de3) | `` generated: Updated rust-analyzer.nix ``                       |
| [`6e5d4bf4`](https://github.com/nix-community/nixvim/commit/6e5d4bf44c0537ca82d98d630c9a1aa7f299e255) | `` flake.lock: Update ``                                         |
| [`8eab77b5`](https://github.com/nix-community/nixvim/commit/8eab77b51b6c2522eceaae4ff18fb8a9b5abe495) | `` docs: Support GFM style admonitions in option descriptions `` |
| [`cab2a30a`](https://github.com/nix-community/nixvim/commit/cab2a30ae1e12905ec1611b7b5ddf9dc9b12c578) | `` docs: Create a markdown-it plugin ``                          |
| [`66655215`](https://github.com/nix-community/nixvim/commit/6665521525b288d5824314bedf983cc24e217e6a) | `` docs: move pkgs overlays to their own file ``                 |