### PR TITLE
chore(flake/pre-commit-hooks): `6d7586d0` -> `06bb5971`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728634248,
-        "narHash": "sha256-f+Z7KHEHiitzHkG0H+yzZHzERvHr66bUaQ2akM/y3ww=",
+        "lastModified": 1728651332,
+        "narHash": "sha256-lm+asqDSTj0m6j1dtEte1/XG+uzZbwxS3tn7JLaBw84=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "6d7586d0d35ccd1e87bb0ffb7c0d38b4cc0fe469",
+        "rev": "06bb5971c139959d9a951f34e4264d32f5d998e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`6a3d0eb6`](https://github.com/cachix/git-hooks.nix/commit/6a3d0eb6b64920b33683111bce68d1f4a9ef51dd) | `` statix: skip adding `--ignore` if empty `` |