### PR TITLE
chore(flake/pre-commit-hooks): `4ebefcac` -> `6d7586d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728580416,
-        "narHash": "sha256-nKttjKg6lE7O5S+wlBOkXsUGdOgVxZ8SWaCOyodW5so=",
+        "lastModified": 1728634248,
+        "narHash": "sha256-f+Z7KHEHiitzHkG0H+yzZHzERvHr66bUaQ2akM/y3ww=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4ebefcac44b5116cf5741be858245db769ddedd1",
+        "rev": "6d7586d0d35ccd1e87bb0ffb7c0d38b4cc0fe469",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`1fe5afc7`](https://github.com/cachix/git-hooks.nix/commit/1fe5afc78489820f5586a9c90f91358a169604a7) | `` statix: fix broken list option `--ignore` `` |
| [`6ce0397f`](https://github.com/cachix/git-hooks.nix/commit/6ce0397f4bd8af17e83639f7c561a64799fd81ae) | `` feat(rustfmt): add settings ``               |