### PR TITLE
chore(flake/nixvim): `7916df22` -> `af650ba9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728571833,
-        "narHash": "sha256-hSMfDsmcPNx74soy7xK01squgiwNGf0eYTfbW8ZUCuk=",
+        "lastModified": 1728593423,
+        "narHash": "sha256-xM3+7mvWwM5i+RXD97wQ/fSoQDFidVxNszIfKIv9msE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7916df22d2dde3d9db37047ce78bbf13e1129794",
+        "rev": "af650ba9401501352d6eaaced192bbb4abfaec87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`af650ba9`](https://github.com/nix-community/nixvim/commit/af650ba9401501352d6eaaced192bbb4abfaec87) | `` tests/lsp-servers: de-couple from grouped tests ``                        |
| [`88302aa1`](https://github.com/nix-community/nixvim/commit/88302aa17aa9693bc683d626f34263b0247ce052) | `` plugins/lsp: use a no-default option when there is no default provided `` |
| [`0d2751b5`](https://github.com/nix-community/nixvim/commit/0d2751b53c6c69a3c4ef43b0d3a8fb773899f09c) | `` tests/generated: validate declared lsp packages ``                        |