### PR TITLE
chore(flake/nixpkgs): `a3c0b3b2` -> `5785b6bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -249,11 +249,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728888510,
-        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
+        "lastModified": 1729070438,
+        "narHash": "sha256-KOTTUfPkugH52avUvXGxvWy8ibKKj4genodIYUED+Kc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+        "rev": "5785b6bb5eaae44e627d541023034e1601455827",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`f30a0466`](https://github.com/NixOS/nixpkgs/commit/f30a04667246ba84b5e4335a5a38fe52bd175635) | `` .github/workflows: remove update-terraform-providers ``          |
| [`4ea3ee89`](https://github.com/NixOS/nixpkgs/commit/4ea3ee8920abc4b402091ce3dd26a826795f079a) | `` terraform-providers: enable update bot ``                        |
| [`1fc46edf`](https://github.com/NixOS/nixpkgs/commit/1fc46edf19c4706001dbab0d9f53ea09443d7431) | `` Revert "terraform-providers: bump go to 1.23" ``                 |
| [`e1826774`](https://github.com/NixOS/nixpkgs/commit/e18267741b4db55e8a4869565ab4646cd717b29e) | `` terraform-providers.yandex: 0.128.0 -> 0.130.0 ``                |
| [`db7c46d7`](https://github.com/NixOS/nixpkgs/commit/db7c46d7e0b6501d09905d38437a1ccd0076b8ce) | `` terraform-providers.vsphere: 2.9.1 -> 2.9.3 ``                   |
| [`cc475b71`](https://github.com/NixOS/nixpkgs/commit/cc475b71d634e696043b95e926c1452d00b544f1) | `` terraform-providers.venafi: 0.21.0 -> 0.21.1 ``                  |
| [`8415d801`](https://github.com/NixOS/nixpkgs/commit/8415d801894a0ffd6e45c62408dd199741b926bf) | `` terraform-providers.vcd: 3.13.0 -> 3.14.0 ``                     |
| [`065dd8cd`](https://github.com/NixOS/nixpkgs/commit/065dd8cd01a02b26c11789ef55dca715490437b9) | `` terraform-providers.turbot: 1.11.1 -> 1.11.2 ``                  |
| [`a9bb6f80`](https://github.com/NixOS/nixpkgs/commit/a9bb6f804dc25adf1db54dfedf53d836b9fd7ab7) | `` terraform-providers.tls: 4.0.5 -> 4.0.6 ``                       |
| [`ca5b040a`](https://github.com/NixOS/nixpkgs/commit/ca5b040a7e00c334d694433b698fcf87eec91bb8) | `` terraform-providers.tencentcloud: 1.81.120 -> 1.81.133 ``        |
| [`462008b2`](https://github.com/NixOS/nixpkgs/commit/462008b2d909335fcadca9c395ac8d58a6f19fb6) | `` terraform-providers.time: 0.12.0 -> 0.12.1 ``                    |
| [`cd446b66`](https://github.com/NixOS/nixpkgs/commit/cd446b66bcce13b10ce935348c43208b3e545518) | `` terraform-providers.tfe: 0.58.1 -> 0.59.0 ``                     |
| [`4fa20007`](https://github.com/NixOS/nixpkgs/commit/4fa200071b6d93bebd236c8509c677ac64bbd3e3) | `` terraform-providers.talos: 0.5.0 -> 0.6.0 ``                     |
| [`48ed6b17`](https://github.com/NixOS/nixpkgs/commit/48ed6b1772035b32876dfe5d9d6abd32419c2583) | `` terraform-providers.temporalcloud: 0.0.11 -> 0.0.13 ``           |
| [`4e11b5e1`](https://github.com/NixOS/nixpkgs/commit/4e11b5e197dcd2853773889a6a87c61a3330a166) | `` terraform-providers.sumologic: 2.31.3 -> 2.31.5 ``               |
| [`b6c51b7f`](https://github.com/NixOS/nixpkgs/commit/b6c51b7f3b11b6c0d69a2f5eb7d52ecb61a9832b) | `` terraform-providers.tailscale: 0.16.2 -> 0.17.2 ``               |
| [`d3b2afa4`](https://github.com/NixOS/nixpkgs/commit/d3b2afa4ea434d375987a0349cc44ce1cd36c44c) | `` terraform-providers.snowflake: 0.95.0 -> 0.97.0 ``               |
| [`560c4d53`](https://github.com/NixOS/nixpkgs/commit/560c4d53d5aa843307afac91f8d453f31d9548de) | `` terraform-providers.spotinst: 1.190.0 -> 1.195.0 ``              |
| [`f65d66ac`](https://github.com/NixOS/nixpkgs/commit/f65d66ac10665407c02516b2fa079a9a8d92dc9d) | `` terraform-providers.spacelift: 1.15.0 -> 1.16.1 ``               |
| [`184153e9`](https://github.com/NixOS/nixpkgs/commit/184153e9e487ff7e182194bd99c4585cec18e106) | `` terraform-providers.selectel: 5.3.0 -> 5.4.0 ``                  |
| [`c056b546`](https://github.com/NixOS/nixpkgs/commit/c056b54608c4c9ffb0444207a251cac19de5d3fb) | `` terraform-providers.scaleway: 2.44.0 -> 2.46.0 ``                |
| [`240151db`](https://github.com/NixOS/nixpkgs/commit/240151db3192e93d5cfff414978a07edbb32f39d) | `` terraform-providers.rancher2: 5.0.0 -> 5.1.0 ``                  |
| [`b2f44e34`](https://github.com/NixOS/nixpkgs/commit/b2f44e343f52356e4ecd8e8b888ff9991347d568) | `` terraform-providers.rundeck: 0.4.7 -> 0.4.9 ``                   |
| [`cba6865f`](https://github.com/NixOS/nixpkgs/commit/cba6865f97155779e8c1c0a91ee2f3e7025ba574) | `` terraform-providers.random: 3.6.2 -> 3.6.3 ``                    |
| [`d6bd07bb`](https://github.com/NixOS/nixpkgs/commit/d6bd07bb08132fd8c167061031215bc7774a9c72) | `` terraform-providers.project: 1.7.2 -> 1.8.0 ``                   |
| [`fb3503ee`](https://github.com/NixOS/nixpkgs/commit/fb3503ee7a1310f4b89d061a9d2109cbfac097cb) | `` terraform-providers.pagerduty: 3.15.6 -> 3.16.0 ``               |
| [`05983d10`](https://github.com/NixOS/nixpkgs/commit/05983d10a425ab32ce27a1be63d56ace707b069e) | `` terraform-providers.ovh: 0.48.0 -> 0.51.0 ``                     |
| [`45348859`](https://github.com/NixOS/nixpkgs/commit/45348859e2ddd4e10b6b08da186eb69134325f87) | `` terraform-providers.opentelekomcloud: 1.36.18 -> 1.36.20 ``      |
| [`02638055`](https://github.com/NixOS/nixpkgs/commit/026380558ca1be4f6d73e07e08bc4950645f5b92) | `` terraform-providers.oci: 6.9.0 -> 6.13.0 ``                      |
| [`d00b5b2a`](https://github.com/NixOS/nixpkgs/commit/d00b5b2a8a7c8087346b05d58f20eece3970cb69) | `` terraform-providers.okta: 4.10.0 -> 4.11.0 ``                    |
| [`ae0a45f4`](https://github.com/NixOS/nixpkgs/commit/ae0a45f4aee16bb2cdebd9210706066ed8e64d9b) | `` terraform-providers.openstack: 2.1.0 -> 3.0.0 ``                 |
| [`1707091b`](https://github.com/NixOS/nixpkgs/commit/1707091b938b0cee8b8f40526ff35eeedb8c0156) | `` terraform-providers.null: 3.2.2 -> 3.2.3 ``                      |
| [`2fd45f6f`](https://github.com/NixOS/nixpkgs/commit/2fd45f6fc3b5f52a1eb22e85f09b1d90e2d994cd) | `` terraform-providers.ns1: 2.4.1 -> 2.4.4 ``                       |
| [`f835fc0b`](https://github.com/NixOS/nixpkgs/commit/f835fc0b0aacb8837d8f85de0ab1fed7ab582798) | `` terraform-providers.nomad: 2.3.1 -> 2.4.0 ``                     |
| [`6f519bbf`](https://github.com/NixOS/nixpkgs/commit/6f519bbf58e31dcd3e3b0bd83a93917e215b9240) | `` terraform-providers.newrelic: 3.45.0 -> 3.50.0 ``                |
| [`db241362`](https://github.com/NixOS/nixpkgs/commit/db24136263fd6ac379c7ec5a57540177dfbf8003) | `` terraform-providers.mongodbatlas: 1.18.1 -> 1.21.1 ``            |
| [`8185860a`](https://github.com/NixOS/nixpkgs/commit/8185860a3ebdd9b7d890539434a4af85ed76c795) | `` terraform-providers.migadu: 2024.9.5 -> 2024.10.10 ``            |
| [`7bd0ef8a`](https://github.com/NixOS/nixpkgs/commit/7bd0ef8af117311b4957e74117ceda79efc83478) | `` terraform-providers.lxd: 2.3.0 -> 2.4.0 ``                       |
| [`0bb2dd57`](https://github.com/NixOS/nixpkgs/commit/0bb2dd5730078aa7d3dd59754937450f6df9e03e) | `` terraform-providers.minio: 2.5.0 -> 2.5.1 ``                     |
| [`03f23f73`](https://github.com/NixOS/nixpkgs/commit/03f23f730a4591b573236d14a11671dddf75150e) | `` terraform-providers.local: 2.5.1 -> 2.5.2 ``                     |
| [`187d8271`](https://github.com/NixOS/nixpkgs/commit/187d8271da852aa7b7507282d6883620ea1d6bcc) | `` terraform-providers.linode: 2.27.0 -> 2.29.1 ``                  |
| [`ea3801dd`](https://github.com/NixOS/nixpkgs/commit/ea3801dd2163c9fa2f0a4235d3d0f93168a5d28f) | `` terraform-providers.ibm: 1.69.0 -> 1.70.0 ``                     |
| [`1e9015a5`](https://github.com/NixOS/nixpkgs/commit/1e9015a58c35b557e042bdeb1bd7677561c98252) | `` terraform-providers.kubernetes: 2.32.0 -> 2.33.0 ``              |
| [`2ebd99a8`](https://github.com/NixOS/nixpkgs/commit/2ebd99a8c4b9a97efbba45cc66eb732b3c7e5ddb) | `` terraform-providers.libvirt: 0.7.6 -> 0.8.0 ``                   |
| [`eafdc604`](https://github.com/NixOS/nixpkgs/commit/eafdc604b234fc00b4b3113145714b96c6dad1b0) | `` terraform-providers.huaweicloud: 1.68.1 -> 1.69.0 ``             |
| [`b6c5dcc6`](https://github.com/NixOS/nixpkgs/commit/b6c5dcc6806c9e1406395969d59bfecbecb226e0) | `` terraform-providers.helm: 2.15.0 -> 2.16.1 ``                    |
| [`58d9eadf`](https://github.com/NixOS/nixpkgs/commit/58d9eadf7ca043a5c85246f3a7deef8c61e88d63) | `` terraform-providers.http: 3.4.4 -> 3.4.5 ``                      |
| [`db395f6f`](https://github.com/NixOS/nixpkgs/commit/db395f6f20f21079552d55cb98cb5443638dac70) | `` terraform-providers.google-beta: 6.2.0 -> 6.7.0 ``               |
| [`17486b42`](https://github.com/NixOS/nixpkgs/commit/17486b423197e16e0bbf7dc9e5f8429175d2c6ab) | `` terraform-providers.grafana: 3.7.0 -> 3.10.0 ``                  |
| [`471d42db`](https://github.com/NixOS/nixpkgs/commit/471d42dbf2cc503f9e9618e7659431374a660c41) | `` terraform-providers.google: 6.2.0 -> 6.7.0 ``                    |
| [`b71238a0`](https://github.com/NixOS/nixpkgs/commit/b71238a07414d72cef565f3f3efe0cc82f0a2fc5) | `` terraform-providers.fortios: 1.20.0 -> 1.21.0 ``                 |
| [`4e4076bb`](https://github.com/NixOS/nixpkgs/commit/4e4076bb68a0c80026f4733a1188cc0ed1cea1ab) | `` terraform-providers.gitlab: 17.3.1 -> 17.4.0 ``                  |
| [`f8bc5193`](https://github.com/NixOS/nixpkgs/commit/f8bc5193097f9717c2d66e566fc122c5820baae9) | `` terraform-providers.github: 6.2.3 -> 6.3.1 ``                    |
| [`893b6d4b`](https://github.com/NixOS/nixpkgs/commit/893b6d4bd296c20b8dc5cd98df983224f35f7390) | `` terraform-providers.fastly: 5.13.0 -> 5.14.0 ``                  |
| [`4b1e0ef2`](https://github.com/NixOS/nixpkgs/commit/4b1e0ef268d62f28f6013a7e86ba7c3c1672b03f) | `` terraform-providers.external: 2.3.3 -> 2.3.4 ``                  |
| [`57b20a89`](https://github.com/NixOS/nixpkgs/commit/57b20a896bc41852be59be8da239c288523b801c) | `` terraform-providers.equinix: 2.4.1 -> 2.8.0 ``                   |
| [`013da8ed`](https://github.com/NixOS/nixpkgs/commit/013da8ed4a7c0a63e8a98ef459fcb0ae97794e9e) | `` terraform-providers.exoscale: 0.59.2 -> 0.61.0 ``                |
| [`7656afdd`](https://github.com/NixOS/nixpkgs/commit/7656afdde12238893510a20a4065901b58f24b3e) | `` terraform-providers.doppler: 1.10.0 -> 1.11.0 ``                 |
| [`74fecb9c`](https://github.com/NixOS/nixpkgs/commit/74fecb9cdf6109f8bd28ccd25d5ce620e546c6d8) | `` terraform-providers.datadog: 3.44.0 -> 3.46.0 ``                 |
| [`16f846a2`](https://github.com/NixOS/nixpkgs/commit/16f846a2e5f284037ce1bd6f6250b6cbd7d206b6) | `` terraform-providers.dns: 3.4.1 -> 3.4.2 ``                       |
| [`4e9af7e2`](https://github.com/NixOS/nixpkgs/commit/4e9af7e2d067a567814ae61279b4320a8363caff) | `` terraform-providers.digitalocean: 2.40.0 -> 2.42.0 ``            |
| [`f1a16d02`](https://github.com/NixOS/nixpkgs/commit/f1a16d027b323f1eaa0af1e1ac1ef023bc8bfae8) | `` terraform-providers.cloudinit: 2.3.4 -> 2.3.5 ``                 |
| [`704300f6`](https://github.com/NixOS/nixpkgs/commit/704300f628393d1b7c4eeabd22b07287add8d685) | `` terraform-providers.aws: 5.66.0 -> 5.72.0 ``                     |
| [`e300f054`](https://github.com/NixOS/nixpkgs/commit/e300f05416e8c38a2399da6f3aab6c00a71bdc70) | `` terraform-providers.buildkite: 1.10.2 -> 1.12.0 ``               |
| [`d8819434`](https://github.com/NixOS/nixpkgs/commit/d8819434b90d8eec229ef162a336ca1e7a531b17) | `` terraform-providers.azurerm: 4.1.0 -> 4.5.0 ``                   |
| [`893030ea`](https://github.com/NixOS/nixpkgs/commit/893030eac1e9c418b5b50d0ff6b0ca544c1bd634) | `` terraform-providers.bitwarden: 0.8.1 -> 0.10.0 ``                |
| [`fbab3c43`](https://github.com/NixOS/nixpkgs/commit/fbab3c434466086eb17398e5afa7fb403e678d3d) | `` terraform-providers.bigip: 1.22.3 -> 1.22.4 ``                   |
| [`e84b7b9e`](https://github.com/NixOS/nixpkgs/commit/e84b7b9eaf3b929f9aa273d5295e3dbfd1f95183) | `` terraform-providers.azuread: 2.53.1 -> 3.0.2 ``                  |
| [`b27168e4`](https://github.com/NixOS/nixpkgs/commit/b27168e440c54ab58d1243e1c760c66231fe04a5) | `` terraform-providers.aviatrix: 3.1.5 -> 3.2.0 ``                  |
| [`e924205e`](https://github.com/NixOS/nixpkgs/commit/e924205eae182d8552dee5acc12e2fd44c7c55d4) | `` terraform-providers.argocd: 6.1.1 -> 6.2.0 ``                    |
| [`3043bf71`](https://github.com/NixOS/nixpkgs/commit/3043bf714ccb07369068746e2dfa31221bb85134) | `` terraform-providers.auth0: 1.6.0 -> 1.7.1 ``                     |
| [`24437279`](https://github.com/NixOS/nixpkgs/commit/24437279d11160128193a45de1e1e8d88ca2f5f1) | `` terraform-providers.alicloud: 1.230.0 -> 1.231.0 ``              |
| [`a05e96c1`](https://github.com/NixOS/nixpkgs/commit/a05e96c1c67a9cf091f4c77c06833bf767fe1269) | `` terraform-providers.artifactory: 11.9.1 -> 12.2.0 ``             |
| [`74aa7083`](https://github.com/NixOS/nixpkgs/commit/74aa708325a5e4b824aa05543e491b81d29046e2) | `` terraform-providers.akamai: 6.4.0 -> 6.5.0 ``                    |
| [`364420f3`](https://github.com/NixOS/nixpkgs/commit/364420f361f1b17618aa7673aef3c534ce60eec2) | `` terraform-providers.aiven: 4.24.0 -> 4.27.0 ``                   |
| [`cbdb8ee3`](https://github.com/NixOS/nixpkgs/commit/cbdb8ee3e0f838f8f0a2b63c24f69b4a4848103e) | `` vrc-get: 1.8.1 -> 1.8.2 ``                                       |
| [`49473d40`](https://github.com/NixOS/nixpkgs/commit/49473d40836337a5a849c5c33bf421c894398263) | `` cliphist: 0.6.0 -> 0.6.1 ``                                      |
| [`978f4e45`](https://github.com/NixOS/nixpkgs/commit/978f4e458ff492d035bab86a0bee5501bc1c8ac3) | `` edl: mark as unfree ``                                           |
| [`3f4b6c6f`](https://github.com/NixOS/nixpkgs/commit/3f4b6c6f167d4a7a492ccf74adda288b73b85d16) | `` cliphist: add update script ``                                   |
| [`ea4ca62e`](https://github.com/NixOS/nixpkgs/commit/ea4ca62e96b59ced420a0209eb0f7a217e4f18d3) | `` cliphist: move to by-name ``                                     |
| [`22d53c33`](https://github.com/NixOS/nixpkgs/commit/22d53c3318d9c3d20965d1ffc1b5e97c670ebe9f) | `` cliphist: 0.5.0 -> 0.6.0 ``                                      |
| [`97686ec9`](https://github.com/NixOS/nixpkgs/commit/97686ec9073b9349e6a0c0555190310ec55cdf72) | `` darling: fix build with ffmpeg_7 ``                              |
| [`631dbc68`](https://github.com/NixOS/nixpkgs/commit/631dbc683015c6787163ee0f91cbec54fe4f8807) | `` rPackages.ragg: 1.3.2 -> 1.3.3 ``                                |
| [`2dbd40a1`](https://github.com/NixOS/nixpkgs/commit/2dbd40a19a9ec828792a7bdb49ab324296c6c089) | `` qcad: use stdenv.mkDerivation ``                                 |
| [`42a12a05`](https://github.com/NixOS/nixpkgs/commit/42a12a0551a59ec1ad09d87d70b1dcabb323f92d) | `` nixos-rebuild: Fix broken -I option ``                           |
| [`3781c470`](https://github.com/NixOS/nixpkgs/commit/3781c47074042fb797dec854ef7a9a0b2c8af6f0) | `` vimPlugins.nvim-treesitter: update grammars ``                   |
| [`5be77acb`](https://github.com/NixOS/nixpkgs/commit/5be77acb621ca19932c663a7c6a12f3719e04bed) | `` vimPlugins: update on 2024-10-15 ``                              |
| [`0ed4d765`](https://github.com/NixOS/nixpkgs/commit/0ed4d765b4452a9beee4c20c64385d7b1a090652) | `` qpwgraph: 0.7.5 -> 0.7.8 ``                                      |
| [`ec2b16f5`](https://github.com/NixOS/nixpkgs/commit/ec2b16f5ac4ae58bd82c539ad6de853322c56e88) | `` setconf: migrate to by-name ``                                   |
| [`56137a2c`](https://github.com/NixOS/nixpkgs/commit/56137a2cacefb66c8b9cd11d6a44349a100474e8) | `` setconf: get rid of rec ``                                       |
| [`96043dc7`](https://github.com/NixOS/nixpkgs/commit/96043dc729d5701783b17830e135b9bd0d8fd155) | `` setconf: use the new Python packaging guidelines ``              |
| [`d9ce15a3`](https://github.com/NixOS/nixpkgs/commit/d9ce15a363306688d7d088bde06a45bb9d706d18) | `` bitwarden-desktop: remove unneeded dbus-run-session for tests `` |
| [`bf63690b`](https://github.com/NixOS/nixpkgs/commit/bf63690b2ec630b89e9255a24df624a0d44c2606) | `` bitwarden-desktop: fix build and guard against breakage ``       |
| [`0c8d09f2`](https://github.com/NixOS/nixpkgs/commit/0c8d09f2746cb8d4b5f6ce2a2f15ad5927ecd29c) | `` audacity: remove `with lib` from meta and `rec` ``               |
| [`0ee4e13f`](https://github.com/NixOS/nixpkgs/commit/0ee4e13f4b85192681d451610a7b474884b9ca71) | `` audacity: format with nixfmt-rfc-style ``                        |
| [`a47f07a4`](https://github.com/NixOS/nixpkgs/commit/a47f07a48aaa452e300291ffe2dcc004533344bc) | `` audacity: move to by-name ``                                     |
| [`501b85f3`](https://github.com/NixOS/nixpkgs/commit/501b85f3d5e271c6fbfd2770f65804749729ac12) | `` nixos/tests/gerrit: Drop dead hook to LFS plugin ``              |
| [`5a5c04d1`](https://github.com/NixOS/nixpkgs/commit/5a5c04d1ea8319b6733e3084dcfe3dded171c662) | `` nixos/zapret: init ``                                            |
| [`221d9605`](https://github.com/NixOS/nixpkgs/commit/221d96051a41a9bf0bad14df45a5a0bb3d09847f) | `` libinput: fix eventGUISupport = true builds ``                   |
| [`f03dc49b`](https://github.com/NixOS/nixpkgs/commit/f03dc49b48be9fd9b7d3c062a8ddd794a8e89824) | `` markdownlint-cli2: 0.13.0 -> 0.14.0 ``                           |
| [`1cce98b1`](https://github.com/NixOS/nixpkgs/commit/1cce98b1f040628a92a73740f8b53b49e6d120d7) | `` pylyzer: 0.0.65 -> 0.0.66 ``                                     |
| [`1815d5a7`](https://github.com/NixOS/nixpkgs/commit/1815d5a7a7af07f3921162fd2f03e1ae74171a35) | `` verilator: 5.026 -> 5.028 ``                                     |
| [`4d705079`](https://github.com/NixOS/nixpkgs/commit/4d705079248a3b9cb21bc27f34099a70d0088fa4) | `` luaPackages.lz-n: 2.8.0 -> 2.8.1 ``                              |
| [`f4efef83`](https://github.com/NixOS/nixpkgs/commit/f4efef839f9bce5d15c4ae875c62c9bcb6ba4f8e) | `` python312Packages.mdformat: refactor ``                          |
| [`9a2bd032`](https://github.com/NixOS/nixpkgs/commit/9a2bd0328a087704c00bf96a4ee4007ecb3b5d67) | `` python312Packages.mdformat: 0.7.17 -> 0.7.18 ``                  |
| [`5f75ac75`](https://github.com/NixOS/nixpkgs/commit/5f75ac75e96bcf4cded4b195fa1a969f624f9986) | `` checkov: 3.2.260 -> 3.2.266 ``                                   |
| [`5ba235f3`](https://github.com/NixOS/nixpkgs/commit/5ba235f31833a6632565e892791d7c06857e06ff) | `` kdePackages: Plasma 6.2.0 -> 6.2.1 ``                            |
| [`ac179d3d`](https://github.com/NixOS/nixpkgs/commit/ac179d3de83827d11c95551b364875a7891684ef) | `` aqbanking: 6.5.4 -> 6.5.12beta ``                                |
| [`196c6090`](https://github.com/NixOS/nixpkgs/commit/196c6090b2c43ba5af107744a8eb28605844cdf3) | `` gwenhywfar: 5.10.1 -> 5.11.2beta ``                              |
| [`36ca2a6c`](https://github.com/NixOS/nixpkgs/commit/36ca2a6cfbb60ec304df5dc9d4f91a68f0cf2fbe) | `` nufmt: add maintainer khaneliman ``                              |
| [`b9aac85c`](https://github.com/NixOS/nixpkgs/commit/b9aac85c3afaa83ddd71d013474f9f0c3a04e928) | `` nufmt: unstable-2023-09-25 -> 0-unstable-2024-10-15 ``           |
| [`3d2d89f9`](https://github.com/NixOS/nixpkgs/commit/3d2d89f9ce7b6d064dc5b25da1e1df55ce8fb55c) | `` azpainter: add darwin bundle ``                                  |
| [`f671edcf`](https://github.com/NixOS/nixpkgs/commit/f671edcf3efe05d3c3755793312f1aa57d13819c) | `` azpainter: format with nixfmt-rfc-style ``                       |
| [`2af1a249`](https://github.com/NixOS/nixpkgs/commit/2af1a249674b2a11593368937858a0b825dfeea0) | `` azpainter: migrate to by-name ``                                 |
| [`fc5290ed`](https://github.com/NixOS/nixpkgs/commit/fc5290ed2c62dff93cc10e3a3305c4fc9879cf89) | `` python312Packages.cpyparsing: 2.4.7.2.4.0 -> 2.4.7.2.4.1 ``      |
| [`cb5cfd9a`](https://github.com/NixOS/nixpkgs/commit/cb5cfd9a6f3d7bea462ad40813b1af414036ac58) | `` nufmt: add update script ``                                      |
| [`19284e4f`](https://github.com/NixOS/nixpkgs/commit/19284e4f795d2add82a743e5b50df8cfd1558ad5) | `` gokrazy: unstable-2023-08-12 -> 0-unstable-2024-09-27 ``         |
| [`90580711`](https://github.com/NixOS/nixpkgs/commit/9058071101c138f3ccee58fdb81b5c759483707e) | `` python312Packages.pygsl: 2.4.0 -> 2.4.1 ``                       |
| [`5535fe31`](https://github.com/NixOS/nixpkgs/commit/5535fe31c18a8d6e23eff450b8adf32ff711b212) | `` perlPackages.SeleniumRemoteDriver: init at 1.49 ``               |
| [`eee9e1f6`](https://github.com/NixOS/nixpkgs/commit/eee9e1f686b21e6c053b94bc8c0bab53e3826cd4) | `` python312Packages.qcodes: 0.48.0 -> 0.49.0 ``                    |
| [`506a4499`](https://github.com/NixOS/nixpkgs/commit/506a4499d0c756036a92a73789dafe2136c9d4f1) | `` qcad: 3.30.1.3 -> 3.31.1.2 ``                                    |
| [`ad974fe1`](https://github.com/NixOS/nixpkgs/commit/ad974fe189ece3931498cae218010eabed34e8a3) | `` element-desktop: 1.11.79 -> 1.11.81 ``                           |
| [`2f4291af`](https://github.com/NixOS/nixpkgs/commit/2f4291af950f6edbcf2d80610c27380e5112f426) | `` neovim: expose vimPackage ``                                     |
| [`d2b448ea`](https://github.com/NixOS/nixpkgs/commit/d2b448eaf377b46c729a098fe5a970d3a5e16fb9) | `` gat: 0.18.0 -> 0.19.1 ``                                         |
| [`896fe3b9`](https://github.com/NixOS/nixpkgs/commit/896fe3b9c1c5d33ea122fcebc704d2ee2153c5c3) | `` intel-gmmlib: 22.5.1 -> 22.5.2 ``                                |
| [`3a109c3a`](https://github.com/NixOS/nixpkgs/commit/3a109c3ad3c3e37289f201117cf6efea9ef92187) | `` deepin.dde-device-formatter: clear up dtk qpa ``                 |
| [`59196d8e`](https://github.com/NixOS/nixpkgs/commit/59196d8ea414b54035ad615563b5b2baa7c22917) | `` ssm-session-manager-plugin: 1.2.650.0 -> 1.2.677.0 ``            |
| [`40a3f136`](https://github.com/NixOS/nixpkgs/commit/40a3f1362d4732c156cd90cb0654a0666b81370b) | `` pipectl: 0.5.0 -> 0.5.1 ``                                       |
| [`191a9524`](https://github.com/NixOS/nixpkgs/commit/191a952428a4c9958d038402720c36ae5c86f5fb) | `` manifest-tool: 2.1.7 -> 2.1.8 ``                                 |
| [`127dcca3`](https://github.com/NixOS/nixpkgs/commit/127dcca388698d81419cffba84e67b823c59cf2f) | `` nixos/tests/networking: test nameservers via DHCP ``             |
| [`964f3946`](https://github.com/NixOS/nixpkgs/commit/964f3946dc93663084ce301306780190b29c16f7) | `` whoami: init at 1.10.3 ``                                        |
| [`a69181cb`](https://github.com/NixOS/nixpkgs/commit/a69181cb38e9245d89b3dba64349b66bc6236b68) | `` maintainers: add dvcorreia ``                                    |
| [`50f31648`](https://github.com/NixOS/nixpkgs/commit/50f31648ff01a60a50440351793f5d7888977a64) | `` python312Packages.trimesh: 4.4.9 -> 4.5.0 ``                     |
| [`d2fa2839`](https://github.com/NixOS/nixpkgs/commit/d2fa28391b922a7600ad9e3b11b9e066ede87c8c) | `` azpainter: 3.0.8 -> 3.0.9a ``                                    |
| [`0fd3ceaa`](https://github.com/NixOS/nixpkgs/commit/0fd3ceaa502d391be8c4215c061ab897b9ddf3bd) | `` txr: 295 -> 296 ``                                               |
| [`3cb2f6ce`](https://github.com/NixOS/nixpkgs/commit/3cb2f6ce77f474a84bac1345f676a2df765b9725) | `` python312Packages.photutils: 1.13.0 -> 2.0.0 ``                  |
| [`75d6f8a5`](https://github.com/NixOS/nixpkgs/commit/75d6f8a5908e0b3410f88d73bb80279a033af9c6) | `` python312Packages.gcal-sync: 6.1.5 -> 6.1.6 ``                   |
| [`9c2358e7`](https://github.com/NixOS/nixpkgs/commit/9c2358e7223b3eb53e2b59f4c69f454e5ad38900) | `` python3{11,12}Packages.nose: drop ``                             |
| [`09075ef4`](https://github.com/NixOS/nixpkgs/commit/09075ef4be8dcf5db5767abc62fe7c83cfb31d5e) | `` python3{11,12}Packages.pytest_7: drop nose dependency ``         |
| [`364ddc4e`](https://github.com/NixOS/nixpkgs/commit/364ddc4e940b38652ba3a3b0d579dae1e513cd71) | `` python3{11,12}Packages.nose2pytest: disable tests ``             |
| [`428d7f7a`](https://github.com/NixOS/nixpkgs/commit/428d7f7a68b0ef8d0c7b318712e269aabc06b4df) | `` python3{11,12}Packages.nose2pytest: add pytest dependency ``     |
| [`0d0c32e3`](https://github.com/NixOS/nixpkgs/commit/0d0c32e366de8ccf96218cb4e9fc81a649137e41) | `` converve: fix darwin build ``                                    |
| [`e5d0387e`](https://github.com/NixOS/nixpkgs/commit/e5d0387e74165ecbb939307544298ae80ec2e454) | `` bootstrap-studio: 6.7.2 -> 6.7.3 ``                              |
| [`9f1d63f8`](https://github.com/NixOS/nixpkgs/commit/9f1d63f8d46b7ed89f3b6c0ea41777735a030eef) | `` cmtk: darwin ``                                                  |
| [`002b8bbd`](https://github.com/NixOS/nixpkgs/commit/002b8bbd65d3b8bc6ef874967a0b25c51c02692f) | `` reactphysics3d: 0.10.1 -> 0.10.2 ``                              |
| [`940d5453`](https://github.com/NixOS/nixpkgs/commit/940d545355d5e79859502334f2fe269c3996046b) | `` qemu-user: fix build under musl ``                               |
| [`b713071a`](https://github.com/NixOS/nixpkgs/commit/b713071a827ebeeea6df50175ffdd170adb4b1f1) | `` python3{11,12}Packages.mhcflurry: remove unused nose input ``    |
| [`cb76eb37`](https://github.com/NixOS/nixpkgs/commit/cb76eb37554a42a8f4b01aa36763eeafc9669ad6) | `` asymptote: 2.90 -> 2.92 ``                                       |
| [`209b7f63`](https://github.com/NixOS/nixpkgs/commit/209b7f634b4acef930ac39acc146dc0c4c4b04f3) | `` nixosTests.snipe-it: fix test ``                                 |
| [`b13432ed`](https://github.com/NixOS/nixpkgs/commit/b13432edec928c78fe4f383afa748dd092c5ad91) | `` snipe-it: 7.0.12 -> 7.0.13 ``                                    |
| [`459c32e4`](https://github.com/NixOS/nixpkgs/commit/459c32e47ea9506113ae61c4a35a45f8a830dba1) | `` coqPackages.RustExtraction: init at 0.1.0 ``                     |
| [`447d4686`](https://github.com/NixOS/nixpkgs/commit/447d4686a327ea3aadff3c00b944104786b29edf) | `` home-assistant-custom-components.yassi: 0.4.0 -> 0.4.1 ``        |
| [`764d8eaa`](https://github.com/NixOS/nixpkgs/commit/764d8eaa80fbffba9746c674e37f168563ce4096) | `` telegram-desktop: 5.6.1-unstable-2024-10-12 -> 5.6.2 ``          |
| [`8574a14d`](https://github.com/NixOS/nixpkgs/commit/8574a14dd82a7669253dcff86d94c40b1204a8e3) | `` python3{11,12}Packages.mhcflurry: remove nose dependency ``      |
| [`da607251`](https://github.com/NixOS/nixpkgs/commit/da6072514625d81c1a79f95a3377c25d8e73a2c6) | `` zed-editor: 0.156.1 -> 0.156.2 ``                                |