### PR TITLE
chore(flake/nixvim): `6a1bf6bd` -> `2f49c76a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1727370276,
-        "narHash": "sha256-CgMTCzKYilIzRSTCrui/4OvMj3yYXjPV+uSFPT9d2MM=",
+        "lastModified": 1727422267,
+        "narHash": "sha256-MH7KsHouYH2nLtQVXE3qSMVLnEeLux+leUQW+llWeUs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6a1bf6bdc30e0d92139165d30977db9d6ace4c69",
+        "rev": "2f49c76a6a158ce056c3e7c56e7e0a3d80658c90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`2f49c76a`](https://github.com/nix-community/nixvim/commit/2f49c76a6a158ce056c3e7c56e7e0a3d80658c90) | `` lib: remove `nixvimTypes` alias ``                                     |
| [`bafc6308`](https://github.com/nix-community/nixvim/commit/bafc6308f64f9a96f6bdb25b5f2a416b5d48958c) | `` plugins/none-ls/settings: cleanup lib usage ``                         |
| [`a32d2e6d`](https://github.com/nix-community/nixvim/commit/a32d2e6df07024b9f04e0c0f1f9693d0599ca164) | `` plugins: cleanup lib usage in several plugins ``                       |
| [`d718446b`](https://github.com/nix-community/nixvim/commit/d718446b61eb88bd5da5b72624cb2bd0513632d3) | `` lib: remove `maintainers` alias ``                                     |
| [`cb2b76c1`](https://github.com/nix-community/nixvim/commit/cb2b76c1a9ec067ed0c449080f4973fecf8532ef) | `` docs/home-manager: eval options without checking config definitions `` |