### PR TITLE
chore(flake/nixvim): `3c7b6ae5` -> `036e1166`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1729196897,
-        "narHash": "sha256-xftdQl0kxWJZNWCDSl0pU2E7zCmGjhD/N9ZWgPXK0A0=",
+        "lastModified": 1729281122,
+        "narHash": "sha256-fcV0T+Spw5/vF1Rgt/UiH4gKIDbb5NiIGagmBIULFyA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3c7b6ae5d1524c691a1b65f7290facd0dc296e40",
+        "rev": "036e11665f819ebf1dddf493ba212c1ec441eaad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`036e1166`](https://github.com/nix-community/nixvim/commit/036e11665f819ebf1dddf493ba212c1ec441eaad) | `` tests: cleanup tests to better use `callTest` pattern `` |
| [`4a508cee`](https://github.com/nix-community/nixvim/commit/4a508ceee235edf0a094e21ea1687c45d3cc4d6b) | `` tests: use `callTest` pattern ``                         |
| [`990ef039`](https://github.com/nix-community/nixvim/commit/990ef039f79cd75a4a2b2ffeba5f45a21cb5ccc6) | `` tests: move test derivations to `tests/default.nix` ``   |