### PR TITLE
chore(flake/nixvim): `0b665b20` -> `4e5bd1d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1726244180,
-        "narHash": "sha256-NgoWSJuT/wG4stAsuNLZsEJNyQan9q3cVEMprTLiRMQ=",
+        "lastModified": 1726250726,
+        "narHash": "sha256-Z9/tIEMhQIEtt5BYTu75dp4kyDqqS/zb+47oakNQ6sA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0b665b200b4935aed7f525bf04abf87e91ea4c83",
+        "rev": "4e5bd1d79bb88b98e4d23241096989373150112c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`4e5bd1d7`](https://github.com/nix-community/nixvim/commit/4e5bd1d79bb88b98e4d23241096989373150112c) | `` lib: segregate and deprecate functions that need `pkgs` `` |
| [`f47e8f8f`](https://github.com/nix-community/nixvim/commit/f47e8f8f79f2095aeb60c2c8ac8681206b16753b) | `` lib: use `lib.fix` and `self` internally ``                |
| [`7a147234`](https://github.com/nix-community/nixvim/commit/7a147234f8c151e9be1500e1fa687de9b2b8c401) | `` lib: rename `helpers.nix` -> `default.nix` ``              |