### PR TITLE
chore(flake/nixvim): `25b8d2ab` -> `429f2e8d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728727368,
-        "narHash": "sha256-7FMyNISP7K6XDSIt1NJxkXZnEdV3HZUXvFoBaJ/qdOg=",
+        "lastModified": 1728778939,
+        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "eb74e0be24a11a1531b5b8659535580554d30b28",
+        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728726232,
-        "narHash": "sha256-8ZWr1HpciQsrFjvPMvZl0W+b0dilZOqXPoKa2Ux36bc=",
+        "lastModified": 1728903686,
+        "narHash": "sha256-ZHFrGNWDDriZ4m8CA/5kDa250SG1LiiLPApv1p/JF0o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d57112db877f07387ce7104b5ac346ede556d2d7",
+        "rev": "e1aec543f5caf643ca0d94b6a633101942fd065f",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728385805,
-        "narHash": "sha256-mUd38b0vhB7yzgAjNOaFz7VY9xIVzlbn3P2wjGBcVV0=",
+        "lastModified": 1728901530,
+        "narHash": "sha256-I9Qd0LnAsEGHtKE9+uVR0iDFmsijWSy7GT0g3jihG4Q=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "48b50b3b137be5cfb9f4d006835ce7c3fe558ccc",
+        "rev": "a60ac02f9466f85f092e576fd8364dfc4406b5a6",
         "type": "github"
       },
       "original": {
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1728985146,
-        "narHash": "sha256-Kopqg/ZYUxle3wNruPmISv7uU/iMJQ4/wEqx4rGG4xA=",
+        "lastModified": 1729015933,
+        "narHash": "sha256-raKxsI2SGe/vF2PvzFatd/Sl9eVUCuCUUVg7cINFVbQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "25b8d2ab20fbc4a291e83a490382d503c999ab3a",
+        "rev": "429f2e8d1aa61181c0ec72bdafe022fbb6a092d6",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728701796,
-        "narHash": "sha256-FTDCOUnq+gdnHC3p5eisv1X1mMtKJDNMegwpZjRzQKY=",
+        "lastModified": 1728905062,
+        "narHash": "sha256-W/lClt0bRgFRO0WFtytX/LEILpPNq+FOjIfESpkeu5c=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "9578d865b081c29ae98131caf7d2f69a42f0ca6e",
+        "rev": "f82d3e1c1c9d1eaeb91878519e2d27b27c66ce84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`429f2e8d`](https://github.com/nix-community/nixvim/commit/429f2e8d1aa61181c0ec72bdafe022fbb6a092d6) | `` plugins/lsp/efmls-configs: enable lua_format on x86 darwin ``  |
| [`296bb568`](https://github.com/nix-community/nixvim/commit/296bb568ee160657380cbca2ee34926a62ff517f) | `` plugins/lsp/efmls-configs: enable php tests again on darwin `` |
| [`db95f9db`](https://github.com/nix-community/nixvim/commit/db95f9dbd4e693fb9157dd90b7a011808bee2d81) | `` plugins/none-ls: disable broken packages ``                    |
| [`49f7d73d`](https://github.com/nix-community/nixvim/commit/49f7d73de55c348b2446cbef5af066cc63e93ce4) | `` plugins/lsp/efmls-configs: disable dmd ``                      |
| [`bb86faf8`](https://github.com/nix-community/nixvim/commit/bb86faf8cf4e2da8aff5791915283730549b008c) | `` plugins/auto-save: fix deprecation errors ``                   |
| [`ca5ba6d5`](https://github.com/nix-community/nixvim/commit/ca5ba6d5fe8330e9e32db60f8a392338b5fa9c91) | `` generated: Update ``                                           |
| [`6235f274`](https://github.com/nix-community/nixvim/commit/6235f2745d68258eab3a472e30e1d7f7c870f1e4) | `` flake.lock: Update ``                                          |