### PR TITLE
chore(flake/nixvim): `f2259372` -> `46e574d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1731655668,
-        "narHash": "sha256-fqSu7sw/3ueGJKp2JdXl4Vvx0g5Ti3brEaOQFe9WbeQ=",
+        "lastModified": 1731675303,
+        "narHash": "sha256-Pd0ZZICCwwDIE+ruHTDg8Oaizna5bJrdw5BSTht+Pdc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f2259372fbb7c084027747e8238f268f648342b6",
+        "rev": "46e574d4ea1642dd87a6bfb162053c52b2e4878b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`46e574d4`](https://github.com/nix-community/nixvim/commit/46e574d4ea1642dd87a6bfb162053c52b2e4878b) | `` plugins/snacks: init ``                |
| [`54f56716`](https://github.com/nix-community/nixvim/commit/54f567166dd7a92d860d7ce8ca8b4a7a7a2a0246) | `` plugins/vim-dadbod-completion: init `` |
| [`5dfc9526`](https://github.com/nix-community/nixvim/commit/5dfc9526ef13a8fe87c3db314616ba2c76648041) | `` plugins/vim-dadbod-ui: init ``         |
| [`d408ffd6`](https://github.com/nix-community/nixvim/commit/d408ffd6b477facbcf3f7a23a0636875f4448cc3) | `` plugins/vim-dadbod: init ``            |