### PR TITLE
chore(flake/nixpkgs): `dc460ec7` -> `5e4fbfb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731319897,
-        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`52b48e20`](https://github.com/NixOS/nixpkgs/commit/52b48e2033feb2b39f0f39dd52736d03c289e01b) | `` gh: 2.61.0 -> 2.62.0 ``                                                          |
| [`0388195e`](https://github.com/NixOS/nixpkgs/commit/0388195e8a50c23d9e5c143e49bad54bcbfa4852) | `` nixos/release-notes-24.11: add g810-led ``                                       |
| [`059a8da6`](https://github.com/NixOS/nixpkgs/commit/059a8da6b10b5d301a9b0c100d699f197800ac8b) | `` nixos/g810-led: add to modules-list.nix ``                                       |
| [`dba59277`](https://github.com/NixOS/nixpkgs/commit/dba59277c214714bd05305d7e0f3beafb12c07c6) | `` gitlab: update bundler version ``                                                |
| [`72a499c0`](https://github.com/NixOS/nixpkgs/commit/72a499c09e308e87fb2090fa8f6fb21c1bcc00ce) | `` code-cursor: 0.42.4 -> 0.42.5 (#356008) ``                                       |
| [`179d274b`](https://github.com/NixOS/nixpkgs/commit/179d274b6e8a73575871bbe5f13f6dd08013e564) | `` lima: fix build on Linux ``                                                      |
| [`8abd7b32`](https://github.com/NixOS/nixpkgs/commit/8abd7b32202df6c492446edb05ef925af1515e18) | `` nixos/plasma6: add qtimageformats to the requiredPackages ``                     |
| [`0b3eef74`](https://github.com/NixOS/nixpkgs/commit/0b3eef7441c4c8becc61d67004bd8d05c33922a1) | `` postgresql_12: remove ``                                                         |
| [`b8fe9967`](https://github.com/NixOS/nixpkgs/commit/b8fe9967b53e377f95b7f07c12107d66c3e8cd53) | `` thunderbird-latest: 132.0 -> 132.0.1 ``                                          |
| [`b2e28581`](https://github.com/NixOS/nixpkgs/commit/b2e2858135d8c95b04e485a9c8e0cd897b926bd6) | `` thunderbird: 128.4.2 -> 128.4.3 ``                                               |
| [`c68630b0`](https://github.com/NixOS/nixpkgs/commit/c68630b06d3782bf9547818ed0aea56054bd0616) | `` libcpucycles: add update script ``                                               |
| [`663b2c17`](https://github.com/NixOS/nixpkgs/commit/663b2c175988c985ef6dc2753b66c70b2dbc101a) | `` python3Packages.cirq-google: fix build ``                                        |
| [`d2f8b267`](https://github.com/NixOS/nixpkgs/commit/d2f8b2670faf094b7dc0019c180deb14ea743c05) | `` librandombytes: added update script ``                                           |
| [`6a4d0b34`](https://github.com/NixOS/nixpkgs/commit/6a4d0b34e4d71deea386bda22ce5883bee5e743f) | `` doc/release-notes: change "New Services" to "New Modules" ``                     |
| [`a42c917e`](https://github.com/NixOS/nixpkgs/commit/a42c917e0a7337675271048f1b3b463373391a07) | `` reason: refactor ``                                                              |
| [`f3ce448f`](https://github.com/NixOS/nixpkgs/commit/f3ce448f60f2116ac3316648a956463565da222b) | `` Remove rane as maintainer ``                                                     |
| [`5dbb64eb`](https://github.com/NixOS/nixpkgs/commit/5dbb64eb043f845a5e55c517e2728dd12766d1cc) | `` mpvScripts.smartskip: init at 0-unstable-2023-11-25 ``                           |
| [`72eb4b7e`](https://github.com/NixOS/nixpkgs/commit/72eb4b7e045c36781d99322840a0e2514ae2176d) | `` freecad: remove AndersonTorres as maintainer ``                                  |
| [`e49edea8`](https://github.com/NixOS/nixpkgs/commit/e49edea8cb2861266de59dd71295a704f47e63e6) | `` sysdig-cli-scanner: 1.17.0 -> 1.18.0 ``                                          |
| [`362f26d0`](https://github.com/NixOS/nixpkgs/commit/362f26d024667da9a6ec97b0d33974b7a905a1b6) | `` firefox{,-beta,-devedition,-esr-128}-unwrapped: fix location of update script `` |
| [`48698458`](https://github.com/NixOS/nixpkgs/commit/48698458b65f75775938fd0d039959f756992ab0) | `` meilisearch: 1.11.1 → 1.11.3 ``                                                  |
| [`e8b5299d`](https://github.com/NixOS/nixpkgs/commit/e8b5299ddaffaa84190b663fadf7dffff0b7309c) | `` waveterm: 0.9.1 -> 0.9.2 ``                                                      |
| [`c459597a`](https://github.com/NixOS/nixpkgs/commit/c459597ac0620939ee9debeea0bfb740168ae958) | `` coqPackages_8_16.coq-lsp: fix for recent findlib ``                              |
| [`8530d4c3`](https://github.com/NixOS/nixpkgs/commit/8530d4c332ae8719deb2bed4c1b3c16425f09d48) | `` coqPackages.serapi: fix build ``                                                 |
| [`785e208c`](https://github.com/NixOS/nixpkgs/commit/785e208ce7e912ea10a28c1d9202aec1e020a7f5) | `` ocamlPackages.ppx_deriving: simplify version selection ``                        |
| [`be92f500`](https://github.com/NixOS/nixpkgs/commit/be92f500caf1db039f4a3c4db28558e1ead17a68) | `` coqPackages.coq-lsp: add missing dependency (result) ``                          |
| [`19933008`](https://github.com/NixOS/nixpkgs/commit/19933008229a9371df3234842ac855e5db8a186f) | `` warzone2100: 4.5.4 -> 4.5.5 ``                                                   |
| [`ee070b13`](https://github.com/NixOS/nixpkgs/commit/ee070b132a6f952048443fd285e2f4176ebd6edd) | `` nixos/dashy: import nixosModule ``                                               |
| [`2a79402b`](https://github.com/NixOS/nixpkgs/commit/2a79402b1e5be29cf2548229911ad3bdf1aa982d) | `` nixos/k3s: use same k3s package in multi-node test ``                            |
| [`8e48064d`](https://github.com/NixOS/nixpkgs/commit/8e48064d55aacea8ce03b1c9e705c700d783f5d4) | `` postgresql_17: 17.0 -> 17.1 ``                                                   |
| [`69b07f5a`](https://github.com/NixOS/nixpkgs/commit/69b07f5afee6309d224679ed6d9b4c968c8c26ad) | `` discord: various updates (#355721) ``                                            |
| [`9dc67330`](https://github.com/NixOS/nixpkgs/commit/9dc6733018133e469254ad4f76e76f4360bf56f1) | `` postgresql_15: 15.8 -> 15.9 ``                                                   |
| [`cf1f7e72`](https://github.com/NixOS/nixpkgs/commit/cf1f7e720107fee55bf56fa7ea1c14727b0db9ac) | `` postgresql_14: 14.13 -> 14.14 ``                                                 |
| [`b1a05d93`](https://github.com/NixOS/nixpkgs/commit/b1a05d9399c3a0fea9c108ca2569d5c37a868c0c) | `` postgresql_13: 13.16 -> 13.17 ``                                                 |
| [`b19df982`](https://github.com/NixOS/nixpkgs/commit/b19df9828202a1722ce74bc767a10c0544de034f) | `` zed-editor: 0.161.1 -> 0.161.2 ``                                                |
| [`fbae2750`](https://github.com/NixOS/nixpkgs/commit/fbae27508f9b179f05fc88bae1f68b5c50acbb12) | `` postgresql_12: 12.20 -> 12.21 ``                                                 |
| [`3259761b`](https://github.com/NixOS/nixpkgs/commit/3259761b002883375ecc531d1ffacbaba26cd9f9) | `` nixos/release-notes-24.11: add soteria module ``                                 |
| [`53712fa4`](https://github.com/NixOS/nixpkgs/commit/53712fa4a1bf8737117ef9048a1377ba2e188da5) | `` nixos/soteria: init module ``                                                    |
| [`1b6ddea5`](https://github.com/NixOS/nixpkgs/commit/1b6ddea547bb1d215c855de4a0ce0ced93803500) | `` cunicu: init at 0.5.53 ``                                                        |
| [`1df62418`](https://github.com/NixOS/nixpkgs/commit/1df6241846552e2c6ad36f4f3b80ae3007e0a988) | `` vimPlugins.snipe-nvim: init at 2024-10-15 ``                                     |
| [`9121e18d`](https://github.com/NixOS/nixpkgs/commit/9121e18d25cec671bd71ff9afe7fc4acd372cb42) | `` vimPlugins.vim-dadbod-ui: add a vimCommandCheck hook ``                          |
| [`a8363975`](https://github.com/NixOS/nixpkgs/commit/a8363975808e7eeaf53d681df401ba58aad233c2) | `` release-notes: update 25.05 from 24.11 init ``                                   |
| [`90fcf3aa`](https://github.com/NixOS/nixpkgs/commit/90fcf3aa7eba70f18dad15b634e9336b997d25ac) | `` 25.05 is Warbler ``                                                              |
| [`f49e820f`](https://github.com/NixOS/nixpkgs/commit/f49e820fbc9450736bb6ba982a2ff0a8d014ad1e) | `` 24.11 beta release ``                                                            |
| [`e5d88ac6`](https://github.com/NixOS/nixpkgs/commit/e5d88ac614c7948ce0b9d20baf311e1de9a3bf3e) | `` python312Packages.discogs-client: 2.7 -> 2.7.1 ``                                |
| [`4ec1fbcc`](https://github.com/NixOS/nixpkgs/commit/4ec1fbcc491fb1e68eca5cb9acc485d8145d74d7) | `` lastpass-cli: 1.6.0 -> 1.6.1 ``                                                  |
| [`40d43277`](https://github.com/NixOS/nixpkgs/commit/40d43277521662cd98f4f025ae99cf5fc7035cfc) | `` quark-engine: 24.10.1 -> 24.11.1 ``                                              |
| [`816a7437`](https://github.com/NixOS/nixpkgs/commit/816a7437f985fc136fe991f4e264856ecfbc8323) | `` rygel: include the PipeWire GStreamer plugin ``                                  |
| [`619a42f8`](https://github.com/NixOS/nixpkgs/commit/619a42f81a3252a81ad64248cd2459c676d31e5f) | `` rygel: format ``                                                                 |
| [`4ab23ff7`](https://github.com/NixOS/nixpkgs/commit/4ab23ff7a832d773e8a3797db982015d3f340163) | `` linux_5_15: 5.15.171 -> 5.15.172 ``                                              |
| [`6e39bab2`](https://github.com/NixOS/nixpkgs/commit/6e39bab2d3acfc66fef55ac993aa7f477390424e) | `` linux_6_1: 6.1.116 -> 6.1.117 ``                                                 |
| [`ab249bf1`](https://github.com/NixOS/nixpkgs/commit/ab249bf1fd0231bd5294ecf6fc17d67b02ba3bdc) | `` linux_6_6: 6.6.60 -> 6.6.61 ``                                                   |
| [`8dbca107`](https://github.com/NixOS/nixpkgs/commit/8dbca107eea4eeb3474f6c20f0b8b4aab062e429) | `` linux_6_11: 6.11.7 -> 6.11.8 ``                                                  |
| [`fe74556e`](https://github.com/NixOS/nixpkgs/commit/fe74556e9fbde3fc0444aca1f669ab1ef7c2da6e) | `` linux_testing: 6.12-rc6 -> 6.12-rc7 ``                                           |
| [`0128d057`](https://github.com/NixOS/nixpkgs/commit/0128d0577866e57390fde0236e4c6a04e3c26211) | `` mumps: use magic __structuredAttrs to handle space in makeFlags ``               |
| [`30af19ed`](https://github.com/NixOS/nixpkgs/commit/30af19eddcf943062a84e927c9aad95114938faf) | `` mumps: remove redundent make all in installCheckPhase ``                         |
| [`4b986502`](https://github.com/NixOS/nixpkgs/commit/4b9865028895c84295f624788d06a0e851028cf4) | `` mumps: remove mpi from nativeBuildInputs ``                                      |
| [`73c67181`](https://github.com/NixOS/nixpkgs/commit/73c671819b193dfcd82aff12521d16950408d654) | `` terraform-providers.bitwarden: 0.10.0 -> 0.12.0 ``                               |
| [`db14923f`](https://github.com/NixOS/nixpkgs/commit/db14923f68619d2ad9a5fe7a5e97caf0ab604cfe) | `` terraform-providers.newrelic: 3.50.0 -> 3.52.1 ``                                |
| [`794fb602`](https://github.com/NixOS/nixpkgs/commit/794fb6028ea279eba8cbc14f660f181f6e6af8d5) | `` dediprog-sf100: 1.14.20.x -> 1.14.21,x ``                                        |
| [`a5f34dae`](https://github.com/NixOS/nixpkgs/commit/a5f34daeeb61af0a2f03cbd34737394d91aeb4a1) | `` nixos/g810-led: init ``                                                          |
| [`031d837c`](https://github.com/NixOS/nixpkgs/commit/031d837c806c4555542856a65154123199478fb0) | `` cemu: 2.2 -> 2.4 ``                                                              |
| [`955168be`](https://github.com/NixOS/nixpkgs/commit/955168be69fedd2532b6e48002c9d9099d379c53) | `` python3Packages.chainer: fix build ``                                            |
| [`5ce7ad23`](https://github.com/NixOS/nixpkgs/commit/5ce7ad230b2c29fb17ab318bd1f5c5c4a95db7d1) | `` python3Packages.symspellpy: fix build ``                                         |
| [`522734ba`](https://github.com/NixOS/nixpkgs/commit/522734ba98437471ada4993b33f25647ad0b7f2f) | `` malwoverview: 6.0.0 -> 6.0.1 ``                                                  |
| [`225405ed`](https://github.com/NixOS/nixpkgs/commit/225405ed6e92975f390563ed9de83ab026127904) | `` manim-slides: 5.1.8 -> 5.1.9 ``                                                  |
| [`2a1f30c6`](https://github.com/NixOS/nixpkgs/commit/2a1f30c6adef990b20b5ea4f77da56b3b1d667f2) | `` fblog: 4.13.0 -> 4.13.1 ``                                                       |
| [`f7198d86`](https://github.com/NixOS/nixpkgs/commit/f7198d861220fdcfa52b6c8ad93743f6d631e389) | `` python312Packages.arelle: remove obsolete patch ``                               |
| [`98eb6556`](https://github.com/NixOS/nixpkgs/commit/98eb65560cb3e3473b96f57049cb176d4a45cd7b) | `` protols: 0.6.2 -> 0.8.0 ``                                                       |
| [`fade5922`](https://github.com/NixOS/nixpkgs/commit/fade592271ec71bdb79d6c7bf8f6297ba6f9714b) | `` niri: 0.1.10 -> 0.1.10.1 ``                                                      |
| [`bdf775a2`](https://github.com/NixOS/nixpkgs/commit/bdf775a246782281a412d5ca79603fa298819a07) | `` ngtcp2: 1.8.0 -> 1.8.1 ``                                                        |
| [`55a73793`](https://github.com/NixOS/nixpkgs/commit/55a73793ef375e4c5ae31555f99fbc642a4d1f20) | `` python312Packages.mypy-boto3-organizations: 1.35.28 -> 1.35.60 ``                |
| [`b654fecf`](https://github.com/NixOS/nixpkgs/commit/b654fecf8dbbfb8b3c2314871ea45980d98f7207) | `` python312Packages.mypy-boto3-mediaconvert: 1.35.23 -> 1.35.60 ``                 |
| [`d05feae8`](https://github.com/NixOS/nixpkgs/commit/d05feae84c644d8191185e3ab76e1a996b8d2e51) | `` python312Packages.mypy-boto3-internetmonitor: 1.35.8 -> 1.35.60 ``               |
| [`d87ccc5f`](https://github.com/NixOS/nixpkgs/commit/d87ccc5f64a5225861efca2cc7edcc2f7111593c) | `` python312Packages.mypy-boto3-ec2: 1.35.52 -> 1.35.60 ``                          |
| [`df84b99d`](https://github.com/NixOS/nixpkgs/commit/df84b99dddfafd60e9eac5f01aabc926c7feced5) | `` python312Packages.mypy-boto3-dynamodb: 1.35.54 -> 1.35.60 ``                     |
| [`c631f468`](https://github.com/NixOS/nixpkgs/commit/c631f4680da28a73b5d72acda505573f7c2fd77f) | `` python312Packages.mypy-boto3-cloudtrail: 1.35.27 -> 1.35.60 ``                   |
| [`c283f5d4`](https://github.com/NixOS/nixpkgs/commit/c283f5d43532e488cdcb37dd0821e86f392939af) | `` python312Packages.mypy-boto3-accessanalyzer: 1.35.0 -> 1.35.60 ``                |
| [`35ab575c`](https://github.com/NixOS/nixpkgs/commit/35ab575cedec441582d731472a1e4ec29ef8d166) | `` python312Packages.keep: replace terminaltables with terminaltables3 ``           |
| [`2333f106`](https://github.com/NixOS/nixpkgs/commit/2333f106ddc60d8c20131f27cd0f835f20fdfa65) | `` python312Packages.keep: update ordering ``                                       |
| [`0733bbf1`](https://github.com/NixOS/nixpkgs/commit/0733bbf17e815c0daaa7ac8deb1a19329cfef311) | `` python312Packages.keep: update meta ``                                           |
| [`846aa24c`](https://github.com/NixOS/nixpkgs/commit/846aa24c45527e1dcff76d5b21996ed41ce556cb) | `` python312Packages.keep: update build-system ``                                   |
| [`124de92a`](https://github.com/NixOS/nixpkgs/commit/124de92ab553cb9556e10ebb754aaad368fe07e8) | `` python312Packages.deebot-client: 8.4.0 -> 8.4.1 ``                               |
| [`7fdcedf4`](https://github.com/NixOS/nixpkgs/commit/7fdcedf43f3b08db42d18e9c7e15d1a089c400c4) | `` uefi-firmware-parser: init at 1.12 ``                                            |
| [`127fbda3`](https://github.com/NixOS/nixpkgs/commit/127fbda319b3689d0164e559e86b31e03b7c51ca) | `` python312Packages.spotifyaio: 0.8.7 -> 0.8.8 ``                                  |
| [`f5e00322`](https://github.com/NixOS/nixpkgs/commit/f5e0032255f88592a73bfad6e4dcd43f67da16a0) | `` python312Packages.lcn-frontend: 0.2.1 -> 0.2.2 ``                                |
| [`754ab3ec`](https://github.com/NixOS/nixpkgs/commit/754ab3ec8b7a9e6034d540b509a5126a9efe6b02) | `` python312Packages.ring-doorbell: 0.9.9 -> 0.9.12 ``                              |
| [`28a76a17`](https://github.com/NixOS/nixpkgs/commit/28a76a17bf5fa1e3369c1cdc2df78d119757169c) | `` python312Packages.aioelectricitymaps: refactor ``                                |
| [`f04d9ccc`](https://github.com/NixOS/nixpkgs/commit/f04d9cccc7e6a972239154326da2374ff6404a7c) | `` python312Packages.huum: 0.7.11 -> 0.7.12 ``                                      |
| [`960e9106`](https://github.com/NixOS/nixpkgs/commit/960e9106afee832cb696478c27e54414fc2d6586) | `` python312Packages.reolink-aio: 0.11.0b1 -> 0.11.0 ``                             |
| [`98698756`](https://github.com/NixOS/nixpkgs/commit/98698756ef1ecbdb53e9f1acc6ea41d532b962d3) | `` python312Packages.environs: 11.0.0 -> 11.1.0 ``                                  |
| [`8e7d95b5`](https://github.com/NixOS/nixpkgs/commit/8e7d95b52dabf9a9af9f238de26070e5e221ac8f) | `` python312Packages.aocd-example-parser: unstable-2023-12-17 -> 2023.12.20 ``      |
| [`9fffb9ab`](https://github.com/NixOS/nixpkgs/commit/9fffb9ab665d0b16ad0e5a9fa5237222c31b6f58) | `` python312Packages.aiowithings: 3.1.1 -> 3.1.3 ``                                 |
| [`68fb6d2d`](https://github.com/NixOS/nixpkgs/commit/68fb6d2d23c649a8733e4874fb776fc47b064056) | `` wiliwili: 1.4.1 -> 1.5.0 ``                                                      |
| [`205bb4d1`](https://github.com/NixOS/nixpkgs/commit/205bb4d14b8f22d61383188de28e009f986eadba) | `` catppuccin-plymouth: 0-unstable-2024-05-28 -> 0-unstable-2024-10-19 ``           |
| [`a0e696f5`](https://github.com/NixOS/nixpkgs/commit/a0e696f577d2105741980a921b58c9d3e2d60ea0) | `` python312Packages.oras: 0.2.2 -> 0.2.25 ``                                       |