### PR TITLE
chore(flake/nixvim): `80e49e7f` -> `58d2a5ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1733665616,
+        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732884235,
-        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
+        "lastModified": 1734093295,
+        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "819f682269f4e002884702b87e445c82840c68f2",
+        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732603785,
-        "narHash": "sha256-AEjWTJwOmSnVYsSJCojKgoguGfFfwel6z/6ud6UFMU8=",
+        "lastModified": 1733570843,
+        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6ab87b7c84d4ee873e937108c4ff80c015a40c7a",
+        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1733010437,
-        "narHash": "sha256-xPf3jjDBDA9oMVnWU5DJ8gINCq2EPiupvF/4rD/0eEI=",
+        "lastModified": 1734223742,
+        "narHash": "sha256-vp3wSbCVU/4y5W+YI6H9PSix3WD7XbcIyesmB7W0ZWo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "80e49e7fd3fa720b93d18e6d859d9b9e7aad4a62",
+        "rev": "58d2a5ac9cc4ff987e6edb77f2b55d1dec05ce50",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731936508,
-        "narHash": "sha256-z0BSSf78LkxIrrFXZYmCoRRAxAmxMUKpK7CyxQRvkZI=",
+        "lastModified": 1733773348,
+        "narHash": "sha256-Y47y+LesOCkJaLvj+dI/Oa6FAKj/T9sKVKDXLNsViPw=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "fe07070f811b717a4626d01fab714a87d422a9e1",
+        "rev": "3051be7f403bff1d1d380e4612f0c70675b44fc9",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732894027,
-        "narHash": "sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII+oAc=",
+        "lastModified": 1733761991,
+        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6209c381904cab55796c5d7350e89681d3b2a8ef",
+        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`58d2a5ac`](https://github.com/nix-community/nixvim/commit/58d2a5ac9cc4ff987e6edb77f2b55d1dec05ce50) | `` plugins/dap-lldb: init ``                                                  |
| [`c351af10`](https://github.com/nix-community/nixvim/commit/c351af103f7a5a4228ab9f31bc1e3646c1987a98) | `` tests/efmls-configs: fix eval error ``                                     |
| [`fd279c89`](https://github.com/nix-community/nixvim/commit/fd279c892d0fe72d1c2e9d2eeb0a5ce732239989) | `` tests/lsp-servers: disable typst_lsp ``                                    |
| [`25a3dc7c`](https://github.com/nix-community/nixvim/commit/25a3dc7cb58af9958e95d867ba91b7f45f8778c3) | `` plugins/efmls-configs: add gleam_format to unpackaged ``                   |
| [`99a2827f`](https://github.com/nix-community/nixvim/commit/99a2827f7ce3c25cc23a84961efed0e06359a517) | `` plugins/lsp: add ltex_plus to unpackaged ``                                |
| [`4463eccb`](https://github.com/nix-community/nixvim/commit/4463eccbd27e6f957a29c4245f5488ae4bd0b609) | `` generated: Update ``                                                       |
| [`b3318925`](https://github.com/nix-community/nixvim/commit/b33189256bbe3d777ca9960fa64cc11e13013a72) | `` flake.lock: Update ``                                                      |
| [`e6018ac1`](https://github.com/nix-community/nixvim/commit/e6018ac19521082a86477da18f35488cd453d60d) | `` plugins/lsp: modernize implem of language-servers ``                       |
| [`57464f22`](https://github.com/nix-community/nixvim/commit/57464f22bb13689856d6db246fa5beaf23611648) | `` config-examples: add NikolayGalkin ``                                      |
| [`94535b24`](https://github.com/nix-community/nixvim/commit/94535b24a2193d7e31cf79efca63bfb001a31e4b) | `` plugins/lsp: fix tinymist implementation and update options ``             |
| [`95361fda`](https://github.com/nix-community/nixvim/commit/95361fda3c020f64f9331aaa09e76c2dcb662ac0) | `` treewide: apply deadnix suggestions ``                                     |
| [`c7a261db`](https://github.com/nix-community/nixvim/commit/c7a261db2ceb9ddf6f8e59c8d82431bf9c73b688) | `` flake-modules/dev: add deadnix ``                                          |
| [`09daa2cb`](https://github.com/nix-community/nixvim/commit/09daa2cb8377de50d1afc1e769edaefd90ae7bc0) | `` plugins/efmls-configs: move from lsp to by-name ``                         |
| [`f13bdfec`](https://github.com/nix-community/nixvim/commit/f13bdfec8f2c5786362a78f555ff3577c2a59591) | `` plugins/TEMPLATE: add moduleName ``                                        |
| [`63c81b17`](https://github.com/nix-community/nixvim/commit/63c81b1778b778c83043980c672f4bd2605b2240) | `` lib/options: mkLazyLoadOption: packPathName -> name ``                     |
| [`c37031d7`](https://github.com/nix-community/nixvim/commit/c37031d71ffc6b4cad88871899cb15a40d2e8016) | `` treewide: luaName -> moduleName ``                                         |
| [`a7012e78`](https://github.com/nix-community/nixvim/commit/a7012e7864bde5c5fceadd466d6aee909d2b682c) | `` treewide: originalName -> packPathName ``                                  |
| [`e8e39655`](https://github.com/nix-community/nixvim/commit/e8e396558b52be4319d93b995da91b16fd9793b7) | `` docs/user-guide: add lazy-loading.md ``                                    |
| [`6a192a86`](https://github.com/nix-community/nixvim/commit/6a192a86045c4f0b7fa345ee8950abab468456c1) | `` lib/neovim-plugin: allow `configLocation` to be wrapped using `mkOrder` `` |
| [`c1810144`](https://github.com/nix-community/nixvim/commit/c181014422fa9261db06fc9b5ecbf67f42c30ec3) | `` colorschemes/dracula: switch to mkVimPlugin ``                             |
| [`2b5a4a38`](https://github.com/nix-community/nixvim/commit/2b5a4a3896219078eabc32cb3fc3556cb59d31e6) | `` plugins/neorg: switch to mkNeovimPlugin ``                                 |
| [`c0550513`](https://github.com/nix-community/nixvim/commit/c0550513b3277954f2362c54c0d0f1a0da3d161d) | `` plugins/treesitter: extraConfiguLua -> luaConfig ``                        |
| [`e60af136`](https://github.com/nix-community/nixvim/commit/e60af13695cbbe2e0013ff26f3b3fa1150518aaa) | `` plugins/lightline: extraConfiguLua -> luaConfig ``                         |
| [`455c5bff`](https://github.com/nix-community/nixvim/commit/455c5bff3e551b5bb46778135fc048d5154f2167) | `` plugins/nvim-autopairs: extraConfiguLua -> luaConfig ``                    |
| [`8012fbd9`](https://github.com/nix-community/nixvim/commit/8012fbd998466dde1a2831173531972e8a284110) | `` plugins/lz-n: move to extraConfigLuaPre ``                                 |
| [`d99bc6eb`](https://github.com/nix-community/nixvim/commit/d99bc6ebadce99dcb8b294c31fac96329b3bdf2e) | `` plugins/netman: migrate to mkNeovimPlugin ``                               |
| [`1d0404ff`](https://github.com/nix-community/nixvim/commit/1d0404ff43a4b64335b224bbe43161cb7ce52bf5) | `` plugins/netman: remove with lib; and helpers ``                            |
| [`6fcf389a`](https://github.com/nix-community/nixvim/commit/6fcf389a8de53c535e724abd2581a09afd46d5ba) | `` colorschemes/catppuccin: add originalName ``                               |
| [`2844c316`](https://github.com/nix-community/nixvim/commit/2844c31655e4e710fac1733c8f4456b92d506e8d) | `` plugins/grug-far: init ``                                                  |
| [`54b1d912`](https://github.com/nix-community/nixvim/commit/54b1d912992e4d3e76dadd98f300b28f083ca7bc) | `` plugins/remote-nvim: init ``                                               |
| [`c7b109f5`](https://github.com/nix-community/nixvim/commit/c7b109f5af93f8e59148a1a4838f3472f8ae403d) | `` plugins/otter: fix treesitter warning ``                                   |
| [`22063281`](https://github.com/nix-community/nixvim/commit/220632813768aa8bcc49dd95c7312dc287062877) | `` plugins/neotest: fix adapter warning ``                                    |
| [`c169e6df`](https://github.com/nix-community/nixvim/commit/c169e6df1fb8473e35d2189ff0b2e2d6d5bdb031) | `` plugins/hmts: migrate to mkNeovimPlugin ``                                 |
| [`1040d597`](https://github.com/nix-community/nixvim/commit/1040d597b2b45f77a1a2818c9831c7100d4eb961) | `` plugins/hmts: remove with lib; ``                                          |
| [`58a1f4a3`](https://github.com/nix-community/nixvim/commit/58a1f4a399dcd0a0dde4c4e791fa9d07cc09bc43) | `` plugins/hmts: fix warning ``                                               |
| [`b7526066`](https://github.com/nix-community/nixvim/commit/b752606681ded3f69e99ed568c7075b3578dce48) | `` tests/lazyloading/lz-n: runNvim false ``                                   |
| [`26f1daa4`](https://github.com/nix-community/nixvim/commit/26f1daa47e0ca89ebea09efe1d6db99fada04caf) | `` tests/lazyloading/lz-n: reduce repetition ``                               |
| [`76b567b4`](https://github.com/nix-community/nixvim/commit/76b567b43c9d1587f25884d745d08f5034b2c541) | `` modules/lazyload: warn enabling a lazy loading provider ``                 |
| [`0997b371`](https://github.com/nix-community/nixvim/commit/0997b371c784e9f623c8666ec006e8970ed76166) | `` lib/neovim-plugin: freeform lazy settings ``                               |
| [`d24dd313`](https://github.com/nix-community/nixvim/commit/d24dd313cfb5212aaec9e8cb15c273d869bf6e4b) | `` tests/lazyloading: lazy-load -> lz-n ``                                    |
| [`277b2658`](https://github.com/nix-community/nixvim/commit/277b2658a9e7ab82f948be8f7b73aee1d9f0a4c0) | `` plugins/typescript-tools: todo about lazy loading ``                       |
| [`c3f9cb72`](https://github.com/nix-community/nixvim/commit/c3f9cb721c7d920c281139b90254732870679401) | `` lib/neovim-plugin: refactor mkLazyLoadOption ``                            |
| [`3cfde155`](https://github.com/nix-community/nixvim/commit/3cfde1554c3aff3a3652a2779fec0170cf3c6f34) | `` lib/neovim-plugin: support lz-n lazy config ``                             |
| [`da30527d`](https://github.com/nix-community/nixvim/commit/da30527de18ea14971d176e81eb4e39037035838) | `` lib/neovim-plugin: use mkLazyLoadOption ``                                 |
| [`6ed719db`](https://github.com/nix-community/nixvim/commit/6ed719dba8a5ed821ae525311669e7195422cf6f) | `` lib/options: added mkLazyLoadOption ``                                     |
| [`301868d3`](https://github.com/nix-community/nixvim/commit/301868d380d267a313a4a7aa6344e03ab8f16074) | `` lib/neovim-plugin: support lazy loading luaConfig.content ``               |
| [`2e30f482`](https://github.com/nix-community/nixvim/commit/2e30f4828d2f0c669a3f28a4a32148d02b7a92b4) | `` plugins/cmp/sources: add cmp-vimtex ``                                     |
| [`39adaa0b`](https://github.com/nix-community/nixvim/commit/39adaa0b7af4c7a1ea97bfce985787c656cac551) | `` plugins/cmp/sources: sort list ``                                          |
| [`8dfa5fa8`](https://github.com/nix-community/nixvim/commit/8dfa5fa8a204f0dc14654c07619bb3df132099e0) | `` flake-modules/dev: cosmetic refactor ``                                    |
| [`99cb3fb8`](https://github.com/nix-community/nixvim/commit/99cb3fb8fc7fc073d695e7c029d9c93e95e2520c) | `` plugins/dotnet: init ``                                                    |
| [`cf7e026c`](https://github.com/nix-community/nixvim/commit/cf7e026c8c86c5548d270e20c04f456939591219) | `` mkNeovimPlugin: refactor lua code generation logic ``                      |
| [`f2a991ae`](https://github.com/nix-community/nixvim/commit/f2a991ae8ca430146f529357dad47d45d3548a3a) | `` plugins/colorizer: rename, switch to mkNeovimPlugin ``                     |
| [`4b5364a6`](https://github.com/nix-community/nixvim/commit/4b5364a66bffd22536e358214b37068b34287a7a) | `` plugins/persisted: init ``                                                 |
| [`e2f81c8e`](https://github.com/nix-community/nixvim/commit/e2f81c8e8e8baa28b100e0e43b721f16de6299d8) | `` plugins/schemastore: remove table wrapping ``                              |
| [`30f3a324`](https://github.com/nix-community/nixvim/commit/30f3a3242efb223d8c67c6cbd06c19b2a4a289ab) | `` plugins/nvim-colorizer: add missing options ``                             |
| [`08be2027`](https://github.com/nix-community/nixvim/commit/08be20270d62e31f215f4592867d53576af15001) | `` flake.lock: Update ``                                                      |
| [`ae78face`](https://github.com/nix-community/nixvim/commit/ae78face8d6a09abe2504d41c035b6460c15a17b) | `` treewide: format with latest nixfmt ``                                     |
| [`c6080c20`](https://github.com/nix-community/nixvim/commit/c6080c206e994b65b69940d456d503f12f8b7b44) | `` plugins/copilot-chat: update mappings ``                                   |
| [`bca825e5`](https://github.com/nix-community/nixvim/commit/bca825e5184a2d9d9c74f0c97a372532b86f0b37) | `` plugins/none-ls: update packages ``                                        |
| [`c6e8f4dd`](https://github.com/nix-community/nixvim/commit/c6e8f4dd5268e0384fe23ba87a4b40612cf19d29) | `` generated: Update ``                                                       |
| [`4502cf3c`](https://github.com/nix-community/nixvim/commit/4502cf3c0b333690734b7f415daa213893f56969) | `` flake.lock: Update ``                                                      |
| [`6348336d`](https://github.com/nix-community/nixvim/commit/6348336db0e0b17ab6d9c73bc8206db84ebf00d1) | `` modules/lazyload: init w/ assertion ``                                     |
| [`38885227`](https://github.com/nix-community/nixvim/commit/38885227461de58a712362c1c484803d6c90a8b2) | `` plugins/avante: add missing description ``                                 |
| [`277dbeb6`](https://github.com/nix-community/nixvim/commit/277dbeb607210f6a6db656ac7eee9eef3143070c) | `` plugins/codecompanion: init ``                                             |
| [`d4ae1e36`](https://github.com/nix-community/nixvim/commit/d4ae1e362fa2deed663952e31c73f4d85fef6070) | `` plugins/trouble: fix originalName ``                                       |
| [`78bfbf7b`](https://github.com/nix-community/nixvim/commit/78bfbf7b7eb7a1b6cf42e199547de55a55ba2cea) | `` flake.lock: Update ``                                                      |
| [`e680b367`](https://github.com/nix-community/nixvim/commit/e680b367c726e2ae37d541328fe81f8daaf49a6c) | `` treewide: format with latest nixfmt ``                                     |
| [`d55ca74c`](https://github.com/nix-community/nixvim/commit/d55ca74c054a98a38d1056f82008151c5a75b477) | `` flake.lock: Update ``                                                      |
| [`3c6dd42f`](https://github.com/nix-community/nixvim/commit/3c6dd42ff8ef739f1a9c231c5669798c56070ac6) | `` plugin/lsp: simplify automatic keymap description ``                       |
| [`d867aaea`](https://github.com/nix-community/nixvim/commit/d867aaea43a7efcfc2cd19a6e0fc89783e15838e) | `` plugin/lsp: automatic keymap description ``                                |
| [`838829c8`](https://github.com/nix-community/nixvim/commit/838829c8f9cb238a915fe3d6ac36df1a3f040d2c) | `` lsp/keymaps: cosmetic implem changes ``                                    |