### PR TITLE
chore(flake/nixvim): `2e1b3b7d` -> `48b62ac2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728736326,
-        "narHash": "sha256-JYy050VI7AQyDPHjZ/48rdNFfVvdbR0wPtsRA/4nc7E=",
+        "lastModified": 1728752931,
+        "narHash": "sha256-ZTj+Ahtouc9m9Ea4qfAFAkOR/1cq+6H7BOjO69MjZ78=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2e1b3b7d43f485866573f70411a4797ce38e27bb",
+        "rev": "48b62ac2e607fb0c5332ba2a2455e9cf3184832a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`48b62ac2`](https://github.com/nix-community/nixvim/commit/48b62ac2e607fb0c5332ba2a2455e9cf3184832a) | `` plugins/trouble: update to v3 ``                |
| [`066ee7d0`](https://github.com/nix-community/nixvim/commit/066ee7d0a94f292d851361ea33d870905e741982) | `` plugins/trouble: remove with lib and helpers `` |
| [`df515c65`](https://github.com/nix-community/nixvim/commit/df515c651e4b9d6983cdfa2eaaa285085066a6f9) | `` tests/trouble: add more examples ``             |