### PR TITLE
chore(flake/nixvim): `a20fbbc4` -> `a4c3ad01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1730058276,
-        "narHash": "sha256-t4fyRWIiDBJiDBnqqnxnk9nfT1SDTZN+koJLiuKkIT8=",
+        "lastModified": 1730150629,
+        "narHash": "sha256-5afcjZhCy5EcCdNGKTPoUdywm2yppTSf7GwX/2Rq6Ig=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a20fbbc4b9665ec215e7bea061a1d64f6fd652ce",
+        "rev": "a4c3ad01cd0755dd1e93473d74efdd89a1cf5999",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`a4c3ad01`](https://github.com/nix-community/nixvim/commit/a4c3ad01cd0755dd1e93473d74efdd89a1cf5999) | `` feat: add blink.nvim ``               |
| [`e7356f6b`](https://github.com/nix-community/nixvim/commit/e7356f6be06a68e36987df6cfde3541a6817b708) | `` plugins/nui: initialize ``            |
| [`90d7deed`](https://github.com/nix-community/nixvim/commit/90d7deedc46425e796a3c5549b2affd0ca66f8bf) | `` noice: migrate to mkNeovimPlugin ``   |
| [`89cad1aa`](https://github.com/nix-community/nixvim/commit/89cad1aae709f27d9a59ce403fddb8f340f9a02d) | `` noice: remove with lib and helpers `` |