### PR TITLE
chore(flake/nixvim): `6f210158` -> `aa06b176`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730490306,
-        "narHash": "sha256-AvCVDswOUM9D368HxYD25RsSKp+5o0L0/JHADjLoD38=",
+        "lastModified": 1730633670,
+        "narHash": "sha256-ZFJqIXpvVKvzOVFKWNRDyIyAo+GYdmEPaYi1bZB6uf0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1743615b61c7285976f85b303a36cdf88a556503",
+        "rev": "8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730448474,
-        "narHash": "sha256-qE/cYKBhzxHMtKtLK3hlSR3uzO1pWPGLrBuQK7r0CHc=",
+        "lastModified": 1730600078,
+        "narHash": "sha256-BoyFmE59HDF3uybBySsWVoyjNuHvz3Wv8row/mSb958=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "683d0c4cd1102dcccfa3f835565378c7f3cbe05e",
+        "rev": "4652874d014b82cb746173ffc64f6a70044daa7e",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1730569492,
-        "narHash": "sha256-NByr7l7JetL9kIrdCOcRqBu+lAkruYXETp1DMiDHNQs=",
+        "lastModified": 1730731617,
+        "narHash": "sha256-W7FNEe+gewzTSx0lykzZ3XUKmJ8uKk/SpIPblZIfYc0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6f210158b03b01a1fd44bf3968165e6da80635ce",
+        "rev": "aa06b176e78c9ae9e779e605cab61c9d8681a54e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`aa06b176`](https://github.com/nix-community/nixvim/commit/aa06b176e78c9ae9e779e605cab61c9d8681a54e) | `` plugins/luasnip: fix example ``                                             |
| [`38dd5b07`](https://github.com/nix-community/nixvim/commit/38dd5b07a00331fffe60236970d914bd0eeaf7da) | `` tests/lsp-servers: disable tests impacted by broken _7zz on x86_64-linux `` |
| [`e3733a2f`](https://github.com/nix-community/nixvim/commit/e3733a2f27e1842f5842d2d4fdd182a707fe682c) | `` tests: disable tests impacted by clj-kondo being broken on x86_64-darwin `` |
| [`f98e11b5`](https://github.com/nix-community/nixvim/commit/f98e11b5c3c35c64f0840ae7fb94a2eaaa8ec14e) | `` tests/efmls-configs: sql-formatter has been moved to top-level ``           |
| [`98e8fcdd`](https://github.com/nix-community/nixvim/commit/98e8fcdded314bbdc50a5ebae16c6903979e4b7c) | `` tests/lsp-servers: disable typescript-language-server on darwin ``          |
| [`454f328b`](https://github.com/nix-community/nixvim/commit/454f328b9a09c6fd7aec68bbe230a14fa5364fc0) | `` flake.lock: Update ``                                                       |