### PR TITLE
chore(flake/nix-fast-build): `8e7c9d76` -> `f51f479d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1730278911,
-        "narHash": "sha256-CrbqsC+lEA3w6gLfpqfDMDEKoEta2sl4sbQK6Z/gXak=",
+        "lastModified": 1732540608,
+        "narHash": "sha256-y1Q87PRcztZ2C1J/xGHk0VxY/T9wB6YL1nLtRbMYW5g=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "8e7c9d76979381441facb8888f21408312cf177a",
+        "rev": "f51f479d001317204f1a47302db36473dc12fc8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`d991bf33`](https://github.com/Mic92/nix-fast-build/commit/d991bf3345c5379d16cd6ce3a0ba0e899dd4ef06) | `` ci(mergify): upgrade configuration to current format `` |