### PR TITLE
chore(flake/nixvim): `9d99d7cf` -> `80e49e7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731604581,
-        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
+        "lastModified": 1732884235,
+        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
+        "rev": "819f682269f4e002884702b87e445c82840c68f2",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731642829,
-        "narHash": "sha256-vG+O2RZRzYZ8BUMNNJ+BLSj6PUoGW7taDQbp6QNJ3Xo=",
+        "lastModified": 1732603785,
+        "narHash": "sha256-AEjWTJwOmSnVYsSJCojKgoguGfFfwel6z/6ud6UFMU8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "f86f158efd4bab8dce3e207e4621f1df3a760b7a",
+        "rev": "6ab87b7c84d4ee873e937108c4ff80c015a40c7a",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1731780782,
-        "narHash": "sha256-CG3rcxcZEViYEUTAXatqXrW0Gn9tQvydF+lLYH+0VPA=",
+        "lastModified": 1733010437,
+        "narHash": "sha256-xPf3jjDBDA9oMVnWU5DJ8gINCq2EPiupvF/4rD/0eEI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9d99d7cfdbd7f94da9571a4d7bbb9de185241935",
+        "rev": "80e49e7fd3fa720b93d18e6d859d9b9e7aad4a62",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731582522,
-        "narHash": "sha256-1w6aM4bG5cl2E4jHLPnMKkrUO4tY1jUX1NI6/RwJN7Y=",
+        "lastModified": 1731936508,
+        "narHash": "sha256-z0BSSf78LkxIrrFXZYmCoRRAxAmxMUKpK7CyxQRvkZI=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "13300b2297c51368e0892c3ebe220f688014fe15",
+        "rev": "fe07070f811b717a4626d01fab714a87d422a9e1",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730321837,
-        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
+        "lastModified": 1732894027,
+        "narHash": "sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII+oAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
+        "rev": "6209c381904cab55796c5d7350e89681d3b2a8ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`80e49e7f`](https://github.com/nix-community/nixvim/commit/80e49e7fd3fa720b93d18e6d859d9b9e7aad4a62) | `` plugins/dashboard: format ``                                                     |
| [`86ff391e`](https://github.com/nix-community/nixvim/commit/86ff391e9ed729914e0ab1f4893466858c225bd6) | `` plugins/dashboard: better rawLua support for header ``                           |
| [`060f4b4c`](https://github.com/nix-community/nixvim/commit/060f4b4c3800367ba202440a7832cddecb7fae26) | `` plugins/aerial: init ``                                                          |
| [`09dfa035`](https://github.com/nix-community/nixvim/commit/09dfa035b65db88ca32df11507c891530f3258ef) | `` plugins/gitlab: init ``                                                          |
| [`880a5705`](https://github.com/nix-community/nixvim/commit/880a57058862752aed6d0215697718c4f646f299) | `` ci: add support for new stable nixos-24.11 branch ``                             |
| [`a35f923d`](https://github.com/nix-community/nixvim/commit/a35f923d6aa05eede3cf694608ce0dde6ba28d54) | `` treewide: replace mentions of 24.05 with 24.11 ``                                |
| [`0c89a669`](https://github.com/nix-community/nixvim/commit/0c89a669f6f8508784c187c9cf9d381592146e92) | `` readme: fix `stable` -> `24.05` in docs URL ``                                   |
| [`98bedb5e`](https://github.com/nix-community/nixvim/commit/98bedb5eebc92ec3a170c7f7844d4dbd944ac334) | `` ci/docs: `stable` -> `24.05` in docs path ``                                     |
| [`72762c8e`](https://github.com/nix-community/nixvim/commit/72762c8ef1e33604d4338b4254a3a45829fa59f8) | `` ci/docs: remove on 24.05 branch ``                                               |
| [`bb5b0a26`](https://github.com/nix-community/nixvim/commit/bb5b0a26556017f1f3a4c07f8bd20dee88f6ffb0) | `` tests/modules-performance: add nvim-cmp to extraPlugins when necessary ``        |
| [`a4e5f694`](https://github.com/nix-community/nixvim/commit/a4e5f694355777c5f4e24bb9398316fbe33084d4) | `` tests/codeium-nvim: fix and update tests ``                                      |
| [`cb0e3a7e`](https://github.com/nix-community/nixvim/commit/cb0e3a7e4049f774e7cbd34c57eeeee17bb1ed2a) | `` plugins/efmls-configs: add new formatter kdlfmt to unpackaged ``                 |
| [`c39ecbb0`](https://github.com/nix-community/nixvim/commit/c39ecbb055597edade9b936905314eade3e5ca96) | `` tests/lsp-servers: disable servers relying on EOL dotnet-core-combined ``        |
| [`41657913`](https://github.com/nix-community/nixvim/commit/41657913df2cb1577620b9609a41ba2201c05218) | `` generated: Update ``                                                             |
| [`4d0b66b9`](https://github.com/nix-community/nixvim/commit/4d0b66b9d7c9d56e9a1e99bc0a7f3d215a66c06c) | `` flake.lock: Update ``                                                            |
| [`05331006`](https://github.com/nix-community/nixvim/commit/05331006a42846d6e55129b642485f45f90c9efc) | `` plugins/vim-suda: init ``                                                        |
| [`fc9178d1`](https://github.com/nix-community/nixvim/commit/fc9178d124eba824f1862513314d351784e1a84c) | `` plugins/image.nvim: ueberzugPackage default to ueberzugppv ``                    |
| [`7eb106ab`](https://github.com/nix-community/nixvim/commit/7eb106ab690ff3f37ef5d517763e68a78a7923e3) | `` flake.lock: Update ``                                                            |
| [`8b19d154`](https://github.com/nix-community/nixvim/commit/8b19d154823619af7ced464185e8d13ec80a758b) | `` plugins/lsp: fix `enabledServers.extraOptions` type merging ``                   |
| [`a1c352af`](https://github.com/nix-community/nixvim/commit/a1c352affcd40ad28ac7c77e10e3313d8a8fa628) | `` plugins/vim-be-good: init ``                                                     |
| [`8507b01e`](https://github.com/nix-community/nixvim/commit/8507b01e0ccd0d0b42939b9e249553c220388249) | `` lib/maintainers: add 347Online ``                                                |
| [`a81a03a3`](https://github.com/nix-community/nixvim/commit/a81a03a3f5dcdcdee5cbe831a9f2e81895e92875) | `` plugins/vim-colemak: init ``                                                     |
| [`6b9d55f9`](https://github.com/nix-community/nixvim/commit/6b9d55f936a5df716f787df0ed172070fccbc1e9) | `` Update docs/user-guide/config-examples.md ``                                     |
| [`99f37733`](https://github.com/nix-community/nixvim/commit/99f377335dccdaeed895dc17b3fbae3ce92c6802) | `` docs/user-guide/config-examples: add spector700's config ``                      |
| [`85759f23`](https://github.com/nix-community/nixvim/commit/85759f2360faa0464da008b040217183d99fd9d9) | `` flake.lock: Update ``                                                            |
| [`c1271fa1`](https://github.com/nix-community/nixvim/commit/c1271fa10a54a3b35db6040dd6e779f349af52bf) | `` ci: fix nix-install-action versions ``                                           |
| [`fb49a740`](https://github.com/nix-community/nixvim/commit/fb49a740f8aa32f4452849f91da0d94839b83cf1) | `` ci: bump nix-install-action ``                                                   |
| [`863d7d5a`](https://github.com/nix-community/nixvim/commit/863d7d5adec45735de8e4cc873578e1f0d915dc4) | `` docs: link to all "available" versions of the docs ``                            |
| [`2f71c425`](https://github.com/nix-community/nixvim/commit/2f71c4250bef7a52fe21bd00d1e58c119f62008c) | `` tests/avante: remove deprecated model option `local` ``                          |
| [`5f0b3371`](https://github.com/nix-community/nixvim/commit/5f0b33710ab1eb0657081e015031c4b9b1eb9b2c) | `` tests/{efmls-configs,none-ls}: re-enable phpstan test ``                         |
| [`7defce38`](https://github.com/nix-community/nixvim/commit/7defce38637187b334afbd58515ec18ad30d4f4b) | `` tests/{efmls-configs,lsp-servers}: re-enable psalm test ``                       |
| [`fd41c5af`](https://github.com/nix-community/nixvim/commit/fd41c5afee9882dfce17f9dee33355fcfa383058) | `` generated: Updated rust-analyzer.nix ``                                          |
| [`2a94d1de`](https://github.com/nix-community/nixvim/commit/2a94d1de6ecf80d022c998d41290834c93f1e7ea) | `` flake.lock: Update ``                                                            |
| [`7b94afce`](https://github.com/nix-community/nixvim/commit/7b94afceaf616d64d43d33340dddf64f57c7a5b2) | `` plugins: cleanup most `extraConfig` args ``                                      |
| [`63cfc84a`](https://github.com/nix-community/nixvim/commit/63cfc84abeec5f8995945098e30e2d8101133d18) | `` lib/modules: add `applyExtraConfig` ``                                           |
| [`c7b7b648`](https://github.com/nix-community/nixvim/commit/c7b7b6481b129d31b5357b4529c28e2cc341b96e) | `` docs: no longer using `master` but `main` ``                                     |
| [`9416bc90`](https://github.com/nix-community/nixvim/commit/9416bc9018cca37b3f24eef290e2113edff25960) | `` docs/ci: use `nix build --argstr` to safely supply input ``                      |
| [`ed30fd85`](https://github.com/nix-community/nixvim/commit/ed30fd858848be9b0f13d48cfa9ae6fd00df21d6) | `` modules/opts: fix code generation condition to prevent false positives ``        |
| [`929bb0cd`](https://github.com/nix-community/nixvim/commit/929bb0cd1cffb9917ab14be9cdb3f27efd6f505f) | `` plugins/telescope: refactor `mkExtension` ``                                     |
| [`c674f10d`](https://github.com/nix-community/nixvim/commit/c674f10d189fcbcf961f3c19479ac44d7d2d6e50) | `` plugins/lsp: Correctly mark servers as disabled if the lsp plugin is disabled `` |
| [`31eb9d8d`](https://github.com/nix-community/nixvim/commit/31eb9d8d759c54f19f81482addbb93db706ee6e1) | `` plugins/lsp: Fix extra config of lsp servers ``                                  |
| [`2017830a`](https://github.com/nix-community/nixvim/commit/2017830a2c81a97f6b7679ea5fa0d921cd0f4535) | `` docs/ci: fix a typo when calling `mkdir -p` ``                                   |
| [`85244475`](https://github.com/nix-community/nixvim/commit/852444755474998b1b24bdd2f60d332a0eb2c830) | `` docs/ci: fix docs being installed to `nixvim/nixvim/<subdir>` ``                 |
| [`2bc8dc86`](https://github.com/nix-community/nixvim/commit/2bc8dc86a04fbccaef9e99fde6d07ef654df36a2) | `` ci/docs: fix `env` vs `environment` error ``                                     |
| [`99b066ba`](https://github.com/nix-community/nixvim/commit/99b066ba6d4dea6311b88807894324bbc6c47658) | `` docs: only set base-href in CI built docs ``                                     |
| [`cdbda982`](https://github.com/nix-community/nixvim/commit/cdbda982f04bd021cfa8d549896410c5caf84fdf) | `` docs/search: refactor to use `override` ``                                       |
| [`9eb07bb1`](https://github.com/nix-community/nixvim/commit/9eb07bb16fe20d6073d820c9202f72962acbbda4) | `` flake.lock: Update ``                                                            |
| [`f4c910dd`](https://github.com/nix-community/nixvim/commit/f4c910dd82eb6e811ba171bc923087b7ecfb321c) | `` tests/lsp-servers: disable deprecated servers ``                                 |
| [`a773b945`](https://github.com/nix-community/nixvim/commit/a773b945fb9c74897333e4cd4f097f21a1d37f51) | `` tests/lsp: ruff_lsp is deprecated, test ruff instead ``                          |
| [`e1417016`](https://github.com/nix-community/nixvim/commit/e1417016dfb561ac922d561f4f00d1c9160b23d9) | `` tests/{lsp-servers,efmls-configs}: disable psalm ``                              |
| [`8b77198d`](https://github.com/nix-community/nixvim/commit/8b77198d494690f947cdf548bc74c4f3bc824a7c) | `` tests/{none-ls,efmls-configs}: disable phpstan ``                                |
| [`909b4f41`](https://github.com/nix-community/nixvim/commit/909b4f41d7339af3b3701cf9955376549b1c514d) | `` tests: re-enable lua-language-servers tests on all platforms ``                  |
| [`1ee4915f`](https://github.com/nix-community/nixvim/commit/1ee4915f6559a5955d12ec8b802777e7272f1c70) | `` plugins/lsp: update lsp-packages.nix ``                                          |
| [`00365d6d`](https://github.com/nix-community/nixvim/commit/00365d6d40737cb88841387099485dbb75c596ed) | `` generated: Updated lspconfig-servers.json ``                                     |
| [`b5a999fb`](https://github.com/nix-community/nixvim/commit/b5a999fb2291abd722a3035c5ce69c373925b049) | `` flake.lock: Update ``                                                            |
| [`5bc3fa69`](https://github.com/nix-community/nixvim/commit/5bc3fa6996ee37b754f2e815a165be6e4d0cfcb9) | `` plugins/quarto: init ``                                                          |