### PR TITLE
chore(flake/nixvim): `46e574d4` -> `be455f7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1731675303,
-        "narHash": "sha256-Pd0ZZICCwwDIE+ruHTDg8Oaizna5bJrdw5BSTht+Pdc=",
+        "lastModified": 1731707185,
+        "narHash": "sha256-IfA3x0eL4Be/7hvdvGSnT8fgiXz7GL3PtjGw3BH68gM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "46e574d4ea1642dd87a6bfb162053c52b2e4878b",
+        "rev": "be455f7f2714ce3479ae5bb662a03bd450f45793",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`be455f7f`](https://github.com/nix-community/nixvim/commit/be455f7f2714ce3479ae5bb662a03bd450f45793) | `` lib/options: use `literalLua` for `defaultNullOpts.mkRaw` ``       |
| [`da6e3499`](https://github.com/nix-community/nixvim/commit/da6e3499d4dbf0d0c69480f619e8f5e2de2c9f8f) | `` lib/utils: add `nestedLiteral` and `nestedLiteralLua` ``           |
| [`eb76e62a`](https://github.com/nix-community/nixvim/commit/eb76e62a9b00e841cd1eb35989bcbca140224cb0) | `` lib/utils: add `literalLua` for use in option docs ``              |
| [`de99f293`](https://github.com/nix-community/nixvim/commit/de99f2938feefc990854363897623a19c077478e) | `` lib/{vim,neovim}-plugin: `installPackage` -> `packageDecorator` `` |
| [`1d78aee7`](https://github.com/nix-community/nixvim/commit/1d78aee791ac3e97134f93af79f00e6e01ed1e86) | `` tests/modules/clipboard: add raw lua code test ``                  |
| [`ef8d57ab`](https://github.com/nix-community/nixvim/commit/ef8d57aba0a4b436632730b558d3996019b3a698) | `` modules/clipboard: allow raw lua code in register option ``        |
| [`5095066d`](https://github.com/nix-community/nixvim/commit/5095066df62f3159ad8ffd950fce7eb4f8521528) | `` docs: improve mk(Neovim/Vim)Plugin function documentation ``       |