### PR TITLE
chore(flake/nixvim): `2f49c76a` -> `ae2b9bd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1727422267,
-        "narHash": "sha256-MH7KsHouYH2nLtQVXE3qSMVLnEeLux+leUQW+llWeUs=",
+        "lastModified": 1727447274,
+        "narHash": "sha256-Z/l2VSccO+gSDYp9fIg3q2sn4zjNlwTeFU0rC55CsAA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2f49c76a6a158ce056c3e7c56e7e0a3d80658c90",
+        "rev": "ae2b9bd445ebe5d5342172c66ecbf60028070d32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`ae2b9bd4`](https://github.com/nix-community/nixvim/commit/ae2b9bd445ebe5d5342172c66ecbf60028070d32) | `` plugins/idris2: init ``                                                  |
| [`6b0c5d59`](https://github.com/nix-community/nixvim/commit/6b0c5d594ac88e7765c97deeda10c5b6e812f7a7) | `` lib/modules: assert that `specialArgs` has a valid `lib` ``              |
| [`5020e587`](https://github.com/nix-community/nixvim/commit/5020e58798abe56f98a484757dba465e3d713641) | `` lib/modules: remove `specialArgsWith` ``                                 |
| [`4b7a4127`](https://github.com/nix-community/nixvim/commit/4b7a41276ae64dab0a046a4e5833892234b6598a) | `` modules/nixpkgs: initial `pkgs` option, drop `defaultPkgs` specialArg `` |
| [`8c3d521b`](https://github.com/nix-community/nixvim/commit/8c3d521bff0142f9b690bccd62c29b3ce8c71ac8) | `` modules: move `nixpkgs` module to top-level modules ``                   |
| [`31579dc2`](https://github.com/nix-community/nixvim/commit/31579dc201e6097e2bad05c8660c82a109ee2c24) | `` plugins/wrapping: init ``                                                |
| [`10925d81`](https://github.com/nix-community/nixvim/commit/10925d811ce6302f28e0272e04a04436527ed38d) | `` maintainers: add ZainKergaye ``                                          |