### PR TITLE
chore(flake/nixvim): `48b62ac2` -> `619e2436`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728752931,
-        "narHash": "sha256-ZTj+Ahtouc9m9Ea4qfAFAkOR/1cq+6H7BOjO69MjZ78=",
+        "lastModified": 1728829992,
+        "narHash": "sha256-722PdOQ4uTTAOyS3Ze4H7LXDNVi9FecKbLEvj3Qu0hM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "48b62ac2e607fb0c5332ba2a2455e9cf3184832a",
+        "rev": "619e24366e8ad34230d65a323d26ca981bfa6927",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`619e2436`](https://github.com/nix-community/nixvim/commit/619e24366e8ad34230d65a323d26ca981bfa6927) | `` plugins/lsp/hls: handle automatic installation of required GHC ``        |
| [`767eb62f`](https://github.com/nix-community/nixvim/commit/767eb62f48c0818e9f4392dc3eb61572cc8bd11d) | `` modules/output: obtain plugin configs from wrapped neovim ``             |
| [`ba77e887`](https://github.com/nix-community/nixvim/commit/ba77e88740a66c6e8e37297321960deb5d24162e) | `` modules/output: remove unused binding ``                                 |
| [`21f7ed6e`](https://github.com/nix-community/nixvim/commit/21f7ed6eb617089f9ea7251303a2567e8ab43e29) | `` tests/modules/output: test that init.lua contains all config sections `` |