### PR TITLE
chore(flake/nixvim): `182ffa45` -> `eda14029`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727999297,
-        "narHash": "sha256-LTJuQPCsSItZ/8TieFeP30iY+uaLoD0mT0tAj1gLeyQ=",
+        "lastModified": 1728385805,
+        "narHash": "sha256-mUd38b0vhB7yzgAjNOaFz7VY9xIVzlbn3P2wjGBcVV0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8c8388ade72e58efdeae71b4cbb79e872c23a56b",
+        "rev": "48b50b3b137be5cfb9f4d006835ce7c3fe558ccc",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728392812,
-        "narHash": "sha256-vphLzFlyrQR8hEECQQSEeikzXUzCdxq3OyoZFD1gwe4=",
+        "lastModified": 1728428263,
+        "narHash": "sha256-TG/ojDMLuLJI4nEo0waZawgAq4r30n7xJ8klEKpFcd0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "182ffa45838d22cd0d6e26718f8ac2b20dec389b",
+        "rev": "eda14029813906b1ef355823de237d86fea59908",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728343677,
-        "narHash": "sha256-KttVq9b9fwfpNaqvoLlcensvBz6t4O6r3h06DHvdMco=",
+        "lastModified": 1728423244,
+        "narHash": "sha256-+YwNsyIFj3dXyLVQd1ry4pCNmtOpbceKUrkNS8wp9Ho=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "dedcfefe55152fa257b9871fe467d7f771f6e2c8",
+        "rev": "f276cc3b391493ba3a8b30170776860f9520b7fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`eda14029`](https://github.com/nix-community/nixvim/commit/eda14029813906b1ef355823de237d86fea59908) | `` plugins/auto-session: migrate to mkNeovimPlugin ``                     |
| [`7f4cfa27`](https://github.com/nix-community/nixvim/commit/7f4cfa2728aea417f7f390df19d17df396823d7c) | `` plugins/auto-session: remove with lib and helpers ``                   |
| [`28485b0e`](https://github.com/nix-community/nixvim/commit/28485b0e57aa61ee3636e7226ddc7283ce11fe4c) | `` options-search: configure title ``                                     |
| [`543f4cce`](https://github.com/nix-community/nixvim/commit/543f4ccec664e3082015bfd71f1cc2d021b1b214) | `` flake.lock: Update ``                                                  |
| [`0e59a28e`](https://github.com/nix-community/nixvim/commit/0e59a28e95ee6f14392064e9acff3104118d1e59) | `` plugins/rustaceanvim: fix deprecation ``                               |
| [`ed4958c2`](https://github.com/nix-community/nixvim/commit/ed4958c20647efd45c7c266a37b8b9976c61eff1) | `` plugin/lsp: Re-enable sourcekit ``                                     |
| [`8d1e6f5a`](https://github.com/nix-community/nixvim/commit/8d1e6f5ac402f368ef8db72c0423e8f50308072c) | `` plugins/lsp: Enable all lsp servers in tests ``                        |
| [`8e8d9afe`](https://github.com/nix-community/nixvim/commit/8e8d9afe8e54597432be29ba757c4ed607ad691e) | `` plugins/lsp: Use the auto-generated lsp plugin list ``                 |
| [`c79bfb75`](https://github.com/nix-community/nixvim/commit/c79bfb75dae149646f417e9b0d7e88fdfbc81909) | `` plugins/lsp: Add a list of all nixpkgs server packages ``              |
| [`aa24b3f9`](https://github.com/nix-community/nixvim/commit/aa24b3f9d83fc9e59890f5664fc1d313c2fc7ad0) | `` update-scripts: Extract the list of all servers from nvim-lspconfig `` |
| [`cab6b0c9`](https://github.com/nix-community/nixvim/commit/cab6b0c9febfecd96e4cda3dfe4ec8675f6d9ddb) | `` tests: Split off in a single derivation the lsp server test ``         |