### PR TITLE
chore(flake/nixvim): `5c6dd20a` -> `9d99d7cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1731760432,
-        "narHash": "sha256-tLOq1smR8yJ7Td4vKKEL251fp94XAibFmqRt3yWJxdI=",
+        "lastModified": 1731780782,
+        "narHash": "sha256-CG3rcxcZEViYEUTAXatqXrW0Gn9tQvydF+lLYH+0VPA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5c6dd20aeb7fa868836cfb20ac2ec546cc3c977a",
+        "rev": "9d99d7cfdbd7f94da9571a4d7bbb9de185241935",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`9d99d7cf`](https://github.com/nix-community/nixvim/commit/9d99d7cfdbd7f94da9571a4d7bbb9de185241935) | `` plugins/lsp: remove buf-language-server ``            |
| [`587b1cbf`](https://github.com/nix-community/nixvim/commit/587b1cbf21bb818f83580edd7444a2587e873078) | `` lib/types: allow inline-lua in `rawLua` type ``       |
| [`c8267ba3`](https://github.com/nix-community/nixvim/commit/c8267ba3955970f20031ff54e507629bf273abb8) | `` plugins/tmux-navigator: re-word usage instructions `` |
| [`a52572c0`](https://github.com/nix-community/nixvim/commit/a52572c060dd991aa9fed0683503931f6b263d0b) | `` plugins/tmux-navigator: use markdown admonition ``    |
| [`7b0df222`](https://github.com/nix-community/nixvim/commit/7b0df222fc156cf2c30dcc2da971bb857b38c801) | `` plugins/kulala: init ``                               |