### PR TITLE
chore(flake/nixvim): `61ec3976` -> `7916df22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728485062,
-        "narHash": "sha256-+2e9hAM2GVDF3gywdQI/OA7s4f0Z9rvFuiVxePI41QM=",
+        "lastModified": 1728571833,
+        "narHash": "sha256-hSMfDsmcPNx74soy7xK01squgiwNGf0eYTfbW8ZUCuk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "61ec39764fbe1e4f21cf801ea7b9209d527c8135",
+        "rev": "7916df22d2dde3d9db37047ce78bbf13e1129794",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728423244,
-        "narHash": "sha256-+YwNsyIFj3dXyLVQd1ry4pCNmtOpbceKUrkNS8wp9Ho=",
+        "lastModified": 1728513479,
+        "narHash": "sha256-yAR9M1jvuAoahYNxo3RNnPMcua1TAIPurFKmH2/g3lg=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "f276cc3b391493ba3a8b30170776860f9520b7fa",
+        "rev": "5cb7ef512ec20a5b7d60fc70dba014560559698a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`7916df22`](https://github.com/nix-community/nixvim/commit/7916df22d2dde3d9db37047ce78bbf13e1129794) | `` plugins/lsp: sort unpackaged ``                                    |
| [`d9dd5739`](https://github.com/nix-community/nixvim/commit/d9dd57390314a279f96912d6c0814029211dd7af) | `` generated/lspconfig-servers.json: update ``                        |
| [`b4f71a93`](https://github.com/nix-community/nixvim/commit/b4f71a933003eb3ff386eb91ddbf959cef771e82) | `` flake-modules/dev: exclude generated files from typos hook ``      |
| [`849c33c2`](https://github.com/nix-community/nixvim/commit/849c33c2839a55d52a9ee6ae1d522bdf5bf28e07) | `` update-scripts/nvim-lspconfig: server_configurations -> configs `` |
| [`684df4d9`](https://github.com/nix-community/nixvim/commit/684df4d93dabf81ebfe8d01709121fc68bf32a3e) | `` tests/lua-ls: disable on x86_64-darwin ``                          |
| [`75ae1057`](https://github.com/nix-community/nixvim/commit/75ae10571da39dbaaf13e2520d8d27715549630d) | `` tests/byte-compile-lua: server_configurations -> configs ``        |
| [`c7fc3812`](https://github.com/nix-community/nixvim/commit/c7fc381247c068c7f869b6b21fa1b2015ffa0aa5) | `` tests/magma-nvim: only run on linux ``                             |
| [`f830aada`](https://github.com/nix-community/nixvim/commit/f830aada6f815e892f022466e173f10f1cb670a7) | `` flake.lock: Update ``                                              |