### PR TITLE
chore(flake/nixpkgs): `1997e4aa` -> `2768c7d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -249,11 +249,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729413321,
-        "narHash": "sha256-I4tuhRpZFa6Fu6dcH9Dlo5LlH17peT79vx1y1SpeKt0=",
+        "lastModified": 1729665710,
+        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1997e4aa514312c1af7e2bda7fad1644e778ff26",
+        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`1c968d80`](https://github.com/NixOS/nixpkgs/commit/1c968d80e6cc08de1f76c6cbe984c3b1bddcaf72) | `` terraform-providers.equinix: 2.8.0 -> 2.9.0 ``                                      |
| [`d7c0a1c0`](https://github.com/NixOS/nixpkgs/commit/d7c0a1c06bf52bca340a7290f01ea894e1424b67) | `` libmodbus: 3.1.10 -> 3.1.11 ``                                                      |
| [`3f892335`](https://github.com/NixOS/nixpkgs/commit/3f8923358716e2e18bdb01798a99f0a7f76f619b) | `` x509-limbo: remove ``                                                               |
| [`48afb494`](https://github.com/NixOS/nixpkgs/commit/48afb49467405bf43ac5bdc6a4a32389d077a268) | `` maintainers: remove NikolaMandic ``                                                 |
| [`78d0db5b`](https://github.com/NixOS/nixpkgs/commit/78d0db5bc44a31d211e13a454521e65e44b3d984) | `` treewide: remove NikolaMandic from maintainers ``                                   |
| [`7a350126`](https://github.com/NixOS/nixpkgs/commit/7a3501266a8a1fda449fc46750ab283ab813b88a) | `` python312Packages.clarifai-grpc: 10.8.7 -> 10.9.10 ``                               |
| [`aa1c556c`](https://github.com/NixOS/nixpkgs/commit/aa1c556c891efe4b43aa87a2e32df977c389119e) | `` teleport: Downgrade Go to 1.22 until upstream supports 1.23 ``                      |
| [`dfd0a836`](https://github.com/NixOS/nixpkgs/commit/dfd0a8366e5520b782ba5364b04c5266bae0bb3b) | `` charmcraft: 3.2.1 -> 3.2.2 ``                                                       |
| [`c4fac0fe`](https://github.com/NixOS/nixpkgs/commit/c4fac0fe9e4fc4ceda3b103ebd867db2d3d95497) | `` xeol: 0.10.0 -> 0.10.1 ``                                                           |
| [`126cdaca`](https://github.com/NixOS/nixpkgs/commit/126cdaca75ab01568561128c861f512f5b953a0f) | `` python312Packages.pylutron: 0.2.15 -> 0.2.16 ``                                     |
| [`1d5add95`](https://github.com/NixOS/nixpkgs/commit/1d5add95c585ecbd854de45a75dfb225cd83028c) | `` maa-cli: 0.4.12 -> 0.5.1 ``                                                         |
| [`7242d22f`](https://github.com/NixOS/nixpkgs/commit/7242d22f41a729d35f37f6207243d8e927ea2746) | `` cnspec: 11.26.0 -> 11.27.0 ``                                                       |
| [`1c9fee87`](https://github.com/NixOS/nixpkgs/commit/1c9fee8711a88d5b09e2072caf331efaec6501d3) | `` pingu: fix build ``                                                                 |
| [`3b0e545b`](https://github.com/NixOS/nixpkgs/commit/3b0e545b7b26762bf880ce142e3abc4fe407ab09) | `` hypridle: 0.1.3 -> 0.1.4 ``                                                         |
| [`308ed17e`](https://github.com/NixOS/nixpkgs/commit/308ed17ebc52565eb92564f646b56dd33aec8b6a) | `` ion: unstable-2022-11-27 -> unstable-2024-09-20 ``                                  |
| [`b4215a71`](https://github.com/NixOS/nixpkgs/commit/b4215a713fac6b3874ea25cbbda785c6b46c9e21) | `` nextcloud-client: fix for wayland ``                                                |
| [`c022ecdd`](https://github.com/NixOS/nixpkgs/commit/c022ecdd9cb1d5724cd6a598a3051ba6ead1f068) | `` trickest-cli: 1.8.2 -> 1.8.3 ``                                                     |
| [`289d7b86`](https://github.com/NixOS/nixpkgs/commit/289d7b86ee88011ebe7e5d7bae7602c46fd934a1) | `` stalwart-mail: 0.10.3 -> 0.10.5 ``                                                  |
| [`185fb07b`](https://github.com/NixOS/nixpkgs/commit/185fb07be28059ec84609d3e761c1f76d152b037) | `` firefox-devedition-unwrapped: 132.0b5 -> 132.0b9 ``                                 |
| [`c1ab98ea`](https://github.com/NixOS/nixpkgs/commit/c1ab98eaf92d0760758580a86e1c8ccd43a358d5) | `` firefox-beta-unwrapped: 132.0b5 -> 132.0b9 ``                                       |
| [`a44b0f63`](https://github.com/NixOS/nixpkgs/commit/a44b0f635ebe4eeaee497edcad816ae5eb432710) | `` awscli2: prevent propagating inputs ``                                              |
| [`7c8b1029`](https://github.com/NixOS/nixpkgs/commit/7c8b1029f2aad9e91a629db15afe862309df5c51) | `` firefox-beta-bin-unwrapped: 132.0b6 -> 132.0b9 ``                                   |
| [`0a952199`](https://github.com/NixOS/nixpkgs/commit/0a952199c13eb6a67f4fef976339cacde8f87d5b) | `` firefox-devedition-bin-unwrapped: 132.0b6 -> 132.0b9 ``                             |
| [`9bf032ab`](https://github.com/NixOS/nixpkgs/commit/9bf032ab9db6810d601053b9cda32f8bdd0a5eb1) | `` neovim: fix withNodeJs regression (#350345) ``                                      |
| [`24d499ca`](https://github.com/NixOS/nixpkgs/commit/24d499ca282c70844bf73f23d051279b84dfb01a) | `` xchm: migrate to by-name ``                                                         |
| [`8f0b97cd`](https://github.com/NixOS/nixpkgs/commit/8f0b97cdaaa093c8d621269666fcdc4641ddeddb) | `` xchm: 1.36 -> 1.37 ``                                                               |
| [`0d3fab39`](https://github.com/NixOS/nixpkgs/commit/0d3fab394f2ceff40afc24ecf73287156407d769) | `` factorio: reformat update.py with ruff and make lint clean ``                       |
| [`8387c162`](https://github.com/NixOS/nixpkgs/commit/8387c1626d200274e5beb968c81327726f057a86) | `` factorio-space-age: name drv -space-age, rather than -experimental ``               |
| [`a9522ff5`](https://github.com/NixOS/nixpkgs/commit/a9522ff5d2d262aebe38bb6cc171b5496e372da9) | `` factorio-experimental: 2.0.8 -> 2.0.9 ``                                            |
| [`b9b0f03e`](https://github.com/NixOS/nixpkgs/commit/b9b0f03e881fc941f82ee6bf038590fefab54ae4) | `` factorio: make update.py more robust about missing experimental versions ``         |
| [`44754ac5`](https://github.com/NixOS/nixpkgs/commit/44754ac517ceecf2a8b95318c45e28192e813a8b) | `` factorio: change update.py to use the Factorio SHA256 hashes file ``                |
| [`8a819d41`](https://github.com/NixOS/nixpkgs/commit/8a819d416fec5fca0675a46b0669b983dc282770) | `` factorio: nixfmt ``                                                                 |
| [`f68438a9`](https://github.com/NixOS/nixpkgs/commit/f68438a9bb75d466f67f6b6ca8b0dd3202273ed1) | `` factorio: migrate to by-name hierarchy ``                                           |
| [`9047b2f9`](https://github.com/NixOS/nixpkgs/commit/9047b2f938f501d341700cd6778e1f33d46c3513) | `` python312Packages.trimesh: 4.5.0 -> 4.5.1 ``                                        |
| [`92e24591`](https://github.com/NixOS/nixpkgs/commit/92e24591835eb9b903f711f37a869d20d6a67c3c) | `` mixxc: 0.2.2 -> 0.2.3 ``                                                            |
| [`dbf7e266`](https://github.com/NixOS/nixpkgs/commit/dbf7e266c9ee5099c52bfc8d0e9dba9879f944bb) | `` python312Packages.pesq: init at 0.0.4 ``                                            |
| [`7f309241`](https://github.com/NixOS/nixpkgs/commit/7f3092416aeb3a50c7a5301dce051ea3198716c5) | `` linux: cherry-pick netfilter fix ``                                                 |
| [`57e48042`](https://github.com/NixOS/nixpkgs/commit/57e480426a5a8ac14d9e8784f99c40b8e38baf05) | `` linux_5_10: 5.10.227 -> 5.10.228 ``                                                 |
| [`b8639314`](https://github.com/NixOS/nixpkgs/commit/b86393146e0d751f86dc1b93c4d42d7070295290) | `` linux_5_15: 5.15.168 -> 5.15.169 ``                                                 |
| [`8b91f4ab`](https://github.com/NixOS/nixpkgs/commit/8b91f4ab38ab483b2c50624664b7a363e8b47e79) | `` linux_6_1: 6.1.113 -> 6.1.114 ``                                                    |
| [`c0b43de1`](https://github.com/NixOS/nixpkgs/commit/c0b43de177e6cc1ac03f6b6bab64b8f4aecce996) | `` linux_6_6: 6.6.57 -> 6.6.58 ``                                                      |
| [`3dffc1ef`](https://github.com/NixOS/nixpkgs/commit/3dffc1ef91996cfd308f87d78888a99e60428b2d) | `` linux_6_11: 6.11.4 -> 6.11.5 ``                                                     |
| [`a498c213`](https://github.com/NixOS/nixpkgs/commit/a498c2132129b4d9f35b7a167da4462a8189afc0) | `` linux_testing: 6.12-rc3 -> 6.12-rc4 ``                                              |
| [`5ac5bf7f`](https://github.com/NixOS/nixpkgs/commit/5ac5bf7f91fa0fa7f5dd4e2aa8bf207a3c034f66) | `` python312Packages.jupyter-console: clean and fix on darwin ``                       |
| [`ab7182d0`](https://github.com/NixOS/nixpkgs/commit/ab7182d069c999fc8800f893dc639d72502dc543) | `` hyprlock: 0.4.1 -> 0.5.0 ``                                                         |
| [`7b01b810`](https://github.com/NixOS/nixpkgs/commit/7b01b810a65df2ffd0dc8e13d6347fbc816c84df) | `` sdbus-cpp_2: init at 2.0.0 ``                                                       |
| [`0b01b203`](https://github.com/NixOS/nixpkgs/commit/0b01b203d689bc1a13163b1be8770866355b5a97) | `` kdePackages: Plasma 6.2.1 -> 6.2.2 ``                                               |
| [`e3d9287a`](https://github.com/NixOS/nixpkgs/commit/e3d9287afe54acf9157ca2f5ef5483db70101131) | `` allure: 2.30.0 -> 2.31.0 ``                                                         |
| [`1d170745`](https://github.com/NixOS/nixpkgs/commit/1d1707456a0fd8608db730ebbdf564dc60121dda) | `` guestfs-tools: 1.52.0 -> 1.52.2 ``                                                  |
| [`ad3f44d1`](https://github.com/NixOS/nixpkgs/commit/ad3f44d15ccab7eabd2b12e3d3e6b2438440d1f0) | `` guestfs-tools: add updateScript ``                                                  |
| [`5c471113`](https://github.com/NixOS/nixpkgs/commit/5c471113283319ceda315ecba1667c88abb35b96) | `` guestfs-tools: refactor ``                                                          |
| [`012e5884`](https://github.com/NixOS/nixpkgs/commit/012e588480eb0bf9ac51991afda957a1a8bfbf27) | `` guestfs-tools: fix build ``                                                         |
| [`6896e06e`](https://github.com/NixOS/nixpkgs/commit/6896e06ebf28cba6d0761f7bae136468da3cb0db) | `` tabby: versionCheckHook ``                                                          |
| [`883b47ed`](https://github.com/NixOS/nixpkgs/commit/883b47ed8647d440605badb05627c4c2808eda55) | `` tabby: 0.11.1 -> 0.18.0 ``                                                          |
| [`564ef796`](https://github.com/NixOS/nixpkgs/commit/564ef796a24f201ee1bbcdf2a8c2e1412b2c5c3f) | `` drawio: drop maintainership ``                                                      |
| [`da2060c0`](https://github.com/NixOS/nixpkgs/commit/da2060c0dee86a677096aab104c029a578bd12ea) | `` drawio: update license ``                                                           |
| [`27b9bed1`](https://github.com/NixOS/nixpkgs/commit/27b9bed15c89899a48a9711b62b5d6ac297d16b4) | `` python312Packages.nebula3-python: 3.8.2 -> 3.8.3 ``                                 |
| [`b2e53587`](https://github.com/NixOS/nixpkgs/commit/b2e53587fb76d5ca18291a91c007b9f1402cd79c) | `` clapper: add gtuber support ``                                                      |
| [`e4f41d55`](https://github.com/NixOS/nixpkgs/commit/e4f41d5598f860bd93de3dc4b53547c4c0db1be2) | `` gtuber: init at 0-unstable-2024-10-11 ``                                            |
| [`50432e13`](https://github.com/NixOS/nixpkgs/commit/50432e13ae3d6f8a9967d6d2455a58e50fc5df67) | `` home-assistant-custom-components.*: Add missing lib.recurseIntoAttrs ``             |
| [`f4f938ad`](https://github.com/NixOS/nixpkgs/commit/f4f938ad86e2e795186463a89ae7508eb9e5144b) | `` maintainers: update rnhmjoj ``                                                      |
| [`a8d21137`](https://github.com/NixOS/nixpkgs/commit/a8d211376f8e50202cf608751fa59f2c47565d1f) | `` cantor: fix build ``                                                                |
| [`3035fa37`](https://github.com/NixOS/nixpkgs/commit/3035fa37064da029bc4c007dc93bb516cde7b8f8) | `` tex-fmt: 0.4.4 -> 0.4.6 ``                                                          |
| [`0e1a5001`](https://github.com/NixOS/nixpkgs/commit/0e1a5001733ddf7deb30bba9e861bce73c898c6f) | `` kube-router: 2.2.1 -> 2.2.2 ``                                                      |
| [`ac156c8a`](https://github.com/NixOS/nixpkgs/commit/ac156c8a50d57b103ab4f9c3ad32767fe6d23a4d) | `` cantor: nixfmt ``                                                                   |
| [`b12bcabd`](https://github.com/NixOS/nixpkgs/commit/b12bcabd244ff468d7f5ecf4aec4af28e9c7098d) | `` maintainers: remove erictapen from packages that I don't really maintain anymore `` |
| [`a60d8c94`](https://github.com/NixOS/nixpkgs/commit/a60d8c940cadafb7a33ac415b8b2718bb6d82766) | `` alioth: init at 0.5.0 ``                                                            |
| [`6db0f02e`](https://github.com/NixOS/nixpkgs/commit/6db0f02efcbf80b8e6c16e007917a730ec3e1179) | `` crosvm.updateScript: update cargoHash ``                                            |
| [`a3f9e97d`](https://github.com/NixOS/nixpkgs/commit/a3f9e97d78566a4b777560b9654f3778a1db6886) | `` crosvm: 128.1 -> 129.0 ``                                                           |
| [`a76ccc48`](https://github.com/NixOS/nixpkgs/commit/a76ccc4820dd415b872686753ad3b5dffa1381c6) | `` yt-dlp: 2024.10.7 -> 2024.10.22 ``                                                  |
| [`50ea63c3`](https://github.com/NixOS/nixpkgs/commit/50ea63c313a3a39d55442225ed53038dabdeb376) | `` python312Packages.influxdb-client: 1.46.0 -> 1.47.0 ``                              |
| [`e6bd3903`](https://github.com/NixOS/nixpkgs/commit/e6bd3903101dacbc14819f6b3028d3edf5df1fd1) | `` python312Packages.ha-mqtt-discoverable: 0.14.0 -> 0.16.0 ``                         |
| [`b6bda769`](https://github.com/NixOS/nixpkgs/commit/b6bda7695752b217cf2d6a623653e5192f69c6de) | `` python312Pakcages.dncil: init at 1.0.2 ``                                           |
| [`05d349dd`](https://github.com/NixOS/nixpkgs/commit/05d349dd293b1f15c14e5e4ceaa75c559670e9da) | `` nixos/tests: add wakapi ``                                                          |
| [`a466f146`](https://github.com/NixOS/nixpkgs/commit/a466f1462734692cd484f184a978187f250eabdc) | `` nixos/wakapi: fix incorrect assertion conditions ``                                 |
| [`fbec0c0d`](https://github.com/NixOS/nixpkgs/commit/fbec0c0d7fa8fcb7864bd598f14014c168cd5693) | `` nixos/wakapi: fix failing assertions ``                                             |
| [`c3ce64b1`](https://github.com/NixOS/nixpkgs/commit/c3ce64b13a18825ef34d51eca1b5b244e245bd26) | `` nixos/wakapi: fix typo in warning conditional ``                                    |
| [`3fe0ef1e`](https://github.com/NixOS/nixpkgs/commit/3fe0ef1e3ca7367083bb58791ab36d5b0346d53a) | `` cloudflared: 2024.9.1 -> 2024.10.0 ``                                               |
| [`89dd2bc0`](https://github.com/NixOS/nixpkgs/commit/89dd2bc0f415377251e2198717b8b19b27293adb) | `` folio: 24.11 -> 24.12 ``                                                            |
| [`57e4e0c6`](https://github.com/NixOS/nixpkgs/commit/57e4e0c6f63b050a7bd2a48ccd6e3458a9b70d3d) | `` whatsie: 4.16.0 -> 4.16.1 ``                                                        |
| [`026c4e21`](https://github.com/NixOS/nixpkgs/commit/026c4e214b6269857ae258341f4402ce927d6306) | `` python312Packages.pyvlx: refactor ``                                                |
| [`ca240398`](https://github.com/NixOS/nixpkgs/commit/ca24039865345d2e208b1b08af7fbbc67a7d1533) | `` python312Packages.sensorpush-ble: refactor ``                                       |
| [`dd9a1131`](https://github.com/NixOS/nixpkgs/commit/dd9a11313f3e5f4b07b82b9e8225dee0684cf47f) | `` python312Packages.gcal-sync: 6.1.6 -> 6.2.0 ``                                      |
| [`804d07c1`](https://github.com/NixOS/nixpkgs/commit/804d07c1b5f8ffc2a7a7f4bb4089b90aebd32f8b) | `` python312Packages.xiaomi-ble: 0.32.0 -> 0.33.0 ``                                   |
| [`1b7ef9fd`](https://github.com/NixOS/nixpkgs/commit/1b7ef9fd89b71d15d7af68d715abad3d75750e45) | `` python312Packages.pyswitchbot: 0.48.2 -> 0.50.1 ``                                  |
| [`8478b073`](https://github.com/NixOS/nixpkgs/commit/8478b0738d4acad31990ed4ea3d6446e12fd7511) | `` tailscale: move to by-name (#350402) ``                                             |
| [`eaadc9e2`](https://github.com/NixOS/nixpkgs/commit/eaadc9e24befaa132af0f0a21bf7ad5d4f5e1ce0) | `` docs/vim.section.md: Add note about nvimRequireCheck (#349864) ``                   |
| [`93b0eb60`](https://github.com/NixOS/nixpkgs/commit/93b0eb60e053bffce2985f2aabe3348e5085c1b1) | `` ddnet: 18.4 -> 18.6 (remove commented out patch) ``                                 |
| [`e7df6d2a`](https://github.com/NixOS/nixpkgs/commit/e7df6d2a3392b7845a95a999ad039f8108007bc5) | `` rye: 0.41.0 -> 0.42.0 ``                                                            |
| [`0e93d25f`](https://github.com/NixOS/nixpkgs/commit/0e93d25f0458c66d7326fe43334b4ff4966ee1b7) | `` python312Packages.open-clip-torch: 2.27.1 -> 2.28.0 ``                              |
| [`8b042181`](https://github.com/NixOS/nixpkgs/commit/8b042181e62bf244a04b7c3bd8441e5917f10dad) | `` rustywind: 0.22.0 -> 0.23.1 ``                                                      |
| [`30b289ca`](https://github.com/NixOS/nixpkgs/commit/30b289cac193eb3560f3d1eebe2d2c99f4c17c6d) | `` python312Packages.pycrdt: 0.10.3 -> 0.10.4 ``                                       |
| [`84a9c957`](https://github.com/NixOS/nixpkgs/commit/84a9c957943d3e231a0b793853c5949dce95e666) | `` shanggu-fonts: make installPhase more readable ``                                   |
| [`a7f3eef2`](https://github.com/NixOS/nixpkgs/commit/a7f3eef2ed74c025b17497d6d82f02c66baf0540) | `` python312Packages.sensorpush-ble: 1.6.2 -> 1.7.0 ``                                 |
| [`4c6b6c0c`](https://github.com/NixOS/nixpkgs/commit/4c6b6c0c5d1ac0ac0e81c94d020d3f89d6615931) | `` qemu: 9.1.0 -> 9.1.1 ``                                                             |
| [`371bba45`](https://github.com/NixOS/nixpkgs/commit/371bba4560e5f8bdac64c25ce5c684c103b908c1) | `` askalono: 0.4.6 -> 0.5.0 ``                                                         |
| [`08378ef1`](https://github.com/NixOS/nixpkgs/commit/08378ef15a4ab182701f96c0fee614b6f93189c6) | `` hypridle: 0.1.2 -> 0.1.3 ``                                                         |
| [`dcf0d465`](https://github.com/NixOS/nixpkgs/commit/dcf0d465c7edeed0edf31be4e815ed37a7013b6f) | `` spirit: 0.5.0 -> 0.6.0 ``                                                           |
| [`d50cc096`](https://github.com/NixOS/nixpkgs/commit/d50cc09605071724a9cc6283a09ae11023193b7c) | `` haskellPackages: add artem as a maintainer of certain packages ``                   |
| [`2689f6d7`](https://github.com/NixOS/nixpkgs/commit/2689f6d7dc43a2b3da76ed39c03251a11e2d5d7c) | `` maintainers: add artem ``                                                           |
| [`a12121e0`](https://github.com/NixOS/nixpkgs/commit/a12121e081ce7d00616957dc67f88cee83fac842) | `` powerdns-admin: provide distutils ``                                                |
| [`07900c10`](https://github.com/NixOS/nixpkgs/commit/07900c10c9a5fbc132bf1a793ce852707e559ddc) | `` weblate: relax qrcode constraint ``                                                 |
| [`ffa77e9e`](https://github.com/NixOS/nixpkgs/commit/ffa77e9e2f7d38b8997d14e841cf4f5c8b63bb46) | `` python312Packages.flet: relax qrcode constraint ``                                  |
| [`65d2f3c7`](https://github.com/NixOS/nixpkgs/commit/65d2f3c7f5b034dbaa4aebc0ac8b5611ce02ced7) | `` fdroidserver: provide setuptools for build step ``                                  |
| [`707acdb9`](https://github.com/NixOS/nixpkgs/commit/707acdb9bdf8e7c6d8ebbe7bdfaaa9afa90d4bff) | `` pacu: relax qrcode constraint ``                                                    |
| [`47a2622b`](https://github.com/NixOS/nixpkgs/commit/47a2622bf24aa01420c6975ba38a1d9203757b05) | `` python312Packages.django-two-factor-auth: relax qrcode constraint ``                |