### PR TITLE
chore(flake/nixvim): `8fd162d9` -> `2ea7009e`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-result
+result*
 .direnv
 .pre-commit-config.yaml

--- a/config/basic-plugins.nix
+++ b/config/basic-plugins.nix
@@ -5,6 +5,7 @@
     guess-indent.enable = true;
     tmux-navigator.enable = true;
     todo-comments.enable = true;
+    web-devicons.enable = true;
     # TODO: configure which-key: https://github.com/folke/which-key.nvim
     # nixvim docs: https://nix-community.github.io/nixvim/#_plugins_which_key_enable
     which-key.enable = true;

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -27,6 +27,13 @@
     plugins.nvim-jdtls = {
       enable = true;
       rootDir = helpers.mkRaw "require('jdtls.setup').find_root({ 'packageInfo' }, 'Config')";
+      cmd = [
+        (lib.getExe pkgs.jdt-language-server)
+        "-Dlog.protocol=true"
+        "-Dlog.level=ALL"
+        "--add-modules=ALL-SYSTEM"
+      ];
+      data.__raw = "os.getenv('HOME') .. '/.local/share/eclipse/' .. vim.fn.fnamemodify(root_dir, ':p:h:t')";
       extraOptions = {
         on_attach = ''
           function(client, bufnr)
@@ -38,16 +45,6 @@
             vim.keymap.set('n', '<leader>rv', jdtls.extract_variable_all, { desc = 'Extract variable', buffer = bufnr })
             vim.keymap.set('n', '<leader>rc', jdtls.extract_constant, { desc = 'Extract constant', buffer = bufnr })
           end
-        '';
-        cmd = helpers.mkRaw ''
-          {
-            "${lib.getExe pkgs.jdt-language-server}",
-            "-Dlog.protocol=true",
-            "-Dlog.level=ALL",
-            "-data",
-            os.getenv("HOME") .. '/.local/share/eclipse/' .. vim.fn.fnamemodify(root_dir, ':p:h:t'),
-            "--add-modules=ALL-SYSTEM",
-          }
         '';
       };
       settings = {

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1726745158,
+        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726036828,
-        "narHash": "sha256-ZQHbpyti0jcAKnwQY1lwmooecLmSG6wX1JakQ/eZNeM=",
+        "lastModified": 1727346017,
+        "narHash": "sha256-z7OCFXXxIseJhEHiCkkUOkYxD9jtLU8Kf5Q9WC0SjJ8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a1671642826633586d12ac3158e463c7a50a112",
+        "rev": "c124568e1054a62c20fbe036155cc99237633327",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726032244,
-        "narHash": "sha256-3VvRGPkpBJobQrFD3slQzMAwZlo4/UwxT8933U5tRVM=",
+        "lastModified": 1727003835,
+        "narHash": "sha256-Cfllbt/ADfO8oxbT984MhPHR6FJBaglsr1SxtDGbpec=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "f4f18f3d7229845e1c9d517457b7a0b90a38b728",
+        "rev": "bd7d1e3912d40f799c5c0f7e5820ec950f1e0b3d",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1726281510,
-        "narHash": "sha256-KJkzmVHjZsDyE5rE/4kwzkBWn3Sb4F/O5DRUXmEldpk=",
+        "lastModified": 1727366999,
+        "narHash": "sha256-IGzvFj3RDBkLF92pF4txAon7kJTQMhmR/HTKViKhys8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8fd162d9513b0d1acc8ce58848febf2dbe2e7733",
+        "rev": "2ea7009e61ea02e08e480c94c06e71e640a59132",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725953301,
-        "narHash": "sha256-4DDSCLE4+5mT7HEt7OqBWVBKpY5d+jRPmaobHzEoSas=",
+        "lastModified": 1726995581,
+        "narHash": "sha256-lgsE/CTkZk9OIiFGEIrxXZQ7Feiv41dqlN7pEfTdgew=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "9eaa0246f803758c26f00d21188de00098b79c8b",
+        "rev": "3b7dd61b365ca45380707453758a45f2e9977be3",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725271838,
-        "narHash": "sha256-VcqxWT0O/gMaeWTTjf1r4MOyG49NaNxW4GHTO3xuThE=",
+        "lastModified": 1727252110,
+        "narHash": "sha256-3O7RWiXpvqBcCl84Mvqa8dXudZ1Bol1ubNdSmQt7nF4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "9fb342d14b69aefdf46187f6bb80a4a0d97007cd",
+        "rev": "1bff2ba6ec22bc90e9ad3f7e94cca0d37870afa3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`2ea7009e`](https://github.com/nix-community/nixvim/commit/2ea7009e61ea02e08e480c94c06e71e640a59132) | `` tests/none-ls: re-enable clojure ``                                         |
| [`1e289328`](https://github.com/nix-community/nixvim/commit/1e28932840f3cc9174b2c95432fb8ade057bf415) | `` tests/lsp: re-enable ols ``                                                 |
| [`803bded9`](https://github.com/nix-community/nixvim/commit/803bded988cb9ab0cf88fcf31f694df18079aca5) | `` tests/lsp: re-enable omnisharp ``                                           |
| [`5e8f822a`](https://github.com/nix-community/nixvim/commit/5e8f822af5fb3f39cba09dd156531c0aebd624ec) | `` flake-modules/dev: treefmt re-enable taplo linux ``                         |
| [`3510cade`](https://github.com/nix-community/nixvim/commit/3510cade90bab98d978d3b045445022107f83671) | `` tests/lint: re-enable clojure ``                                            |
| [`59ae79ce`](https://github.com/nix-community/nixvim/commit/59ae79ce79bacaf3a4963ed9de6aa465227d8961) | `` tests/lsp: re-enable taplo ``                                               |
| [`3f17f500`](https://github.com/nix-community/nixvim/commit/3f17f500b389c2d3ba84375373df33945692fc66) | `` lib/maintainers: remove duplicate entry ``                                  |
| [`ac14f62e`](https://github.com/nix-community/nixvim/commit/ac14f62e22d8d5b2c0f06029c42847bf404b1789) | `` tests/none-ls: re-enable prisma_format ``                                   |
| [`07a65fbd`](https://github.com/nix-community/nixvim/commit/07a65fbd3c1881ef6bcb99aa623e5e1375953b3b) | `` tests/lsp: re-enable prismals ``                                            |
| [`6e1f3a50`](https://github.com/nix-community/nixvim/commit/6e1f3a504df1c77e9980c175e4bfcbb47631028f) | `` flake.lock: Update ``                                                       |
| [`2ab8751b`](https://github.com/nix-community/nixvim/commit/2ab8751b8be55accb78ca0ca58f1f4ff387001d7) | `` modules/output: add `build.initSource` option ``                            |
| [`692e3931`](https://github.com/nix-community/nixvim/commit/692e39311ec19cdd3e623dc14450b64f2aa94d57) | `` modules/{output,files,test}: move outputs to `build` scope ``               |
| [`7bda0f1c`](https://github.com/nix-community/nixvim/commit/7bda0f1ce49e9da252bcee20b5f700e6dcd3cf8d) | `` modules/output: don't remove "site" dir when `impureRtp` is disabled ``     |
| [`11924e15`](https://github.com/nix-community/nixvim/commit/11924e15935a359c232cebf7756df1a809f05ae9) | `` modules/output: add `impureRtp` option ``                                   |
| [`fb7cda28`](https://github.com/nix-community/nixvim/commit/fb7cda2868fa9646fb9718da37605b9191f71f30) | `` modules/output: refactor `wrapRc` default ``                                |
| [`a8f678da`](https://github.com/nix-community/nixvim/commit/a8f678da24418e1c84eb0818e1d154d67c982033) | `` wrappers: explicitly set `_file` for wrapper modules ``                     |
| [`b3a90d73`](https://github.com/nix-community/nixvim/commit/b3a90d737d5e69d784a07f359ea71178b506b8dd) | `` modules/files: don't set `shorthandOnlyDefinesConfig` ``                    |
| [`5b55858f`](https://github.com/nix-community/nixvim/commit/5b55858fe3e59cf3d6587202dfd4d48ca99aa457) | `` wrappers: use `(evalModules {}).type` for nixvim submodule ``               |
| [`8f991cc8`](https://github.com/nix-community/nixvim/commit/8f991cc8bc417ddbd1d5c7732268255557c13f4a) | `` wrappers/shared: only propagate files when nixvim is enabled ``             |
| [`87509bac`](https://github.com/nix-community/nixvim/commit/87509bac1f73517d9bb5d696b6d73ba7622cef90) | `` wrappers: move assertion propagation to `_shared.nix` ``                    |
| [`6da94195`](https://github.com/nix-community/nixvim/commit/6da94195c2e3ac849eea8fc84febfccbedcbef95) | `` modules/misc: include `assertions` and `meta` modules in the repo ``        |
| [`901346e3`](https://github.com/nix-community/nixvim/commit/901346e38b81c236305e29934dd02c1f64bd8621) | `` plugins/luasnip: fix `extend_filetypes` -> `filetype_extend` ``             |
| [`e64c5118`](https://github.com/nix-community/nixvim/commit/e64c511811559033e65d1c57b4d3df83deac7683) | `` tests/package-options: allow option defaults to throw ``                    |
| [`a75c2235`](https://github.com/nix-community/nixvim/commit/a75c2235d920dfd443d52c134bb51aa458f26814) | `` plugins/rest: v3 migration ``                                               |
| [`78816c0c`](https://github.com/nix-community/nixvim/commit/78816c0c9c0ecef977b1b3b3ffd4555d6c86120c) | `` flake.lock: Update ``                                                       |
| [`9bcba520`](https://github.com/nix-community/nixvim/commit/9bcba520c8148eb65b5de6042828d389a283eccc) | `` plugins/otter: remove cmp source registration ``                            |
| [`47364df4`](https://github.com/nix-community/nixvim/commit/47364df49645e89d8aa03aa61c893e12ecbac366) | `` lib/types/pluginLuaConfig: use `lib.optional` instead of `lib.mkIf` ``      |
| [`a9345dcf`](https://github.com/nix-community/nixvim/commit/a9345dcfc31519734361fecd246d32164feafbca) | `` plugins/markview: mode -> modes ``                                          |
| [`b473bdc5`](https://github.com/nix-community/nixvim/commit/b473bdc5ae1260296d0f43f8f1fba6248b1ee078) | `` treewide: consolidate iconsPackage removal and warning ``                   |
| [`38a18356`](https://github.com/nix-community/nixvim/commit/38a183564ba441f80bcf18dab448d1ed8348f440) | `` plugins/telescope: iconsPackage -> icons provider options ``                |
| [`5ff98645`](https://github.com/nix-community/nixvim/commit/5ff98645ce3e52fced5f1a9f07bb9b741993ca7c) | `` plugins/lspsaga: iconsPackage -> icons provider options ``                  |
| [`254b15d0`](https://github.com/nix-community/nixvim/commit/254b15d066bfb997a321e44b8880eca2aad2068b) | `` plugins/nvim-tree: iconsPackage -> icons provider options ``                |
| [`e23bd547`](https://github.com/nix-community/nixvim/commit/e23bd5475c992cda52c9e08aad431e73c9f54692) | `` plugins/neo-tree: iconsPackage -> icons provider options ``                 |
| [`2e281c43`](https://github.com/nix-community/nixvim/commit/2e281c43e06437eb698ce653b4950c8650344bfb) | `` plugins/trouble: iconsPackage -> icons provider options ``                  |
| [`b2929765`](https://github.com/nix-community/nixvim/commit/b2929765ab12fc7bdd5082eab0b9192e3dabdf3f) | `` plugins/alpha: iconsPackage -> icons provider options ``                    |
| [`7a3423ae`](https://github.com/nix-community/nixvim/commit/7a3423ae18a3ec653fae5c5f6e430ccb9ac52ab0) | `` plugins/diffview: iconsPackage -> icons provider options ``                 |
| [`cf13d60c`](https://github.com/nix-community/nixvim/commit/cf13d60cd64db7cac50a996637f124993d31bcfc) | `` plugins/fzf-lua: iconsPackage -> icons provider options ``                  |
| [`59a9652a`](https://github.com/nix-community/nixvim/commit/59a9652aeeb05e629ad838646e870d8a6975b59d) | `` plugins/bufferline: iconsPackage -> icons provider options ``               |
| [`2cf80fd6`](https://github.com/nix-community/nixvim/commit/2cf80fd66fb25bf896292c5598080f1e69e46bbb) | `` plugins/barbar: iconsPackage -> icons provider options ``                   |
| [`23a903f1`](https://github.com/nix-community/nixvim/commit/23a903f13c42f897063addc1958160a366295b16) | `` plugins/chadtree: iconsPackage -> icons provider options ``                 |
| [`81ae3feb`](https://github.com/nix-community/nixvim/commit/81ae3febd21dfee1371486f82a2e22cb7ed7edb2) | `` lib: throw when deprecated builders are used on a lib without `pkgs` ``     |
| [`1116ae63`](https://github.com/nix-community/nixvim/commit/1116ae633278947af22180d2d3a20cf49ef8f0f5) | `` docs: use `evalNixvim` helper ``                                            |
| [`191b0a95`](https://github.com/nix-community/nixvim/commit/191b0a950237e02bc4478b5174c7b5fcf67cc4ef) | `` treewide: avoid passing `pkgs` to our lib ``                                |
| [`76df0961`](https://github.com/nix-community/nixvim/commit/76df09619d081b23b9dcb3cfd96e541c7f895759) | `` lib/types/pluginLuaConfig: only merge `pre` and `post` when defined ``      |
| [`d2f9e011`](https://github.com/nix-community/nixvim/commit/d2f9e011d9c6e3d765422b78039e61ddf9e69749) | `` lib/neovim-plugin: Add lua configuration scoped to the plugin ``            |
| [`2bc6a949`](https://github.com/nix-community/nixvim/commit/2bc6a949924319f61619d32695115a61394741f8) | `` plugins/lsp/ts_ls: add pluginDefault filetypes ``                           |
| [`a8ab7343`](https://github.com/nix-community/nixvim/commit/a8ab73432aab0086a299182376087d5b77b86f5f) | `` plugins/lsp/volar: add ts-ls integration ``                                 |
| [`384f97cf`](https://github.com/nix-community/nixvim/commit/384f97cf50c534a18f5a8feac81d40623267aa81) | `` flake.lock: Update ``                                                       |
| [`2f09998b`](https://github.com/nix-community/nixvim/commit/2f09998b654db4fd9c81d11ece3a40d74e7bf3ac) | `` plugins/otter: add autoActivate ``                                          |
| [`3211ce35`](https://github.com/nix-community/nixvim/commit/3211ce356be612ae89a38c60799992bde8a47127) | `` flake.lock: Update ``                                                       |
| [`c2080ede`](https://github.com/nix-community/nixvim/commit/c2080ede4f0e6b838f1437c128e684004776afe3) | `` ci(Mergify): configuration update ``                                        |
| [`400d1d92`](https://github.com/nix-community/nixvim/commit/400d1d927d76791b46ae30d431d908c60e411a26) | `` lib: fix escaping bugs in wrapVimscriptForLua and wrapLuaForVimscript ``    |
| [`2df1bdd1`](https://github.com/nix-community/nixvim/commit/2df1bdd14d564235a55552dfc6a9dd5018cbad9b) | `` plugins/lsp/gopls: add goPackage ``                                         |
| [`5660c401`](https://github.com/nix-community/nixvim/commit/5660c4011c68f2e7af64dbb1ed356c3f99eff9e5) | `` plugins/alpha: proper terminal support ``                                   |
| [`beb42716`](https://github.com/nix-community/nixvim/commit/beb42716ff7d4935c2bd1d8fddf8cce96eaf226a) | `` plugins/alpha: remove helpers and with lib ``                               |
| [`17b79813`](https://github.com/nix-community/nixvim/commit/17b79813bfefaba19e80bcb7a9cafdef4406f6e4) | `` plugins/alpha: rawLua support ``                                            |
| [`9307b201`](https://github.com/nix-community/nixvim/commit/9307b201a3dc57d5b71ded4f897ea9d096544877) | `` plugins/telescope-live-grep-args: init ``                                   |
| [`11b9de72`](https://github.com/nix-community/nixvim/commit/11b9de7264bc721dd78a4db533523fe2593aa01a) | `` plugins/telescope-manix: fix manixPackage usage ``                          |
| [`b34379e9`](https://github.com/nix-community/nixvim/commit/b34379e9819d171b7ab8f268bdf05dc0b699b3c6) | `` plugins/package-info: add telescope integration ``                          |
| [`d4b18276`](https://github.com/nix-community/nixvim/commit/d4b1827606e57b417c882d1a525bd34d67999cfc) | `` plugins/package-info: init ``                                               |
| [`04ad7937`](https://github.com/nix-community/nixvim/commit/04ad7937c0f74db1a8a1b8af44c895bd91792e15) | `` plugins/nvim-surround: init ``                                              |
| [`092d1a8a`](https://github.com/nix-community/nixvim/commit/092d1a8a9c764f3892894ceabbbe21b53d63896d) | `` plugins/surround: rename to vim-surround ``                                 |
| [`061d47f7`](https://github.com/nix-community/nixvim/commit/061d47f7c526946fd2d62202835032d7adaf8b65) | `` plugins/tokyonight: add moon style to settings ``                           |
| [`650e204c`](https://github.com/nix-community/nixvim/commit/650e204c071a0faaf1f4073f5a0f0536cd738fed) | `` plugins/telescope-manix: init ``                                            |
| [`6cbf441c`](https://github.com/nix-community/nixvim/commit/6cbf441c22b2c26a1561993f5993e20612a6df1c) | `` plugins/nvim-jdtls: configuration allow raw lua ``                          |
| [`5a5b9b80`](https://github.com/nix-community/nixvim/commit/5a5b9b8004520c0eb550740b7a59400f55175673) | `` plugins/otter: remove myself as maintainer ``                               |
| [`2e3083e4`](https://github.com/nix-community/nixvim/commit/2e3083e42509c399b224239f6d7fa17976b18536) | `` plugins/lsp: rename tsserver to ts-ls ``                                    |
| [`95b322a5`](https://github.com/nix-community/nixvim/commit/95b322a5220744a5cac725e62fa4e612851edbc2) | `` plugins/helpview: init ``                                                   |
| [`336ba155`](https://github.com/nix-community/nixvim/commit/336ba155ffcb20902b93873ad84527a833f57dc8) | `` plugins/overseer: fix strategy option ``                                    |
| [`9e81cb73`](https://github.com/nix-community/nixvim/commit/9e81cb73913b730467d74fde21c4613c525e77c7) | `` plugins/glow: support style path ``                                         |
| [`0999f925`](https://github.com/nix-community/nixvim/commit/0999f92567412ba871f9734543a51c1c90dd0b82) | `` plugins/glow: remove helpers ``                                             |
| [`accf5e67`](https://github.com/nix-community/nixvim/commit/accf5e67b16a857e546abd321877af061319147d) | `` plugins/smartcolumn: init ``                                                |
| [`fcb782cd`](https://github.com/nix-community/nixvim/commit/fcb782cd9c340f1d9f610ca4c75309c82ec89bff) | `` flake: add an empty `nixvimConfiguration` to the `legacyPackages` output `` |
| [`ccc2469e`](https://github.com/nix-community/nixvim/commit/ccc2469e4f1fce144c98e18bd59c022289cf91e8) | `` tests/neotest: disable on darwin ``                                         |
| [`f88402d5`](https://github.com/nix-community/nixvim/commit/f88402d5a7085697e8a2953428e66b9d8b420785) | `` plugins/coq-thirdparty: remove copilot ``                                   |
| [`1a1de277`](https://github.com/nix-community/nixvim/commit/1a1de2779bd50ff683c7e847676dcf1872f18945) | `` tests/lsp: remove tsserver test ``                                          |
| [`f0bd18b4`](https://github.com/nix-community/nixvim/commit/f0bd18b4200becfe752e98baf1bd608496081a96) | `` generated: Updated efmls-configs.nix ``                                     |
| [`9a32aecc`](https://github.com/nix-community/nixvim/commit/9a32aeccfca5e927988cda89c3243979f738c3c3) | `` flake.lock: Update ``                                                       |
| [`f76051e0`](https://github.com/nix-community/nixvim/commit/f76051e06e40921cfb3eb0b4bc718880a6f1d9b1) | `` plugins/compiler: init ``                                                   |
| [`4f01fd98`](https://github.com/nix-community/nixvim/commit/4f01fd981af20ba998fb591317b56cd94491f628) | `` plugins/ts-comments-nvim: init ``                                           |
| [`add9aca7`](https://github.com/nix-community/nixvim/commit/add9aca76eee69831f44f57caf12eb4bf2fc23a1) | `` plugins/overseer: init ``                                                   |
| [`a20d9562`](https://github.com/nix-community/nixvim/commit/a20d95625bee35b6230503ee21f930d3fe7dfa2c) | `` plugins/precognition: init ``                                               |
| [`57219622`](https://github.com/nix-community/nixvim/commit/57219622b8d27c80b06024346e105cb67c2b5d74) | `` typo ``                                                                     |
| [`61be7a6e`](https://github.com/nix-community/nixvim/commit/61be7a6eed7b6e70db9731cdf32d6a3e163cee73) | `` plugins/nvim-jdtls: use jdtLanguageServerPackage option ``                  |
| [`b42d4588`](https://github.com/nix-community/nixvim/commit/b42d4588ae5350ceb291389f8d9280568bd23bff) | `` plugins/neoclip: sqlite-lua assertion ``                                    |
| [`e3e37741`](https://github.com/nix-community/nixvim/commit/e3e37741771d47b3c57329db9077f5eef30a9777) | `` plugins/neorg: use neorgTelescopePackage option ``                          |
| [`7a9bb2ee`](https://github.com/nix-community/nixvim/commit/7a9bb2ee9527dc14f20176b42de5df6357938af8) | `` plugins/fzf-lua: remove extra fzf package include ``                        |
| [`875b8125`](https://github.com/nix-community/nixvim/commit/875b8125591e68892f8d9bcdbfcf9481fc37f09b) | `` plugins/rest: remove extra curl package include ``                          |
| [`59d03e76`](https://github.com/nix-community/nixvim/commit/59d03e76d97342ef2e155b28554fbe16947f3981) | `` colorschemes/palette: use lsp package ``                                    |
| [`068f5e97`](https://github.com/nix-community/nixvim/commit/068f5e97fcb6041e50aa46b44bebd434c9abfd8e) | `` plugins/tagbar: use tagsPackage ``                                          |
| [`0e9b8351`](https://github.com/nix-community/nixvim/commit/0e9b8351da90b776c9469dc5f07db3117b07747a) | `` plugins/typescript-tools: remove redundant extraPlugins ``                  |
| [`34297f5e`](https://github.com/nix-community/nixvim/commit/34297f5e040f739981b5943440e2caeb6b3cb10d) | `` plugins/yanky: sqlite-lua assertion ``                                      |
| [`da1a10d0`](https://github.com/nix-community/nixvim/commit/da1a10d0f3104d9f588f049b7dfe86ce5bcc3373) | `` plugins/efmls: use efmLangServerPackage option ``                           |
| [`9832cb86`](https://github.com/nix-community/nixvim/commit/9832cb86fb1384089a6a95cb62120faf12c6210c) | `` plugins/vimtex: use package options for extraPackages ``                    |
| [`ff3fee3a`](https://github.com/nix-community/nixvim/commit/ff3fee3ae5490fbccf8529aac2c7805c87fc4975) | `` plugins/direnv: use direnvPackage ``                                        |
| [`6bf63e88`](https://github.com/nix-community/nixvim/commit/6bf63e8871af9bdb1d1005f9dabecd9d1837eecd) | `` plugins/typst-vim: use typstPackage ``                                      |
| [`dfea1785`](https://github.com/nix-community/nixvim/commit/dfea17859073c8a3e56a8674e5e64bb7b32ae11f) | `` plugins/octo: use ghPackage ``                                              |
| [`4d460d61`](https://github.com/nix-community/nixvim/commit/4d460d6151b27bd045a5442b40c2aa1427592efb) | `` plugins/rust-tools: use lsp package ``                                      |
| [`9c476a09`](https://github.com/nix-community/nixvim/commit/9c476a094874683ed462ab8efbaaeb5f028bb1c1) | `` plugins/lsp: use package option ``                                          |
| [`873d7b51`](https://github.com/nix-community/nixvim/commit/873d7b51a73d2c35950c3ec8a5a017d801c11715) | `` plugins/telescope: add batPackage ``                                        |
| [`93b8b75f`](https://github.com/nix-community/nixvim/commit/93b8b75ff3ee3218fd330e263cf29933aa46fbf4) | `` plugins/image: add curlPackage and ueberzugPackage ``                       |
| [`6915b851`](https://github.com/nix-community/nixvim/commit/6915b851a2c260e6743ea0dc2573cfc0e0831577) | `` plugins/neogit: use whichPackage ``                                         |
| [`5316141e`](https://github.com/nix-community/nixvim/commit/5316141e5095459afe34f6fc835189cc47cdcfa2) | `` plugins/packer: use package option ``                                       |
| [`1364f071`](https://github.com/nix-community/nixvim/commit/1364f071adc9335723a631e9e82eca6c0d8e7ba0) | `` plugins/lazy: use package option ``                                         |
| [`f1881b4e`](https://github.com/nix-community/nixvim/commit/f1881b4e4b7007cbf22d3ff005fdb8a876bddea2) | `` plugins/markdown-preview: fix browserFunc rename ``                         |
| [`2d5949f6`](https://github.com/nix-community/nixvim/commit/2d5949f65ca6060552ca5841716119c6d7d4bb54) | `` plugins/sqlite-lua: init ``                                                 |
| [`908721cd`](https://github.com/nix-community/nixvim/commit/908721cdbd25efb05d0975ada5d980e89bba64fa) | `` tests/darwin: add system.stateversion ``                                    |
| [`79f0f738`](https://github.com/nix-community/nixvim/commit/79f0f738594b327f1f8a9f00bdb76100b5f6b7e1) | `` flake.lock: Update ``                                                       |
| [`e170e4b5`](https://github.com/nix-community/nixvim/commit/e170e4b5981f98c052257617580f95a307802bf9) | `` plugins/lsp/idris2-lsp: init ``                                             |