### PR TITLE
chore(flake/nixvim): `e552c984` -> `f11a877b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1731504310,
-        "narHash": "sha256-R20OKYJcDcEqjQGI2/Z/kmaTMoBVSLd5ESR8fbW79Rk=",
+        "lastModified": 1731527733,
+        "narHash": "sha256-12OpSgbLDiKmxvBXwVracIfGI9FpjFyHpa1r0Ho+NFA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e552c984a24c88017f8bfe6807527b7a9c77e22c",
+        "rev": "f11a877bcc1d66cc8bd7990c704f91c1e99c7d08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`f11a877b`](https://github.com/nix-community/nixvim/commit/f11a877bcc1d66cc8bd7990c704f91c1e99c7d08) | `` tests/modules/output: add tests for providers `` |
| [`d100a4e9`](https://github.com/nix-community/nixvim/commit/d100a4e9943420b7a4ccb900964034171fcc29fb) | `` modules/output: expose `withPython3` ``          |
| [`590153d4`](https://github.com/nix-community/nixvim/commit/590153d40354f6c12f3060f2b74eef98bb59a663) | `` modules/output: expose `withPerl` ``             |