### PR TITLE
chore(flake/nixpkgs): `345c263f` -> `99dc8785`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -249,11 +249,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726243404,
-        "narHash": "sha256-sjiGsMh+1cWXb53Tecsm4skyFNag33GPbVgCdfj3n9I=",
+        "lastModified": 1726463316,
+        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "345c263f2f53a3710abe117f28a5cb86d0ba4059",
+        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`f5507819`](https://github.com/NixOS/nixpkgs/commit/f5507819243685adf72372b37d7e37bb032bc85b) | `` hydra: 0-unstable-2024-08-27 -> 0-unstable-2024-09-15 ``                 |
| [`4d0986e5`](https://github.com/NixOS/nixpkgs/commit/4d0986e5ffa56ec4705db6d9aa4509dbaec32d4a) | `` hydra: add unstableGitUpdater ``                                         |
| [`395d3350`](https://github.com/NixOS/nixpkgs/commit/395d3350e4628550d067d713f514361f916df1e6) | `` ircdog: 0.5.4 -> 0.5.5 (#342181) ``                                      |
| [`13cdb077`](https://github.com/NixOS/nixpkgs/commit/13cdb0775b87afce1a70d95f75200cb1cdac2751) | `` emacsPackages.eglot: only build info manual when needed ``               |
| [`ad11a735`](https://github.com/NixOS/nixpkgs/commit/ad11a7357b6cedf22b27e8df1ed26ba97f74cb71) | `` maintainers: remove kfears (#342128) ``                                  |
| [`94c62f50`](https://github.com/NixOS/nixpkgs/commit/94c62f5036e7744247309cf5a11847e1168ac289) | `` nixos/networking.firewall: fix refactor regression ``                    |
| [`8acaf55d`](https://github.com/NixOS/nixpkgs/commit/8acaf55d0aca15edf7ba210cd057e5d053e75cca) | `` emacsPackages.mu4e: add linj to maintainers ``                           |
| [`859dde2e`](https://github.com/NixOS/nixpkgs/commit/859dde2eb5df4308e5ffa04fbfdfa8a0e33bdc33) | `` emacsPackages.mu4e: stop setting wrong meta.mainProgram ``               |
| [`be4319b9`](https://github.com/NixOS/nixpkgs/commit/be4319b9186a4b4140d9b09f7671f77009d066da) | `` emacsPackages.mu4e: build package tarball in postBuild instead ``        |
| [`16f8c536`](https://github.com/NixOS/nixpkgs/commit/16f8c5365295c816ae7eaef0caba019253e83ce3) | `` emacsPackages.mu4e: make pname and version overridable ``                |
| [`980f8408`](https://github.com/NixOS/nixpkgs/commit/980f840859cfe91b6702440d36c40d7a83a46c0f) | `` emacs: factor out elisp package override helpers ``                      |
| [`acff7907`](https://github.com/NixOS/nixpkgs/commit/acff7907ed35a1aa418f3a849544e894b5dd1b72) | `` SDL1: fix building for musl with GCC 14 ``                               |
| [`4b871128`](https://github.com/NixOS/nixpkgs/commit/4b8711284895989bc89c13eed746d622d218fb5e) | `` ollama: add cuda-merged to buildInputs ``                                |
| [`4c1d5381`](https://github.com/NixOS/nixpkgs/commit/4c1d53818b5766629cfb4c4dce890a4571a7abd9) | `` nixos/doc: update `Installing` section (#341995) ``                      |
| [`00c62e5b`](https://github.com/NixOS/nixpkgs/commit/00c62e5b25c737ec96c81452340e7cd3ee58e4cb) | `` simdutf: 5.4.15 -> 5.5.0 ``                                              |
| [`fc851ed4`](https://github.com/NixOS/nixpkgs/commit/fc851ed483a60556016e08d7ba0ee5f8842a964c) | `` bcachefs-tools: remove johnrtitor as maintainer ``                       |
| [`4e54a5a3`](https://github.com/NixOS/nixpkgs/commit/4e54a5a38a40315bb4b71bff068d10bc5d9fc4c4) | `` linuxPackages_6_11.perf: fix build ``                                    |
| [`35333be9`](https://github.com/NixOS/nixpkgs/commit/35333be988e07c7250f172bce1c372e8f0aa6006) | `` regal: 0.25.0 -> 0.26.2 ``                                               |
| [`5fc58c6b`](https://github.com/NixOS/nixpkgs/commit/5fc58c6b7a27f7705453643254ec1a090bfe649b) | `` linux_6_11: init at 6.11 ``                                              |
| [`dbfe1b17`](https://github.com/NixOS/nixpkgs/commit/dbfe1b17a208c5715acd6586ca0e28879aa1339c) | `` Nextpnr: add himbaechel target ``                                        |
| [`31146b0c`](https://github.com/NixOS/nixpkgs/commit/31146b0c4453d403bce131bbf8539d392294b88e) | `` strace: 6.10 -> 6.11 ``                                                  |
| [`90aee059`](https://github.com/NixOS/nixpkgs/commit/90aee059a22a7e003147f13adb4fa9bf596c4108) | `` sn0int: 0.26.0 -> 0.26.1 ``                                              |
| [`c607f9fb`](https://github.com/NixOS/nixpkgs/commit/c607f9fbcc7952a6dd0e92d6d470aa4647425e19) | `` musescore: Switch to the more minimalist wrapGAppsNoGuiHook ``           |
| [`e11598ef`](https://github.com/NixOS/nixpkgs/commit/e11598efb90882e8a7d5ce3a510eb016cd1c62c0) | `` goldendict-ng: 24.05.05 -> 24.09.0 ``                                    |
| [`1c9765ac`](https://github.com/NixOS/nixpkgs/commit/1c9765accf65bb047ea7fb15706ebce128ee4dab) | `` nixos/release-notes: fix md link in section about gitea ``               |
| [`aa568b6c`](https://github.com/NixOS/nixpkgs/commit/aa568b6c40c90d3a1657965f9104d5e8c33994fa) | `` ansible: 2.17.3 -> 2.17.4 ``                                             |
| [`d6725bb4`](https://github.com/NixOS/nixpkgs/commit/d6725bb4e318c25f5d6f909cad7ea3e7688ab238) | `` spotube: 3.8.0 -> 3.8.1, fix webview ``                                  |
| [`2f379811`](https://github.com/NixOS/nixpkgs/commit/2f3798116dc522866f129f222a8e8b631503c7eb) | `` fabric-ai: init at 1.4.14 ``                                             |
| [`015b6667`](https://github.com/NixOS/nixpkgs/commit/015b6667efb0c21f5c71938d120fffaef0db2511) | `` doc/hooks/premake: add documentation ``                                  |
| [`38dfdd90`](https://github.com/NixOS/nixpkgs/commit/38dfdd90968e983559fe25bb069a1261d60dfc45) | `` python312Packages.pymupdf: mark as broken ``                             |
| [`68652a1f`](https://github.com/NixOS/nixpkgs/commit/68652a1fa96f19eca25889e501a25c22861f4fa3) | `` tcp_wrappers: 7.6.q-26 -> 7.6.q-33 ``                                    |
| [`dec9bb30`](https://github.com/NixOS/nixpkgs/commit/dec9bb30aa61cd726e6548f1dacc75a81dcb59b1) | `` maintainers: update callumio's gpg keys ``                               |
| [`2505777e`](https://github.com/NixOS/nixpkgs/commit/2505777e0c90e4ae553b40033dfd931aaa442ea5) | `` nixos/netbird: remove misuzu as maintainer ``                            |
| [`ad3c462a`](https://github.com/NixOS/nixpkgs/commit/ad3c462a6ecdabfaa0ae4f5d694ba3f299247b96) | `` netbird: remove misuzu as maintainer ``                                  |
| [`fc402c2a`](https://github.com/NixOS/nixpkgs/commit/fc402c2ab80fae35243491d8c318fd4549ddb8b7) | `` systemd: fix building for musl with GCC 14 ``                            |
| [`00e9c6ba`](https://github.com/NixOS/nixpkgs/commit/00e9c6bafcf8b628cf74e60a6e95001eb22363db) | `` envoy: move to by-name ``                                                |
| [`090dbc26`](https://github.com/NixOS/nixpkgs/commit/090dbc264ff67408f943efd165a16ea7d4d44f41) | `` envoy: 1.31.0 -> 1.31.1 ``                                               |
| [`85b0872f`](https://github.com/NixOS/nixpkgs/commit/85b0872fc926c0389f1b2e59cbb3afd57659b5b5) | `` power-profiles-daemon: 0.22 -> 0.23 ``                                   |
| [`d963c59b`](https://github.com/NixOS/nixpkgs/commit/d963c59b4ddd4da5c5750b631d27df0cf64a6601) | `` gpscorrelate: fix build ``                                               |
| [`70f53bf3`](https://github.com/NixOS/nixpkgs/commit/70f53bf307afef70447b233c424e43bb3ad9ed20) | `` nixos/dendrite: fix broken example conf link ``                          |
| [`91b9f1c8`](https://github.com/NixOS/nixpkgs/commit/91b9f1c8e4e435d17f2700275f768c3fc6608cd7) | `` agate: 3.3.8 → 3.3.9 ``                                                  |
| [`19808ce7`](https://github.com/NixOS/nixpkgs/commit/19808ce7f0bc4cc694d3ef99c9edd7ae7388aa74) | `` l3afpad: remove ``                                                       |
| [`4b37f165`](https://github.com/NixOS/nixpkgs/commit/4b37f165fda99debcb8230cf06164de28b09049b) | `` mhwaveedit: remove ``                                                    |
| [`646ef5a8`](https://github.com/NixOS/nixpkgs/commit/646ef5a89cf9d549b98157eaeba3f8dd79c8993f) | `` aumix: remove ``                                                         |
| [`68467caa`](https://github.com/NixOS/nixpkgs/commit/68467caab1361c1c55d00678398eef53fccf8155) | `` xprite-editor: remove ``                                                 |
| [`dae90a0d`](https://github.com/NixOS/nixpkgs/commit/dae90a0d29343bbb9ffc5d3f7bcfb816fca3e639) | `` gmpc: remove ``                                                          |
| [`8d9d116f`](https://github.com/NixOS/nixpkgs/commit/8d9d116f351dba71e459a0ddf40d8d7b76d54704) | `` psensor: remove ``                                                       |
| [`9af58a2f`](https://github.com/NixOS/nixpkgs/commit/9af58a2f4f7114954d6689290b2adf34efe6e895) | `` gnome-dictionary: remove ``                                              |
| [`578b246a`](https://github.com/NixOS/nixpkgs/commit/578b246a0788ecd34dcb845ad2bf56ee32824196) | `` gtkperf: remove ``                                                       |
| [`6abef67b`](https://github.com/NixOS/nixpkgs/commit/6abef67bb487ad81774c6cf5f2c255f8e138a32b) | `` gnome_mplayer: remove ``                                                 |
| [`50713e03`](https://github.com/NixOS/nixpkgs/commit/50713e031f80040e74eef4bc50bf6d01c6159228) | `` gmtk: remove ``                                                          |
| [`27fc9477`](https://github.com/NixOS/nixpkgs/commit/27fc947777ba42ae791347c48a07b4480097a487) | `` mp3info: remove ``                                                       |
| [`d49f90a0`](https://github.com/NixOS/nixpkgs/commit/d49f90a01c2243068513277d45334f8ef65ff774) | `` gmtp: remove ``                                                          |
| [`c92c230c`](https://github.com/NixOS/nixpkgs/commit/c92c230c35527fd713905dbd2e355396d7aff45d) | `` gnome-hexgl: remove ``                                                   |
| [`03989303`](https://github.com/NixOS/nixpkgs/commit/039893032ec0535ac8d9e143c36e086bd4b84f0d) | `` vinagre: remove ``                                                       |
| [`db1cd9f9`](https://github.com/NixOS/nixpkgs/commit/db1cd9f96f44c61b1805ee48543e2b42fedcc657) | `` python312Packages.langchain-aws: 0.1.17 -> 0.2.0 ``                      |
| [`4e835ba3`](https://github.com/NixOS/nixpkgs/commit/4e835ba3b48e947ae72e7bc51ea285b5084a43b9) | `` python312Packages.langchain-mongodb: 0.1.8 -> 0.2.0 ``                   |
| [`8f75a9e5`](https://github.com/NixOS/nixpkgs/commit/8f75a9e571c83731f7d9e0d7eca7db9852240885) | `` python312Packages.langchain-azure-dynamic-sessions: 0.1.0 -> 0.2.0 ``    |
| [`de804d0b`](https://github.com/NixOS/nixpkgs/commit/de804d0b229be6dd6ee18cf7e06a6dcdb4f23930) | `` python312Packages.langchain-openai: 0.1.23 -> 0.2.0 ``                   |
| [`1a03ee6f`](https://github.com/NixOS/nixpkgs/commit/1a03ee6f4614f4ea848950e256c3280e21bba591) | `` python312Packages.langgraph-checkpoint: skip failing test ``             |
| [`6298dbaa`](https://github.com/NixOS/nixpkgs/commit/6298dbaa8f3b532c73f8ad6bf95f1eb9c69ea045) | `` python312Packages.langchain-chroma: 0.1.2 -> 0.1.4 ``                    |
| [`a9e619e8`](https://github.com/NixOS/nixpkgs/commit/a9e619e8c11e7556a6ccbf6a14e3c22bb45c493c) | `` python312Packages.langchain-standard-tests: update dependencies ``       |
| [`5d4a97b0`](https://github.com/NixOS/nixpkgs/commit/5d4a97b02530773c079336c11061233dc66942d5) | `` python312Packages.langchain-huggingface: 0.0.3 -> 0.1.0 ``               |
| [`f7d7fdc9`](https://github.com/NixOS/nixpkgs/commit/f7d7fdc9112f5c02426b3a799f6a3b66501295ed) | `` python312Packages.langsmith: 0.1.99 -> 0.1.120 ``                        |
| [`e512aef2`](https://github.com/NixOS/nixpkgs/commit/e512aef2101ea68ad752408a1d68b36727617af0) | `` python312Packages.langchain-community: 0.2.16 -> 0.3.0 ``                |
| [`8100c98c`](https://github.com/NixOS/nixpkgs/commit/8100c98c67a85b8911b27de45a1eef8fde0e5314) | `` python312Packages.langchain: 0.2.16 -> 0.3.0 ``                          |
| [`28f52755`](https://github.com/NixOS/nixpkgs/commit/28f5275588f0d8dec3d9d3f5b91c811c1ebf9e11) | `` python312Packages.langchain-text-splitters: 0.2.4 -> 0.3.0 ``            |
| [`7fa9e367`](https://github.com/NixOS/nixpkgs/commit/7fa9e367ba45d74e79e1824b284ade4b28b155ad) | `` python312Packages.langchain-core: 0.2.38 -> 0.3.0 ``                     |
| [`60fa9871`](https://github.com/NixOS/nixpkgs/commit/60fa9871e9d4fc00fc02ebed00edebab923b5e49) | `` python312Packages.langgraph-checkpoint-sqlite: 1.0.2 -> 1.0.3 ``         |
| [`6892e47e`](https://github.com/NixOS/nixpkgs/commit/6892e47e9d112cdceb1636dd9b2215d4aa13f736) | `` python312Packages.langgraph: 0.2.19 -> 0.2.21 ``                         |
| [`af2be5c7`](https://github.com/NixOS/nixpkgs/commit/af2be5c7e682d1fd6cf56c529cee676183736452) | `` python3Packages.wikitextparser: 0.55.13 -> 0.56.2 ``                     |
| [`289996b7`](https://github.com/NixOS/nixpkgs/commit/289996b763fe7048a42ab217ca853c9a1bb0de1d) | `` automatic-timezoned: 2.0.31 -> 2.0.32 ``                                 |
| [`5f52e427`](https://github.com/NixOS/nixpkgs/commit/5f52e4273af2158249f6241e484a17126968662b) | `` function-runner: 6.0.0 -> 6.2.1 ``                                       |
| [`f63b2e74`](https://github.com/NixOS/nixpkgs/commit/f63b2e7401e4af42603d64cee273b04373a3cac9) | `` bngblaster: 0.9.6 -> 0.9.7 ``                                            |
| [`6cf7d32a`](https://github.com/NixOS/nixpkgs/commit/6cf7d32a365794f382edfa5fcd7a7181a605bc9e) | `` thonny: derivation cleanup ``                                            |
| [`b28301d7`](https://github.com/NixOS/nixpkgs/commit/b28301d784662f8974d1203bdf933c04f84ab098) | `` thonny: nixfmt-rfc-style ``                                              |
| [`7d0b98b4`](https://github.com/NixOS/nixpkgs/commit/7d0b98b4b5f4568249ac6cbf50b11fcdc7830a21) | `` thonny: migrate to by-name ``                                            |
| [`61fd4d4a`](https://github.com/NixOS/nixpkgs/commit/61fd4d4a3d1d520a5d02d6e7a01d6c358ba21570) | `` thonny: add darwin bundle ``                                             |
| [`e1973e0a`](https://github.com/NixOS/nixpkgs/commit/e1973e0aa2443f25c4421a6c7647e37250672f25) | `` cntb: fix darwin ``                                                      |
| [`ec1e6cd0`](https://github.com/NixOS/nixpkgs/commit/ec1e6cd0486482012d75b6dac14d195dcd87a6cb) | `` ruff: 0.6.4 -> 0.6.5 ``                                                  |
| [`a3b2a3a4`](https://github.com/NixOS/nixpkgs/commit/a3b2a3a4b3b80518c967257ef448fcb7d2d4dc16) | `` curl: apply patch for CVE-2024-8096 ``                                   |
| [`4ad16ff0`](https://github.com/NixOS/nixpkgs/commit/4ad16ff03d0f55120574aaeefafbdeeb8bbf6ce6) | `` swt: `sha256` → `hash` ``                                                |
| [`d2ff0833`](https://github.com/NixOS/nixpkgs/commit/d2ff0833351f9d309d33824d2ab2285901aca0c3) | `` solana-cli: `sha256` → `hash` ``                                         |
| [`4538b56a`](https://github.com/NixOS/nixpkgs/commit/4538b56ab54ac757440e8ba955bf0a0f2c75972b) | `` fluxcd: `sha256` → `hash` ``                                             |
| [`7ed3d18d`](https://github.com/NixOS/nixpkgs/commit/7ed3d18d09f752bca9899e9f795de3451eea719e) | `` corefonts: `sha256` → `hash` ``                                          |
| [`3477b6f4`](https://github.com/NixOS/nixpkgs/commit/3477b6f431d31081fab8ee1804d7ed0ea6aad7aa) | `` cargo-profiler: `sha256` → `hash` ``                                     |
| [`2641d97c`](https://github.com/NixOS/nixpkgs/commit/2641d97cbf96e0b4caf1733edc47cf1298de0960) | `` pkgs/by-name: Convert hashes to SRI format ``                            |
| [`4ebe4a20`](https://github.com/NixOS/nixpkgs/commit/4ebe4a2089977ff5ab3bdc024adc37878cd8e424) | `` maintainers/scripts/sha-to-sri: ignore `gemset.nix` files ``             |
| [`75594987`](https://github.com/NixOS/nixpkgs/commit/75594987c955031e014a9b04bb0997f16bf5b6c5) | `` sublime4-dev: 4175 -> 4178 ``                                            |
| [`8d009a4c`](https://github.com/NixOS/nixpkgs/commit/8d009a4cad7d3e3006af41acf6b8a6a20a0f07fd) | `` sublime4: 4169 -> 4180 ``                                                |
| [`b4b8ef5b`](https://github.com/NixOS/nixpkgs/commit/b4b8ef5bb6f1d8b31aedf33b0962fd31fc2e09a9) | `` nixos/network-filesystems/samba: fix eval ``                             |
| [`e91370ca`](https://github.com/NixOS/nixpkgs/commit/e91370caa57e0d1a7d6c544f020341d1de794c36) | `` python312Packages.great-tables: add python312Packages.shiny for tests `` |
| [`4daf9708`](https://github.com/NixOS/nixpkgs/commit/4daf97081aa9ce6ba01e2159596bb5fafe0adfa2) | `` python312Packages.aiormq: 6.8.0 -> 6.8.1 ``                              |
| [`7294205a`](https://github.com/NixOS/nixpkgs/commit/7294205acdc0643e01381ed470a0bdca7a6e00a6) | `` python312Packages.obspy: 1.2.2 -> 1.4.1 ``                               |
| [`f1dfc8d3`](https://github.com/NixOS/nixpkgs/commit/f1dfc8d3636dfbde5b54a4c729eb41f221171cc7) | `` nixos/virtualisation.vmware.guest: remove `with lib;` ``                 |
| [`7d7e2942`](https://github.com/NixOS/nixpkgs/commit/7d7e294262b585b33737d6565aa4a08bf4c093a8) | `` nixos/virtualbox-image: remove `with lib;` ``                            |
| [`21755744`](https://github.com/NixOS/nixpkgs/commit/217557441c37a026d23bbf4466bdd30d52d1b5d1) | `` nixos/virtualisation.virtualbox.host: remove `with lib;` ``              |
| [`49fe5ca1`](https://github.com/NixOS/nixpkgs/commit/49fe5ca12cf77e40959a898772a4a9275e47263c) | `` nixos/virtualisation.virtualbox.guest: remove `with lib;` ``             |
| [`3cd35f78`](https://github.com/NixOS/nixpkgs/commit/3cd35f78308fc2276873aad28f1c1f63f7a2ed9a) | `` nixos/virtualisation.docker.rootless: remove `with lib;` ``              |
| [`dd7ab596`](https://github.com/NixOS/nixpkgs/commit/dd7ab59690f5f7f6a13eb49d1cb61fbf63a2b413) | `` nixos/services.nfs: remove `with lib;` ``                                |
| [`a83ffb43`](https://github.com/NixOS/nixpkgs/commit/a83ffb43de504535df0f97b9d504b2c120529396) | `` nixos/boot.tmp: remove `with lib;` ``                                    |
| [`2f7c0a17`](https://github.com/NixOS/nixpkgs/commit/2f7c0a170f741ef3fe320fd83124ed5530e549d9) | `` nixos/boot.loader.efi: remove `with lib;` ``                             |
| [`0a51fdb5`](https://github.com/NixOS/nixpkgs/commit/0a51fdb520065d897bf72d0ec798a7b80f8e287b) | `` nixos/systemd.enableEmergencyMode: remove `with lib;` ``                 |
| [`91cb7594`](https://github.com/NixOS/nixpkgs/commit/91cb7594d018e787b06d504e7ef60eee0cbed138) | `` nixos/boot.initrd.clevis: remove `with lib;` ``                          |
| [`1cd7970b`](https://github.com/NixOS/nixpkgs/commit/1cd7970bb8d97ba2f2b81ab11f724024174713ef) | `` nixos/services.matterbridge: remove `with lib;` ``                       |
| [`252e9bb1`](https://github.com/NixOS/nixpkgs/commit/252e9bb1e753186d427d94d85aaa1caa3b93551a) | `` nixos/services.lxd-image-server: remove `with lib;` ``                   |
| [`2e30f07c`](https://github.com/NixOS/nixpkgs/commit/2e30f07cc0594f52b4622f773dc8cee264636ecc) | `` nixos/services.logmein-hamachi: remove `with lib;` ``                    |
| [`196a14a1`](https://github.com/NixOS/nixpkgs/commit/196a14a174ac6966e8996e03fa89a02bbcd1dd1c) | `` nixos/services.lldpd: remove `with lib;` ``                              |
| [`0d57426b`](https://github.com/NixOS/nixpkgs/commit/0d57426bae16ff62a96338f80a00f869139b5cbc) | `` nixos/services.lambdabot: remove `with lib;` ``                          |
| [`081c71df`](https://github.com/NixOS/nixpkgs/commit/081c71df4bb5cd5c3cafc811fb20a7ed5f17c8e7) | `` nixos/services.keybase: remove `with lib;` ``                            |
| [`f3bb24eb`](https://github.com/NixOS/nixpkgs/commit/f3bb24eb64b3ee68f3c3ada08aed084264537133) | `` nixos/services.jotta-cli: remove `with lib;` ``                          |
| [`6c50168c`](https://github.com/NixOS/nixpkgs/commit/6c50168c7c5ba31a73e27c7b3528b117923ae25a) | `` nixos/services.jitsi-videobridge: remove `with lib;` ``                  |
| [`fee0a07c`](https://github.com/NixOS/nixpkgs/commit/fee0a07c2865e6e9b2bd66e65dbda268f9da50cd) | `` nixos/services.jigasi: remove `with lib;` ``                             |
| [`0cca8e97`](https://github.com/NixOS/nixpkgs/commit/0cca8e97562e44d6ca0923fda53058465b43cf54) | `` nixos/services.jicofo: remove `with lib;` ``                             |
| [`050c8194`](https://github.com/NixOS/nixpkgs/commit/050c81941d1f982d7c800efb28f8e73ca66fa7ba) | `` nixos/services.ivpn: remove `with lib;` ``                               |
| [`aa27551b`](https://github.com/NixOS/nixpkgs/commit/aa27551b009d69ef08ec973aa0ba164cfba1ef07) | `` nixos/services.iodine: remove `with lib;` ``                             |
| [`b610b3ca`](https://github.com/NixOS/nixpkgs/commit/b610b3cac2c390ceaff6106272b107320940d66a) | `` nixos/services.inadyn: remove `with lib;` ``                             |
| [`f69dd2df`](https://github.com/NixOS/nixpkgs/commit/f69dd2df9af8cabf7e54fb2b2b2e9a495712c13b) | `` nixos/services.i2p: remove `with lib;` ``                                |
| [`49224ecc`](https://github.com/NixOS/nixpkgs/commit/49224ecc3b41c31b8a566752b87e362a4825c0ce) | `` nixos/services.htpdate: remove `with lib;` ``                            |
| [`9ceab680`](https://github.com/NixOS/nixpkgs/commit/9ceab680a6c0d721d503c8339582be8cb1d36442) | `` nixos/services.haproxy: remove `with lib;` ``                            |
| [`f30e72ff`](https://github.com/NixOS/nixpkgs/commit/f30e72ffbb3f906943a6c696ae429754abf758a8) | `` nixos/services.hans: remove `with lib;` ``                               |
| [`a811ef82`](https://github.com/NixOS/nixpkgs/commit/a811ef8255b5b585309eac8e883cd6bdfef38a2b) | `` nixos/services.gobgpd: remove `with lib;` ``                             |
| [`90a98fc1`](https://github.com/NixOS/nixpkgs/commit/90a98fc1035dd7dc9b49d088a84528bc05a18456) | `` nixos/services.go-shadowsocks2: remove `with lib;` ``                    |
| [`2ec70782`](https://github.com/NixOS/nixpkgs/commit/2ec70782ab5b6883167a3e5334e1fdc1d7140077) | `` nixos/services.go-neb: remove `with lib;` ``                             |
| [`9ca9ac0b`](https://github.com/NixOS/nixpkgs/commit/9ca9ac0b5165d4c37addbb390f61997068c0442b) | `` nixos/services.go-autoconfig: remove `with lib;` ``                      |
| [`3e72e14a`](https://github.com/NixOS/nixpkgs/commit/3e72e14a6dd84429fdde7e24899bca10942d07c0) | `` nixos/services.gnunet: remove `with lib;` ``                             |
| [`7a65f586`](https://github.com/NixOS/nixpkgs/commit/7a65f586985d06875aaa075a98944dcd51a3c91f) | `` nixos/services.globalprotect: remove `with lib;` ``                      |
| [`878c5dc6`](https://github.com/NixOS/nixpkgs/commit/878c5dc6eb318111e856e7b1b70d5984cfd42816) | `` nixos/services.gitDaemon: remove `with lib;` ``                          |
| [`0b865525`](https://github.com/NixOS/nixpkgs/commit/0b865525e8484167f8471bb4531e0f14c67281e2) | `` nixos/services.gdomap: remove `with lib;` ``                             |
| [`d0901224`](https://github.com/NixOS/nixpkgs/commit/d0901224e12bd83d959a51b2cd3cec19c7100885) | `` nixos/services.gateone: remove `with lib;` ``                            |
| [`191b68cd`](https://github.com/NixOS/nixpkgs/commit/191b68cd26542cfebd561d678ca06b7958c977db) | `` nixos/services.frr: remove `with lib;` ``                                |
| [`fdcec053`](https://github.com/NixOS/nixpkgs/commit/fdcec053e6394a406be84daa65ae5cabc1201b87) | `` nixos/services.frp: remove `with lib;` ``                                |
| [`7cc95389`](https://github.com/NixOS/nixpkgs/commit/7cc95389d125c405e4215bf798618e56a30b8d3c) | `` nixos/services.freeradius: remove `with lib;` ``                         |
| [`a49fa6ee`](https://github.com/NixOS/nixpkgs/commit/a49fa6ee3bf1b16f5a796098eb8a4e6fe4312431) | `` nixos/services.freenet: remove `with lib;` ``                            |
| [`688b0893`](https://github.com/NixOS/nixpkgs/commit/688b08939c5460b73eae1a9f73bc53ca31e157ea) | `` nixos/services.flannel: remove `with lib;` ``                            |
| [`00d0e3ba`](https://github.com/NixOS/nixpkgs/commit/00d0e3ba987cd82fa823843ad53f2e80a32a8555) | `` nixos/networking.firewall: remove `with lib;` ``                         |
| [`e915ced8`](https://github.com/NixOS/nixpkgs/commit/e915ced8040d48eafd8f0365a787f935f2ca990c) | `` nixos/networking.firewall.nftables: remove `with lib;` ``                |
| [`15edaa6e`](https://github.com/NixOS/nixpkgs/commit/15edaa6e16be90a34bd0f549ae0dc6564e56cce0) | `` nixos/networking.firewall.iptables: remove `with lib;` ``                |