### PR TITLE
chore(flake/nixvim): `28bdec9c` -> `4726334e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1729773824,
-        "narHash": "sha256-BfrKKeBJ0AY3UVzTAbf1Pf8CnrWWpjZgHjLrFxtLwf4=",
+        "lastModified": 1729791159,
+        "narHash": "sha256-i5TKYCs9tJ2qaYTsjQh3WwExmj4O0EU+L1jq6ZBVMfM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "28bdec9cf7beb3344f18a8c364d2cd4574ce9318",
+        "rev": "4726334e4413ff55f1db3768c8d08722abbf09cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`4726334e`](https://github.com/nix-community/nixvim/commit/4726334e4413ff55f1db3768c8d08722abbf09cf) | `` docs: move wrapper options to dedicated sub-pages ``  |
| [`131e74e5`](https://github.com/nix-community/nixvim/commit/131e74e5601d1619eac20e5b8daa723e951f87af) | `` docs: move `wrapper-options` to summary index page `` |
| [`cd68b680`](https://github.com/nix-community/nixvim/commit/cd68b680cdc35a48d7972721eba7eda370b9912f) | `` docs: rename `modules` -> `platforms` ``              |
| [`c477b786`](https://github.com/nix-community/nixvim/commit/c477b7865e8c5ec923ae42ebac14b8dd410c873d) | `` docs/mdbook: use a fileset union for source ``        |
| [`c2dbf7ac`](https://github.com/nix-community/nixvim/commit/c2dbf7acf14a4fcf7496db04be08d69f98a6c86e) | `` docs/mdbook: clean up derivation ``                   |