### PR TITLE
chore(flake/nixvim): `24fe0dd2` -> `f2259372`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1731571290,
-        "narHash": "sha256-osvW1d7YxBs5UDRN/RLFqVtWegArqhvonL9odVpWMuc=",
+        "lastModified": 1731655668,
+        "narHash": "sha256-fqSu7sw/3ueGJKp2JdXl4Vvx0g5Ti3brEaOQFe9WbeQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "24fe0dd2478643fcd4dd57c9570b4614fac80144",
+        "rev": "f2259372fbb7c084027747e8238f268f648342b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`f2259372`](https://github.com/nix-community/nixvim/commit/f2259372fbb7c084027747e8238f268f648342b6) | `` plugins/neoconf: init ``       |
| [`f8b3f165`](https://github.com/nix-community/nixvim/commit/f8b3f16556ed399e84277d41e0658fcea95d41f1) | `` maintainers: add BoneyPatel `` |