### PR TITLE
chore(flake/nixvim): `4e5bd1d7` -> `8fd162d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1726250726,
-        "narHash": "sha256-Z9/tIEMhQIEtt5BYTu75dp4kyDqqS/zb+47oakNQ6sA=",
+        "lastModified": 1726281510,
+        "narHash": "sha256-KJkzmVHjZsDyE5rE/4kwzkBWn3Sb4F/O5DRUXmEldpk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4e5bd1d79bb88b98e4d23241096989373150112c",
+        "rev": "8fd162d9513b0d1acc8ce58848febf2dbe2e7733",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`8fd162d9`](https://github.com/nix-community/nixvim/commit/8fd162d9513b0d1acc8ce58848febf2dbe2e7733) | `` plugins/wtf: add history and grep_history keymaps ``      |
| [`87e3c4a1`](https://github.com/nix-community/nixvim/commit/87e3c4a1b2a62f6b79ae946ba1a2b53b0cbb0499) | `` plugins/todo-comments: support conditional key mapping `` |