### PR TITLE
chore(flake/nixvim): `898246c9` -> `b0ebcaa1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1730877618,
-        "narHash": "sha256-HQTKujMb6SwnOqtWA+A7lR4MOCBZUW4vtrkK1E/QweU=",
+        "lastModified": 1730982370,
+        "narHash": "sha256-93ClVkrDHgV7i+gvB/Jotkx6m8McJR0IL7s5zV5D42g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "898246c943ba545a79d585093e97476ceb31f872",
+        "rev": "b0ebcaa17789089b28c44f7610b1ed5f0ee4ae4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`b0ebcaa1`](https://github.com/nix-community/nixvim/commit/b0ebcaa17789089b28c44f7610b1ed5f0ee4ae4d) | `` plugins/helm: switch to mkVimPlugin ``     |
| [`77b49580`](https://github.com/nix-community/nixvim/commit/77b495801c2c6c33e126ef1d7e84e684fd020ecd) | `` plugins/blink-cmp: update configuration `` |