### PR TITLE
chore(flake/nixvim): `2ef948ed` -> `bb0e3892`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1729945956,
-        "narHash": "sha256-nWRynowHjpRsDK6uf+VE6fz7/Wk80uRiAV2NQssGBH8=",
+        "lastModified": 1729956896,
+        "narHash": "sha256-uQwoEyi0P5MHi1EamlYO516szGjiLhP/qxV/1Z0vZO0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2ef948ed8ccf3c93f8caafa93cddca85df5783e9",
+        "rev": "bb0e3892a27efdc6f9c1771927f513577cb1c671",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`bb0e3892`](https://github.com/nix-community/nixvim/commit/bb0e3892a27efdc6f9c1771927f513577cb1c671) | `` plugins/typescript-tools: migrate to mkNeovimPlugin ``   |
| [`2a40d081`](https://github.com/nix-community/nixvim/commit/2a40d081d72258c7d3ef4a01eed7aeabbb376ef1) | `` plugins/typescript-tools: remove with lib and helpers `` |