### PR TITLE
chore(flake/nixvim): `7dc65b2d` -> `e552c984`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1731452383,
-        "narHash": "sha256-Qht3yghgs5rVaYwGtv3i77b8ILlZPPQEZoi6pU8T1TE=",
+        "lastModified": 1731504310,
+        "narHash": "sha256-R20OKYJcDcEqjQGI2/Z/kmaTMoBVSLd5ESR8fbW79Rk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7dc65b2d9873b6bbb6ef90234b3db6546e4ed9af",
+        "rev": "e552c984a24c88017f8bfe6807527b7a9c77e22c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`e552c984`](https://github.com/nix-community/nixvim/commit/e552c984a24c88017f8bfe6807527b7a9c77e22c) | `` plugins/nonels/prettier: use priority instead of null for prettier disableTsFormatting `` |
| [`d593b824`](https://github.com/nix-community/nixvim/commit/d593b82436e55471b19ee19186aed60cc0a10a81) | `` plugins/nonels/prettierd: add disableTsServerFormatting option to prettierd ``            |