### PR TITLE
chore(flake/nixpkgs): `970e93b9` -> `5d67ea6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1733940404,
+        "narHash": "sha256-Pj39hSoUA86ZePPF/UXiYHHM7hMIkios8TYG29kQT4g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "5d67ea6b4b63378b9c13be21e2ec9d1afc921713",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`362f987f`](https://github.com/NixOS/nixpkgs/commit/362f987f977ae628b5299f88f6d76a170ba18df6) | `` codesnap: init at 0.8.2 ``                                                                   |
| [`518ae8fd`](https://github.com/NixOS/nixpkgs/commit/518ae8fd583e3e2ba9bc7c5b3643b3d7823a77aa) | `` ci/eval: add rebuildsByPlatform to the comparison result ``                                  |
| [`cef807f7`](https://github.com/NixOS/nixpkgs/commit/cef807f7be0ec1f5ce169709056086f48a1e0443) | `` rustypaste: 0.15.1 -> 0.16.0 ``                                                              |
| [`7251eb72`](https://github.com/NixOS/nixpkgs/commit/7251eb7213d072ea06d61eb01b392976cda71d91) | `` edk2-uefi-shell: fix cross compilation ``                                                    |
| [`e626888a`](https://github.com/NixOS/nixpkgs/commit/e626888ad91be28c530dd717eb1c683212a2979b) | `` python312Packages.cymem: update meta.changelog ``                                            |
| [`d377d2b0`](https://github.com/NixOS/nixpkgs/commit/d377d2b0a509cf67c5005053516b668e19ebd7bb) | `` codecov-cli: init at 9.1.1 ``                                                                |
| [`bd2db488`](https://github.com/NixOS/nixpkgs/commit/bd2db488d29c1973236f3837a1dac879b707cc3a) | `` home-assistant-custom-components.moonraker: 1.4.0 -> 1.5.0 ``                                |
| [`1182f0c3`](https://github.com/NixOS/nixpkgs/commit/1182f0c3e2d9a2fbfc50e189d8aabf19c5126a5a) | `` python3Packages.test-results-parser: init at 0.5.1 ``                                        |
| [`68936e5e`](https://github.com/NixOS/nixpkgs/commit/68936e5e6fdd44d0cf20028dd8c5b2fb8b956d68) | `` quickgui: remove useless zenity ``                                                           |
| [`eb2ed4eb`](https://github.com/NixOS/nixpkgs/commit/eb2ed4eb3540b9a156ac6faff97701488d986ed7) | `` mangayomi: remove useless zenity ``                                                          |
| [`2a6c78be`](https://github.com/NixOS/nixpkgs/commit/2a6c78be41deb29752afee7cc1b508eb61b0595f) | `` fluffychat: remove useless zenity ``                                                         |
| [`f746723f`](https://github.com/NixOS/nixpkgs/commit/f746723f331bcab6dae51ac1b2fa7af582e233b2) | `` flclash: remove useless zenity ``                                                            |
| [`0d460350`](https://github.com/NixOS/nixpkgs/commit/0d460350cafd072e8864e60f5cdd91724290ca23) | `` cwtch-ui: remove useless zenity ``                                                           |
| [`9dc84e11`](https://github.com/NixOS/nixpkgs/commit/9dc84e1150ed9aa60f630b57abe12f0f7b155ff8) | `` dart.file_picker: init ``                                                                    |
| [`045065ef`](https://github.com/NixOS/nixpkgs/commit/045065efb879b73d21458764ee8d738afe40e3e9) | `` kubescape: 3.0.21 -> 3.0.22 ``                                                               |
| [`b67a2d71`](https://github.com/NixOS/nixpkgs/commit/b67a2d717f116b6bebe815534d5c97d153e20141) | `` vscode-extensions.ms-toolsai.jupyter: 2024.10.0 -> 2024.11.0 ``                              |
| [`a264d75d`](https://github.com/NixOS/nixpkgs/commit/a264d75d5c08f068c473c9088998b705f2bd4f6d) | `` whatsie: Add desktop entry and install icons ``                                              |
| [`f5c1b5b4`](https://github.com/NixOS/nixpkgs/commit/f5c1b5b4552e7cdad7285d34129be529a5ab129b) | `` python312Packages.chex: 0.1.87 -> 0.1.88 ``                                                  |
| [`0e6166ea`](https://github.com/NixOS/nixpkgs/commit/0e6166eaf82f8388622bb4dd4d6630c9aa5a0ba8) | `` python312Packages.softlayer: fix on darwin ``                                                |
| [`47755f03`](https://github.com/NixOS/nixpkgs/commit/47755f037380ddc8c7425f78d5de6958ae00b890) | `` python312Packages.libuuu: fix typo in description ``                                         |
| [`9745ad0a`](https://github.com/NixOS/nixpkgs/commit/9745ad0a8216601541bd0613507f7aeb68daebcc) | `` python312Packages.jupysql: 0.10.13 -> 0.10.16 ``                                             |
| [`f02e016c`](https://github.com/NixOS/nixpkgs/commit/f02e016caa44097bf8905f7e448419c0c4442c21) | `` python312Packages.prettytable: add GaetanLepage as maintainer ``                             |
| [`02660f22`](https://github.com/NixOS/nixpkgs/commit/02660f220ba8fb478c0a8f4f8b533dbeb5606adb) | `` python312Packages.prettytable: 3.11.0 -> 3.12.0 ``                                           |
| [`3ebe0ca4`](https://github.com/NixOS/nixpkgs/commit/3ebe0ca44a6881d8dc2e9c91ce0b4999fdcdcb55) | `` git-worktree-switcher: add mateusauler as co-maintainer ``                                   |
| [`ac2c2f4c`](https://github.com/NixOS/nixpkgs/commit/ac2c2f4cf9e7d051f9dac3729a4ccb7f2c672c22) | `` maintainers: add mateusauler ``                                                              |
| [`a4458d73`](https://github.com/NixOS/nixpkgs/commit/a4458d7310b61aa301e1bb84d84814e32bdf2b1b) | `` sbomnix: 1.7.0 -> 1.7.1 ``                                                                   |
| [`62cbaa39`](https://github.com/NixOS/nixpkgs/commit/62cbaa39ed9a8cd3f38be3abd3edd5569fd1956c) | `` bark-server: 2.1.5 -> 2.1.6 ``                                                               |
| [`b745cbe1`](https://github.com/NixOS/nixpkgs/commit/b745cbe1658dc4b99adf339ff9c7d7b87fdeebb4) | `` pantheon.elementary-terminal: 6.2.0 -> 6.3.0 ``                                              |
| [`f75807ce`](https://github.com/NixOS/nixpkgs/commit/f75807ce2a545eeeeb919d7e31fcc3f3b6c8c6ff) | `` ocm: 1.0.2 -> 1.0.3 ``                                                                       |
| [`3de5332b`](https://github.com/NixOS/nixpkgs/commit/3de5332bba9d99b63c5648158678f790bc987b78) | `` nixos/qt: install kio when qt.platformTheme = "kde" (#364032) ``                             |
| [`22501447`](https://github.com/NixOS/nixpkgs/commit/22501447b2e4ed7120ecfd5625a83a948320ca76) | `` glaze: 4.0.1 -> 4.0.2 ``                                                                     |
| [`e2317b10`](https://github.com/NixOS/nixpkgs/commit/e2317b109f26f822bd92dccc251f64100b27e87f) | `` pywal16: 3.7.1 -> 3.7.2 ``                                                                   |
| [`37dc568a`](https://github.com/NixOS/nixpkgs/commit/37dc568acd913fb18235ba71bad8236648effe08) | `` ocamlPackages.tls-eio: init at 1.0.4 ``                                                      |
| [`e9eff470`](https://github.com/NixOS/nixpkgs/commit/e9eff47002ddc00e9f4b0472f7d0972509605e59) | `` nixos/networking: don't add extra names to ::1 ``                                            |
| [`c1d05367`](https://github.com/NixOS/nixpkgs/commit/c1d053679641c2cbf49573dad584f9656126a8f1) | `` libserdes: 7.7.1 -> 7.8.0 ``                                                                 |
| [`0c1feac4`](https://github.com/NixOS/nixpkgs/commit/0c1feac497d4c8c9743cca5f7187515ff680a211) | `` nixos/ebusd: fix device access ``                                                            |
| [`f313eefa`](https://github.com/NixOS/nixpkgs/commit/f313eefa97ba49cf02c4fe4b9e2cdb1330d88568) | `` pywal16: add updateScript ``                                                                 |
| [`9f4747e9`](https://github.com/NixOS/nixpkgs/commit/9f4747e9d0ec8f808c07bab6f3f3fd197b6ae1a5) | `` pywal16: add optional-dependencies ``                                                        |
| [`3a78dd09`](https://github.com/NixOS/nixpkgs/commit/3a78dd097dd7057624dc492ce3f5064c6d988cc5) | `` pywal16: add man page ``                                                                     |
| [`00edd034`](https://github.com/NixOS/nixpkgs/commit/00edd0346e5b9f2df68a8dfdd6af5f15450949c7) | `` pywal16: 3.6.0 -> 3.7.1 ``                                                                   |
| [`cb68aacc`](https://github.com/NixOS/nixpkgs/commit/cb68aacc006d4518ebba989b9dc25fc6c7b4ec15) | `` gitlab: increase node heap size limit ``                                                     |
| [`774f7640`](https://github.com/NixOS/nixpkgs/commit/774f76409680931e98e50ef6833f9360254a5280) | `` squeezelite: 2.0.0.1504 -> 2.0.0.1507 ``                                                     |
| [`c686ea4e`](https://github.com/NixOS/nixpkgs/commit/c686ea4e8149b953c1d2edcc8e52717f7c5d80f7) | `` tarlz: 0.25 -> 0.26 ``                                                                       |
| [`43501768`](https://github.com/NixOS/nixpkgs/commit/435017687908846624796215077cfd4553cfc415) | `` terraform-providers.ibm: 1.71.2 -> 1.72.1 ``                                                 |
| [`8c822968`](https://github.com/NixOS/nixpkgs/commit/8c822968ec11d3ff06855f1000020f767ff7bfbd) | `` python312Packages.momepy: 0.9.0 -> 0.9.1 ``                                                  |
| [`da227232`](https://github.com/NixOS/nixpkgs/commit/da2272328c6eb3abe32c83bf1977d45645741f00) | `` python312Packages.pdm-build-locked: 0.3.3 -> 0.3.4 ``                                        |
| [`223c3987`](https://github.com/NixOS/nixpkgs/commit/223c39872ed28e720b86c97379047b114864cfe7) | `` python312Packages.cymem: 2.0.8 -> 2.0.10 ``                                                  |
| [`037efbc6`](https://github.com/NixOS/nixpkgs/commit/037efbc6feb40ce68dfd62546de25273d01ace73) | `` goread: 1.7.0 -> 1.7.1 ``                                                                    |
| [`0daaba4f`](https://github.com/NixOS/nixpkgs/commit/0daaba4fbd4e9ff41b06ee5ea0f7697bbf213521) | `` malcontent: Add malcontent-ui to passthru.tests ``                                           |
| [`fa5fd554`](https://github.com/NixOS/nixpkgs/commit/fa5fd554c6edc111db6842ffbc64f0e7622eeeed) | `` malcontent: 0.12.0 → 0.13.0 ``                                                               |
| [`a71752a0`](https://github.com/NixOS/nixpkgs/commit/a71752a06d87d52c861e2386f529f5b5d5bcfb26) | `` starpls: 0.1.17 -> 0.1.20 ``                                                                 |
| [`1634b6e4`](https://github.com/NixOS/nixpkgs/commit/1634b6e49bb8ea08b16395c717f3623703bf6416) | `` python312Packages.gotailwind: 0.2.4 -> 0.3.0 ``                                              |
| [`de0880c0`](https://github.com/NixOS/nixpkgs/commit/de0880c00783fd5c4c89b9152225691ec2127332) | `` duplicity: 3.0.3.1 -> 3.0.3.2 ``                                                             |
| [`cb810460`](https://github.com/NixOS/nixpkgs/commit/cb810460f58a8774106dff029ababf9fcb49868a) | `` marwaita-orange: 22 -> 23 ``                                                                 |
| [`6a81d403`](https://github.com/NixOS/nixpkgs/commit/6a81d40331e754ae2dd3b5f56d9e422504bab42e) | `` cpuinfo: 0-unstable-2024-11-14 -> 0-unstable-2024-12-09 ``                                   |
| [`b2bcb86d`](https://github.com/NixOS/nixpkgs/commit/b2bcb86d1b1549ba43692bf9c00af5c78ce96346) | `` nix-eval-jobs: 2.24.1 -> 2.25.0 ``                                                           |
| [`9b6c95e8`](https://github.com/NixOS/nixpkgs/commit/9b6c95e8e858127732c05083ee63ffd13e470cd9) | `` gitlab-ci-local: 4.55.0 -> 4.56.0 ``                                                         |
| [`e8660434`](https://github.com/NixOS/nixpkgs/commit/e866043406b157c14dc7d588fdd5fc5561e3199f) | `` terraform-providers.cloudflare: 4.44.0 -> 4.48.0 ``                                          |
| [`f6b00e9c`](https://github.com/NixOS/nixpkgs/commit/f6b00e9c88c8e66e16de748217309f516ae3f381) | `` television: 0.5.3 -> 0.6.2 (#364120) ``                                                      |
| [`115709ca`](https://github.com/NixOS/nixpkgs/commit/115709cac4beeb927d3a9fcbcfcbd388022fbf4c) | `` resources: 1.7.0 -> 1.7.1 (#363218) ``                                                       |
| [`d87246a4`](https://github.com/NixOS/nixpkgs/commit/d87246a418a9aefd553fc2ae48380aedef90bdfb) | `` conda: fix aarch64-linux (#363620) ``                                                        |
| [`83b30524`](https://github.com/NixOS/nixpkgs/commit/83b3052499b2ca1ed26a2f1cbfc4ab64b0025fbe) | `` config-store: init at 1.0.0 (#363701) ``                                                     |
| [`e4414e86`](https://github.com/NixOS/nixpkgs/commit/e4414e862bec332af863465c06a2ef5dd84953cc) | `` rqlite: 8.34.1 -> 8.34.3 ``                                                                  |
| [`d6af3b31`](https://github.com/NixOS/nixpkgs/commit/d6af3b31b3da139f960cd80fd1ad3631f28c563e) | `` spotdl: 4.2.8 -> 4.2.10 ``                                                                   |
| [`1c79dc06`](https://github.com/NixOS/nixpkgs/commit/1c79dc069afabcfcd21c45832ba2a2f487fe443e) | `` python312Packages.reptor: 0.24 -> 0.25 ``                                                    |
| [`fae5d602`](https://github.com/NixOS/nixpkgs/commit/fae5d6025cf7ba674a1f48269610064a83464dc9) | `` programs/yubikey-touch-detector: add PartOf=graphical-session.target ``                      |
| [`2190b244`](https://github.com/NixOS/nixpkgs/commit/2190b2449dfc9eb5c42e91d6258c70dd506bcc7b) | `` go-task: 3.40.0 -> 3.40.1 ``                                                                 |
| [`12c98df8`](https://github.com/NixOS/nixpkgs/commit/12c98df8affee9553baf410572af64862586be52) | `` ast-grep: 0.30.0 -> 0.31.1 ``                                                                |
| [`fd21ef2a`](https://github.com/NixOS/nixpkgs/commit/fd21ef2a65f341bbcfb0b26b4daf0ccb3ea59330) | `` nixos/immich: restrict filesystem permissions ``                                             |
| [`b5e27101`](https://github.com/NixOS/nixpkgs/commit/b5e271018c3325877867baa0ec55a52e4ff81e47) | `` google-java-format: 1.25.0 -> 1.25.1 ``                                                      |
| [`1035bd86`](https://github.com/NixOS/nixpkgs/commit/1035bd8668deec43643f191cc1eb445e37d287ce) | `` python312Packages.fints: 4.2.0 -> 4.2.3 ``                                                   |
| [`7a1979d0`](https://github.com/NixOS/nixpkgs/commit/7a1979d03acc73bfa61bd21f2d01a699cc98a852) | `` nomino: 1.3.6 -> 1.3.7 ``                                                                    |
| [`070b61b8`](https://github.com/NixOS/nixpkgs/commit/070b61b84396eab43af107c8fb92b9f2b3919533) | `` yubikey-touch-detector: 1.12.0 -> 1.12.2 ``                                                  |
| [`24420c30`](https://github.com/NixOS/nixpkgs/commit/24420c3050c53725fde1ab56a50dc3c79d66012b) | `` hypnotix: 4.7 -> 4.8 ``                                                                      |
| [`cb52981a`](https://github.com/NixOS/nixpkgs/commit/cb52981ac0751f014530b55c1a5b95dbff8a7e15) | `` limine: 8.4.0 -> 8.6.0 ``                                                                    |
| [`de031286`](https://github.com/NixOS/nixpkgs/commit/de031286612961febfb0ef0fd76a4608eff64b0c) | `` ocamlPackages.utop: 2.14.0 → 2.15.0 ``                                                       |
| [`99926bf0`](https://github.com/NixOS/nixpkgs/commit/99926bf0606a7bbfb90c3ef8d9a41a1e6914960d) | `` vimPlugins.blink-cmp: 0.7.3 -> 0.7.6 ``                                                      |
| [`4e5a66d5`](https://github.com/NixOS/nixpkgs/commit/4e5a66d5210cb5ff292975778bb3bf59289758f6) | `` xen: 4.16 is EOL ``                                                                          |
| [`e812c28e`](https://github.com/NixOS/nixpkgs/commit/e812c28e811b53479f60ec4f4a4a0450dfb5a5ac) | `` networkmanager-vpnc: 1.2.8 → 1.4.0 ``                                                        |
| [`b33f750e`](https://github.com/NixOS/nixpkgs/commit/b33f750edba5d2970e1d9fa3a33da579e2e150b4) | `` twinkle: unstable-2023-03-25 -> unstable-2024-20-11 ``                                       |
| [`579d0cfe`](https://github.com/NixOS/nixpkgs/commit/579d0cfe8b483ff4375fa4bad511d8dbe9e5fceb) | `` lint-staged: 15.2.10 -> 15.2.11 ``                                                           |
| [`12e42194`](https://github.com/NixOS/nixpkgs/commit/12e421949ea7333d3ab484d4fb192c3732e5b2d8) | `` httm: 0.43.2 -> 0.44.0 ``                                                                    |
| [`622f8658`](https://github.com/NixOS/nixpkgs/commit/622f8658b4b527a0e11e40ff285a4ff4129106cf) | `` flutter_rust_bridge_codegen: 2.6.0 -> 2.7.0 ``                                               |
| [`187adc15`](https://github.com/NixOS/nixpkgs/commit/187adc1516900ee3199e5acd9027c99f2d4b4b22) | `` nats-server: 2.10.22 -> 2.10.23 ``                                                           |
| [`0fc40be1`](https://github.com/NixOS/nixpkgs/commit/0fc40be15941fe3ac1d01e379b61907d8770fede) | `` tenere: init at 0.11.2 (#363556) ``                                                          |
| [`45344f2d`](https://github.com/NixOS/nixpkgs/commit/45344f2de4dde33632736b62e24ae9613460a5fa) | `` houdini: fix fhsenv version (#363168) ``                                                     |
| [`d9b23fc6`](https://github.com/NixOS/nixpkgs/commit/d9b23fc6772117dfb477ec64e2684c2fbbde8a01) | `` chamber: 3.1.0 -> 3.1.1 ``                                                                   |
| [`e5a456f2`](https://github.com/NixOS/nixpkgs/commit/e5a456f26f4694449bcffae3012d1377b3f09506) | `` nixos/wireguard-networkd: re-enable by default for networkd users ``                         |
| [`6bc8dcc6`](https://github.com/NixOS/nixpkgs/commit/6bc8dcc6308d33a0034b3d5afdfa9c9b23a1de80) | `` nixos/wireguard-networkd: use systemd credentials for privateKeyFile and presharedKeyFile `` |
| [`6073d7e8`](https://github.com/NixOS/nixpkgs/commit/6073d7e89b86222de86e0278327a3bcda3d91e49) | `` chromium: 131.0.6778.108 -> 131.0.6778.139 ``                                                |
| [`ac5082f8`](https://github.com/NixOS/nixpkgs/commit/ac5082f8e44e234a0e32af00542c2705d0c244dc) | `` syshud: 0-unstable-2024-11-12 -> 0-unstable-2024-11-25 ``                                    |
| [`e8df6593`](https://github.com/NixOS/nixpkgs/commit/e8df65937267c2bc06bc7c562410fae84f4d7329) | `` dotnet: force evaluation of sdk nuget packages ``                                            |
| [`97a25d0b`](https://github.com/NixOS/nixpkgs/commit/97a25d0b58eb9cabe3970eb40ba3b865d94cf8eb) | `` slskd: 0.21.4 -> 0.22.0 (#364051) ``                                                         |
| [`7413ed03`](https://github.com/NixOS/nixpkgs/commit/7413ed0368adf68a41bdf4b882505a82231fcbd1) | `` inkscape-extensions.inkstitch: init at 3.1.0 (#358993) ``                                    |
| [`027b2935`](https://github.com/NixOS/nixpkgs/commit/027b2935ca165874939c289dbc73c3857b745128) | `` clapgrep: init at 1.3.1 (#360741) ``                                                         |
| [`43a8c56b`](https://github.com/NixOS/nixpkgs/commit/43a8c56bd21d391dd04426182042779b71895a12) | `` mold: 2.34.1 -> 2.35.0 (#363845) ``                                                          |
| [`fee3e54a`](https://github.com/NixOS/nixpkgs/commit/fee3e54a0c217516f9123bbea15520f27bb10457) | `` python312Packages.json-repair: 0.30.2 -> 0.30.3 ``                                           |
| [`368ac90b`](https://github.com/NixOS/nixpkgs/commit/368ac90b38e442bcfa49eb7bdc98a7183b182dc2) | `` svg2tikz: mark as broken ``                                                                  |
| [`5a072ae0`](https://github.com/NixOS/nixpkgs/commit/5a072ae0ed1f073226cec73ce2bd61e3ddb838f3) | `` inkscape: 1.3.2 -> 1.4 ``                                                                    |
| [`b31ee5c7`](https://github.com/NixOS/nixpkgs/commit/b31ee5c7e268c71b559df70f5ea3455c0c4deaef) | `` lib2geom: 1.3 → 1.4 ``                                                                       |
| [`d4b61ee6`](https://github.com/NixOS/nixpkgs/commit/d4b61ee6e351ef4ae2eaa5584f12c9890bd0f885) | `` inkscape: add Luflosi as maintainer ``                                                       |
| [`989f8774`](https://github.com/NixOS/nixpkgs/commit/989f87745ba2ba6225ca200a1820756cd4b96656) | `` inkscape: add x123 as maintainer ``                                                          |
| [`2928dcaf`](https://github.com/NixOS/nixpkgs/commit/2928dcaf2918fea68fd5b1fd4fae5b06738cedf5) | `` inkscape: refactor meta ``                                                                   |