### PR TITLE
chore(flake/nixvim): `d42c804a` -> `33d030d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728176751,
-        "narHash": "sha256-hVmdzrZMFC/5q3dSjbKX9qocWN9coPBhs8muLsL3738=",
+        "lastModified": 1728245494,
+        "narHash": "sha256-bulK/Z+SEJaHM2PPk7W/kRvO51Ag9bTebcaWai9EEJc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d42c804ad515f45f8addaf5a4bb0b8ce405ea140",
+        "rev": "33d030d23c9b88bb29e300d702aade58c3734612",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`33d030d2`](https://github.com/nix-community/nixvim/commit/33d030d23c9b88bb29e300d702aade58c3734612) | `` plugins/nonels: remove with lib and helpers ``              |
| [`fb677540`](https://github.com/nix-community/nixvim/commit/fb677540e1b4bf182e744c7699e35ae14d5b3e61) | `` plugins/nonels: move to by-name ``                          |
| [`40cb7af2`](https://github.com/nix-community/nixvim/commit/40cb7af2b9eca28bff5537998c7b60031bb82816) | `` plugins/lsp-status: add undocumented options ``             |
| [`aaecda14`](https://github.com/nix-community/nixvim/commit/aaecda1471443e8278f4ec1ddc0b47a61b7af1ed) | `` docs: fix typo in standalone.md (`makeNixvimWithModule`) `` |
| [`31acdd4b`](https://github.com/nix-community/nixvim/commit/31acdd4b662e2243143d3091c4833d4a0448b424) | `` plugins/rest: move to by-name again ``                      |