### PR TITLE
chore(flake/nixvim): `af650ba9` -> `5cd8c9cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728593423,
-        "narHash": "sha256-xM3+7mvWwM5i+RXD97wQ/fSoQDFidVxNszIfKIv9msE=",
+        "lastModified": 1728603032,
+        "narHash": "sha256-RAKCcBXqF/xOaf7fR11dnIZwZ8SDyNcK3MyVgD0l1xQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "af650ba9401501352d6eaaced192bbb4abfaec87",
+        "rev": "5cd8c9cf3104027b42ffe531fb68463ecb08ebc9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`5cd8c9cf`](https://github.com/nix-community/nixvim/commit/5cd8c9cf3104027b42ffe531fb68463ecb08ebc9) | `` wrappers: define `pkgs` default within type declaration ``       |
| [`e1c0b524`](https://github.com/nix-community/nixvim/commit/e1c0b524877cfa55541915f479dad1c81aecec71) | `` wrappers: move `programs.nixvim` declaration to `_shared.nix` `` |