### PR TITLE
chore(flake/nixvim): `eda14029` -> `61ec3976`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728428263,
-        "narHash": "sha256-TG/ojDMLuLJI4nEo0waZawgAq4r30n7xJ8klEKpFcd0=",
+        "lastModified": 1728485062,
+        "narHash": "sha256-+2e9hAM2GVDF3gywdQI/OA7s4f0Z9rvFuiVxePI41QM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eda14029813906b1ef355823de237d86fea59908",
+        "rev": "61ec39764fbe1e4f21cf801ea7b9209d527c8135",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`61ec3976`](https://github.com/nix-community/nixvim/commit/61ec39764fbe1e4f21cf801ea7b9209d527c8135) | `` plugins/treesitter: update description `` |
| [`e8c8f7f3`](https://github.com/nix-community/nixvim/commit/e8c8f7f38ca1ced86ee24f5df34ce3f46ddd3620) | `` plugins/rest: update v3 options ``        |