### PR TITLE
chore(flake/nixvim): `e3239b4d` -> `c4ad4d0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1729332380,
-        "narHash": "sha256-ePzkpRV4zYR9cO1o5HrYuZRmoEthsPgNP0cvRGlHSro=",
+        "lastModified": 1729368702,
+        "narHash": "sha256-KW+NFU0woUYpiVsdbXO5YAKCnKZ743BJlnG4ZEflvfs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e3239b4d328efaaf090892fbca71a1008dbc5a59",
+        "rev": "c4ad4d0b2e7de04fa9ae0652b006807f42062080",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`c4ad4d0b`](https://github.com/nix-community/nixvim/commit/c4ad4d0b2e7de04fa9ae0652b006807f42062080) | `` modules/nixpkgs: add `overlays` option ``                          |
| [`b9d17d5e`](https://github.com/nix-community/nixvim/commit/b9d17d5e6c981911f33270e0eefdcb978559d990) | `` modules/nixpkgs: restructure `nixpkgs.pkgs.isDefined` assertion `` |