### PR TITLE
chore(flake/nixvim): `429f2e8d` -> `717e7060`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1729015933,
-        "narHash": "sha256-raKxsI2SGe/vF2PvzFatd/Sl9eVUCuCUUVg7cINFVbQ=",
+        "lastModified": 1729093974,
+        "narHash": "sha256-gQ0Zb0YN5+wqzq5v8vh0ssWZgyYzoiiT7La6WWOFiXM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "429f2e8d1aa61181c0ec72bdafe022fbb6a092d6",
+        "rev": "717e7060fafa2c3822a64e3f5bbfd4895577fdbf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`717e7060`](https://github.com/nix-community/nixvim/commit/717e7060fafa2c3822a64e3f5bbfd4895577fdbf) | `` plugins/telescope/live-greps-args: fix `to_fuzzy_refine` example `` |
| [`b9ea7f88`](https://github.com/nix-community/nixvim/commit/b9ea7f88b6117f076d3b122d9bec3f379c57a17a) | `` plugins/nixvim: init ``                                             |