### PR TITLE
chore(flake/nixvim): `58d2a5ac` -> `bc87d912`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733665616,
-        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734093295,
-        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
+        "lastModified": 1735381016,
+        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
+        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733570843,
-        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
+        "lastModified": 1735478292,
+        "narHash": "sha256-Ys9pSP9ch0SthhpbjnkCSJ9ZLfaNKnt/dcy7swjmS1A=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
+        "rev": "71a3a075e3229a7518d76636bb762aef2bcb73ac",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734223742,
-        "narHash": "sha256-vp3wSbCVU/4y5W+YI6H9PSix3WD7XbcIyesmB7W0ZWo=",
+        "lastModified": 1735656123,
+        "narHash": "sha256-AnTW4OA8vW6CGqNJQZ/jV+i9ei7h7g+htGGdshWmQSo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "58d2a5ac9cc4ff987e6edb77f2b55d1dec05ce50",
+        "rev": "bc87d91273928c97a47eab0df9b303bb45adc6f4",
         "type": "github"
       },
       "original": {
@@ -446,11 +446,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733761991,
-        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "lastModified": 1735135567,
+        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
| [`bc87d912`](https://github.com/nix-community/nixvim/commit/bc87d91273928c97a47eab0df9b303bb45adc6f4) | `` tests/{efmls-configs,none-ls}: disable clazy test (broken package) ``                                                 |
| [`29fbcbc2`](https://github.com/nix-community/nixvim/commit/29fbcbc21bc54ed250cdb288bf63df811a013908) | `` tests/openscad: disable on darwin (broken package) ``                                                                 |
| [`80b5d141`](https://github.com/nix-community/nixvim/commit/80b5d141df3dcec6da5625e9a8c3cae47bdc1870) | `` tests/efmls-configs: disable cppcheck test on darwin (broken package) ``                                              |
| [`9159f9e9`](https://github.com/nix-community/nixvim/commit/9159f9e97e5e6f192c188757974b1be81d6fc332) | `` tests/{efmls-configs,none-ls}: disable ansible_lint test (broken package) ``                                          |
| [`3fd7c3bf`](https://github.com/nix-community/nixvim/commit/3fd7c3bf598129b94353fe7906f6aa78cb88b85c) | `` plugins/blink-cmp: rework options ``                                                                                  |
| [`c2e88653`](https://github.com/nix-community/nixvim/commit/c2e88653576b9bfd8634db4882a97b4c29a6d706) | `` tests/lsp-servers: disable solc (broken package) ``                                                                   |
| [`7347e450`](https://github.com/nix-community/nixvim/commit/7347e4508e5bedc2220a2625aba150e6e9e06a3a) | `` tests/lsp-servers: disable ruby_lsp (broken package) ``                                                               |
| [`1753c4a5`](https://github.com/nix-community/nixvim/commit/1753c4a5d280acce62754e14cb5e4173bbc35659) | `` plugins/lsp: mark autohotkey_lsp as unpackaged ``                                                                     |
| [`33373d8f`](https://github.com/nix-community/nixvim/commit/33373d8f3c94266b1113a5ab406591191e3ba839) | `` generated: Update ``                                                                                                  |
| [`6d6bc31d`](https://github.com/nix-community/nixvim/commit/6d6bc31d0c5b4a26c541e32159893e7f5a0369c8) | `` flake.lock: Update ``                                                                                                 |
| [`caef3913`](https://github.com/nix-community/nixvim/commit/caef39133f187a9ba138c5779a6c33307caaf149) | `` lib/options: mkAttrsOf, mkListOf, mkAttributeSet should accept raw values ``                                          |
| [`c04dda02`](https://github.com/nix-community/nixvim/commit/c04dda021b18a192c421ee79b877b341db5b2d69) | `` lib/options/mkRaw: automatically convert example strings to rawLua type ``                                            |
| [`f4b0b81e`](https://github.com/nix-community/nixvim/commit/f4b0b81ef9eb4e37e75f32caf1f02d5501594811) | `` plugins/flutter-tools: use new path for mkNeovimPlugin ``                                                             |
| [`0307cdf2`](https://github.com/nix-community/nixvim/commit/0307cdf297cd6bdafd55a66d69c54b55c482edf8) | `` plugins/blink-cmp: force version for blink.cmp >= 0.8.2 ``                                                            |
| [`9a08553d`](https://github.com/nix-community/nixvim/commit/9a08553d153a49fc2b6ee476bb860f318f939fa7) | `` plugins/flutter-tools: init ``                                                                                        |
| [`7500425d`](https://github.com/nix-community/nixvim/commit/7500425d31566e96ad2602ebbc9f16599f068290) | `` lib/options/mkRaw': handle pluginDefault=null ``                                                                      |
| [`1702f240`](https://github.com/nix-community/nixvim/commit/1702f2407417b1646f5fb4635476d16df9221c8b) | `` plugins/molten: add wezterm as image provider ``                                                                      |
| [`abe2211a`](https://github.com/nix-community/nixvim/commit/abe2211aef2777c318464f4c76e6aa9a15c4f35e) | `` plugins/wezterm: init ``                                                                                              |
| [`3fa487c8`](https://github.com/nix-community/nixvim/commit/3fa487c81d9f1a9bb2887597cc05331d69aa5247) | `` plugins/lint: migrate to mkNeovimPlugin ``                                                                            |
| [`5b35c4ea`](https://github.com/nix-community/nixvim/commit/5b35c4eaed560576cd756121ef032bcccda1ca5e) | `` plugins/glance: init ``                                                                                               |
| [`fc9176c7`](https://github.com/nix-community/nixvim/commit/fc9176c75b2df5b6b73a5cf449998499b28c7c91) | `` modules/test: hide the deprecated `check*` options ``                                                                 |
| [`60e88b87`](https://github.com/nix-community/nixvim/commit/60e88b870c8477bcb043792025eca4c9bb4974e3) | `` docs: treat internal options as invisible ``                                                                          |
| [`e5974b31`](https://github.com/nix-community/nixvim/commit/e5974b316d83540eb79d716ac2ee8c8e35fd61b2) | `` modules/test: document possible types for expectation `value` ``                                                      |
| [`e679ee91`](https://github.com/nix-community/nixvim/commit/e679ee91fad3525ce8cfb1b1a34023ac88afc274) | `` tests: omit `default` suffix in test names ``                                                                         |
| [`ae612f82`](https://github.com/nix-community/nixvim/commit/ae612f824918c336de906fd99048366a83591bdb) | `` tests: use warning-expectations options ``                                                                            |
| [`24e3b11b`](https://github.com/nix-community/nixvim/commit/24e3b11b231e972e564546f24d49f35534728104) | `` modules/test: allow specifying expectation value type ``                                                              |
| [`c2e172b0`](https://github.com/nix-community/nixvim/commit/c2e172b0d35c888177515591579e0d80ff5fb7f2) | `` modules/test: allow arbitrary warning/assertion expecations ``                                                        |
| [`e7dcc9b5`](https://github.com/nix-community/nixvim/commit/e7dcc9b51882fd9f74ac52985739ec76709e8d22) | `` modules/test: allow not building nixvim config ``                                                                     |
| [`1671f861`](https://github.com/nix-community/nixvim/commit/1671f8618fa347d8a0cd62506df386d58d7608f3) | `` lib/mk-neovim-plugin: allow lazy-loading without `luaConfig` ``                                                       |
| [`f8782897`](https://github.com/nix-community/nixvim/commit/f8782897227d5dbc054e481f7756db6b3bf544f2) | `` lib/plugins: make plugin optional when lazy-loading ``                                                                |
| [`87b2679d`](https://github.com/nix-community/nixvim/commit/87b2679d6fb61bac08b2a17501e14da7be534fcb) | `` user-configs: add @r6t config ``                                                                                      |
| [`25c13524`](https://github.com/nix-community/nixvim/commit/25c13524642cb7fe98583a5dd5f90992c76198b9) | `` docs/contributing: fix hyperlink issues ``                                                                            |
| [`ca3c7e29`](https://github.com/nix-community/nixvim/commit/ca3c7e29a857084c4b311aa714b88ab789760fe0) | `` plugins/blink-cmp-copilot: init ``                                                                                    |
| [`8938e09d`](https://github.com/nix-community/nixvim/commit/8938e09db14d510dcc2f266e8b2e738ee527d386) | `` modules/output: add `manDocsPackage` ``                                                                               |
| [`94874035`](https://github.com/nix-community/nixvim/commit/948740353295d181cd846331dea4f81695f98684) | `` modules/context: `flake` option, provides access to our flake ``                                                      |
| [`7391dc14`](https://github.com/nix-community/nixvim/commit/7391dc14ca4642ab43029ac15dc23b5fab721f31) | `` plugins/blink-compat: init ``                                                                                         |
| [`6f45ca4a`](https://github.com/nix-community/nixvim/commit/6f45ca4a22c2f18d72bb582d35421eb6994d5263) | `` lib/modules: `flake` is now required ``                                                                               |
| [`403d5e23`](https://github.com/nix-community/nixvim/commit/403d5e23c5fffe53395425234288f29bb5704bca) | `` lib/modules: remove assertion message for removed `check` arg ``                                                      |
| [`f1b5c2c5`](https://github.com/nix-community/nixvim/commit/f1b5c2c59345a125ea71b1fcd0e4e74a115ba786) | `` lib/tests: remove deprecated dontRun ``                                                                               |
| [`472526d7`](https://github.com/nix-community/nixvim/commit/472526d7aa7f9ff16ae9d443f2fe62596ac0f2eb) | `` wrappers: extract nixvim-lib from extended lib ``                                                                     |
| [`aefab28b`](https://github.com/nix-community/nixvim/commit/aefab28b3b3cd87cc3aa8f27a3984faf7902fb30) | `` lib/overlay: init ``                                                                                                  |
| [`450cccf4`](https://github.com/nix-community/nixvim/commit/450cccf472f40ae8e3b92eec9e5f4b071693ac85) | `` flake.lock: Update ``                                                                                                 |
| [`214731d3`](https://github.com/nix-community/nixvim/commit/214731d35564896397ca4fb7590fb544331a3294) | `` lib/plugins: deprecate `neovim-plugin` & `vim-plugin` aliases ``                                                      |
| [`43a3171d`](https://github.com/nix-community/nixvim/commit/43a3171dec22d079252f4397605f318adf6c6fd5) | `` treewide: `vim-plugin` -> `plugins` ``                                                                                |
| [`5e9a6c00`](https://github.com/nix-community/nixvim/commit/5e9a6c00a95ed842467270246ccc2c0f0863e53c) | `` treewide: `neovim-plugin` -> `plugins` ``                                                                             |
| [`787844cf`](https://github.com/nix-community/nixvim/commit/787844cfe496577db468adbfcaa5dd2f7dd2032d) | `` lib/plugins: call sub-components with relevant args ``                                                                |
| [`690fc895`](https://github.com/nix-community/nixvim/commit/690fc895b57965a261f00ac5542d91dac4f5fb3d) | `` lib/plugins: extract common logic for `package` options ``                                                            |
| [`896f6be6`](https://github.com/nix-community/nixvim/commit/896f6be694cabe6f8d7256f6430c964a3f2af881) | `` lib/plugins: take ownership of `modules` utils ``                                                                     |
| [`ec97297f`](https://github.com/nix-community/nixvim/commit/ec97297fd5c828aed869ceba85a577bab7fb343d) | `` lib/plugins: separate main factory functions ``                                                                       |
| [`88a1c1b4`](https://github.com/nix-community/nixvim/commit/88a1c1b46a38c18427e8a5cc6d2b10b66317e14e) | `` lib/plugins: organise plugin-factory functions in a subdir ``                                                         |
| [`6a4b4221`](https://github.com/nix-community/nixvim/commit/6a4b4221c4ebf1140f73f8df769e97f1828d90fa) | `` dev/new-plugin: originalName -> packPathName ``                                                                       |
| [`d39a09d0`](https://github.com/nix-community/nixvim/commit/d39a09d05dd4649ea8bf8520296aeef0740276df) | `` flake: warn when `lib.<system>.helpers` is used ``                                                                    |
| [`4b3b67fb`](https://github.com/nix-community/nixvim/commit/4b3b67fb6f618726aecea1f07b35c57e4963ea8c) | `` lib: make overrideable & access via flake ``                                                                          |
| [`e2ef15a6`](https://github.com/nix-community/nixvim/commit/e2ef15a665cbd05b33bdeb6f7b8b3c5fe0c9bde1) | `` lib: add `extend` function ``                                                                                         |
| [`937c9b4a`](https://github.com/nix-community/nixvim/commit/937c9b4acf653ce8b25ccc640dff99dcec7cf273) | `` flake.lock: Update ``                                                                                                 |
| [`9f32e25f`](https://github.com/nix-community/nixvim/commit/9f32e25f3f2b029b76e79ef7c1f48cd3596938d8) | `` plugins/treesitter: update docs for custom grammar installation ``                                                    |
| [`354fc0f2`](https://github.com/nix-community/nixvim/commit/354fc0f288e045594e2e30da7ff95189d3545a9a) | `` plugins/todo-comments: add TodoFzfLua ``                                                                              |
| [`6830c55d`](https://github.com/nix-community/nixvim/commit/6830c55d0945036ad9e15f068836dab346862ca3) | `` fix(docs): typo in install.md ``                                                                                      |
| [`f3ef2721`](https://github.com/nix-community/nixvim/commit/f3ef2721abf6e7f4f9ab8346cb1efebb0ecb9769) | `` modules/keymap: quickfix, use "keep" rather than "error" ``                                                           |
| [`37608b46`](https://github.com/nix-community/nixvim/commit/37608b462772e35220e02bfbd9045d0946564436) | `` Revert "plugins/cmp/sources: use mkNeovimPlugin instead of mkVimPlugin for source plugins" ``                         |
| [`2b7f17b6`](https://github.com/nix-community/nixvim/commit/2b7f17b6de578b63b7dc0e4155e36538042bc968) | `` plugins/crates: rename from crates-nvim to crates, move to by-name, migrate to mkNeovimPlugin ``                      |
| [`5d6e83d8`](https://github.com/nix-community/nixvim/commit/5d6e83d8ab5f5df325a2f1a6a870d8c592ad62b0) | `` plugins/copilot-cmp: move to by-name, migrate to mkNeovimPlugin ``                                                    |
| [`7aed1c4b`](https://github.com/nix-community/nixvim/commit/7aed1c4b577b227fc4c892d15a77fb015a7f693e) | `` plugins/cmp-tabnine: move to by-name ``                                                                               |
| [`79a637d1`](https://github.com/nix-community/nixvim/commit/79a637d1962e725218ff46f5234cb3d5617ed36b) | `` modules/keymap: include buffer when registering `keymapsOnEvents` ``                                                  |
| [`520c2868`](https://github.com/nix-community/nixvim/commit/520c2868eb8047942abd58902bb3b6110c6529e2) | `` plugins/cmp-git: move to by-name ``                                                                                   |
| [`a61193ab`](https://github.com/nix-community/nixvim/commit/a61193abcc00f54a1313c6a218123afc5871ce65) | `` plugins/cmp-ai: move to by-name ``                                                                                    |
| [`f1addaad`](https://github.com/nix-community/nixvim/commit/f1addaaddff58d8619d326d313b0468e801c327d) | `` lib/{neovim,vim}-plugin: remove redundant parens ``                                                                   |
| [`6019ce78`](https://github.com/nix-community/nixvim/commit/6019ce784c1a0558a817402e080c0941274928d7) | `` lib/{neovim,vim}-plugin: use `loc` throughout ``                                                                      |
| [`eaa20846`](https://github.com/nix-community/nixvim/commit/eaa20846279654fa038427ce078d4cd9609e5f2f) | `` plugins/cmp-fish: move extra option to the sources list ``                                                            |
| [`5abe382c`](https://github.com/nix-community/nixvim/commit/5abe382c54eff3cd3977733e9d268ab8994f397b) | `` plugins/cmp-tabby: move to by-name ``                                                                                 |
| [`6e52e32d`](https://github.com/nix-community/nixvim/commit/6e52e32d4026076c7ef6d1a72eaa9ac1d82c72ac) | `` dev/list-plugins: trivial refactor ``                                                                                 |
| [`6a9d8403`](https://github.com/nix-community/nixvim/commit/6a9d840370647abb0c980ff1bb8e47edd1255789) | `` plugins/cmp/sources: use mkNeovimPlugin instead of mkVimPlugin for source plugins ``                                  |
| [`11e8a5db`](https://github.com/nix-community/nixvim/commit/11e8a5dbc6ce83444d9de8d247271cc70d812b32) | `` flake.lock: Update ``                                                                                                 |
| [`4f1fe403`](https://github.com/nix-community/nixvim/commit/4f1fe403b18c45614d6b81423038a34cff371244) | `` plugins/openscad: migrate to mkVimPlugin ``                                                                           |
| [`17905dec`](https://github.com/nix-community/nixvim/commit/17905dec3d08062dc8358b86a95058be4c71cc35) | `` modules: let extraPlugins accept null values ``                                                                       |
| [`167167e4`](https://github.com/nix-community/nixvim/commit/167167e4b371a07e4388fb4a2dc71fdcd72731ad) | `` lib/vim-plugin: expose new helpers `settingsOptionDescription` and `processPrefixedGlobals` and `mkSettingsOption` `` |
| [`1d50fa4f`](https://github.com/nix-community/nixvim/commit/1d50fa4f63e27c30d44fa2ceab6ec4ce7d7d6df8) | `` lib: add applyPrefixToAttrs ``                                                                                        |
| [`e24e40e5`](https://github.com/nix-community/nixvim/commit/e24e40e5f1ad9773fa9f7ca9e12de7db494d7468) | `` plugins/obsidian: add missing word in description ``                                                                  |
| [`092e5ed5`](https://github.com/nix-community/nixvim/commit/092e5ed56ae0fdffdc0cfaea9dbebb8f5fa9d1e1) | `` plugins/luasnip: migrate to mkNeovimPlugin ``                                                                         |
| [`aaf0fb16`](https://github.com/nix-community/nixvim/commit/aaf0fb166331dd5f469bd7e63bd993bbb6f4d524) | `` dev/list-plugins: conditionally create devshell only if devshell input is present ``                                  |
| [`f4b7fd46`](https://github.com/nix-community/nixvim/commit/f4b7fd46f6caf984fdfc41281792eac7b7ab8f24) | `` plugins/palette: fix minor typo; (#2696) ``                                                                           |
| [`c803fd73`](https://github.com/nix-community/nixvim/commit/c803fd738f52b177e7d6961acb62a9d1d7c21e7f) | `` dev/list-plugins: derivation cosmetic refactor ``                                                                     |
| [`3461f890`](https://github.com/nix-community/nixvim/commit/3461f890fa34a5048e71b1c9fb1d4aded4acf2c7) | `` plugins/vim-matchup: migrate to mkVimPlugin ``                                                                        |
| [`30895485`](https://github.com/nix-community/nixvim/commit/30895485c3a31bb16ace513def4f3a36bfeb68c6) | `` user-configs: add HeitorAugustoLN's configuration ``                                                                  |
| [`bfb08c1a`](https://github.com/nix-community/nixvim/commit/bfb08c1ab71252ff4e7c86fa4a8565a909f81aa5) | `` plugins/nix-develop: migrate to mkNeovimPlugin ``                                                                     |
| [`6c30476a`](https://github.com/nix-community/nixvim/commit/6c30476a4d5f761149945a65e74179f4492b1ea6) | `` plugins/plantuml-syntax: migrate to mkVimPlugin ``                                                                    |
| [`471f68d9`](https://github.com/nix-community/nixvim/commit/471f68d9bb9e00e7cbc352c452e7e314dced17bb) | `` plugins/vim-bbye: migrate to mkVimPlugin ``                                                                           |
| [`a24ec741`](https://github.com/nix-community/nixvim/commit/a24ec7412ed0b120e49f8f8dd421d5ff1e3171cc) | `` plugins/intellitab: migrate to mkVimPlugin ``                                                                         |
| [`9062a66e`](https://github.com/nix-community/nixvim/commit/9062a66ee9a7c65f65c64920a91963268e66fd93) | `` plugins/gitmessenger: migrate to mkVimPlugin ``                                                                       |
| [`ad87ec83`](https://github.com/nix-community/nixvim/commit/ad87ec831b5d8df6fa5a8846a7b126e378570f6a) | `` dev/list-plugins: add flake check ``                                                                                  |
| [`12db5eaf`](https://github.com/nix-community/nixvim/commit/12db5eaf8ab1abd49307586a6aee488f67fb048c) | `` dev/list-plugins: add --root-path argument ``                                                                         |
| [`bc3b99c4`](https://github.com/nix-community/nixvim/commit/bc3b99c4d90b08726dd919d94eb03563c949d08a) | `` dev/list-plugins: make it a proper package ``                                                                         |
| [`0fb43cbf`](https://github.com/nix-community/nixvim/commit/0fb43cbfb62a46cdfcea7487c397d9f232ac469e) | `` dev/list-plugins: properly error out when parsing is unsuccessfull ``                                                 |
| [`0edc061a`](https://github.com/nix-community/nixvim/commit/0edc061a6c9fcf0d46f30568da31ae325c1f51b6) | `` plugins/gitgutter: migrate to mkVimPlugin ``                                                                          |
| [`76e9d89d`](https://github.com/nix-community/nixvim/commit/76e9d89d96502a4ee8e1cd74a5b50077cf204134) | `` plugins/floaterm: move to mkVimPlugin ``                                                                              |
| [`c179d47d`](https://github.com/nix-community/nixvim/commit/c179d47d3d03075cd48d19d20b983d0445a5c8a1) | `` plugins/*: use new mkSettingsRenamedOptionModules ``                                                                  |
| [`0ddf6e39`](https://github.com/nix-community/nixvim/commit/0ddf6e39ac0dddc02fb0bc45337b4dbb5139b49d) | `` lib/mkSettingsRenamedOptionModules: allow attrs value with 'old' and 'new' keys ``                                    |
| [`7e4f8a2a`](https://github.com/nix-community/nixvim/commit/7e4f8a2a560120d5a21c218d0e80ea18d9397a5e) | `` plugins/friendly-snippets: switch to mkVimPlugin ``                                                                   |
| [`93208b95`](https://github.com/nix-community/nixvim/commit/93208b95362d8b0a8807efc49260d36de13a0c65) | `` plugins/quickmath: migrate to mkVimPlugin ``                                                                          |
| [`ec24d496`](https://github.com/nix-community/nixvim/commit/ec24d496d52c2620b5ce3d237a2a1029a197b412) | `` treewide (cleaning): helpers.toLuaObject -> lib.nixvim.toLuaObject ``                                                 |
| [`78e295fa`](https://github.com/nix-community/nixvim/commit/78e295fa419801efb56a384e37987c25a618f21f) | `` treewide (cleaning): helpers.vim-plugin -> lib.nixvim.vim-plugin ``                                                   |
| [`e54833d2`](https://github.com/nix-community/nixvim/commit/e54833d2f7378d9759d70a213b647e4515f15145) | `` treewide (cleaning): helpers.neovim-plugin -> lib.nixvim.neovim-plugin ``                                             |
| [`1e690618`](https://github.com/nix-community/nixvim/commit/1e690618d92234e59a34f41c3a78004b57cab5ab) | `` tests: use our extended lib in tests ``                                                                               |
| [`ea26af3e`](https://github.com/nix-community/nixvim/commit/ea26af3ee98f6f6c0c4c61534d2174ceb6ade767) | `` dev/list-plugins: cleanup migrated plugins ``                                                                         |
| [`85b99028`](https://github.com/nix-community/nixvim/commit/85b990286d391cce9a41d72cf4303637a7b43a10) | `` flake-modules/new-plugin: find project root ``                                                                        |
| [`35b6d9bc`](https://github.com/nix-community/nixvim/commit/35b6d9bc9d576725dd374f81cff46539307b84ff) | `` flake-modules/new-plugin: init ``                                                                                     |
| [`a9578bca`](https://github.com/nix-community/nixvim/commit/a9578bcae59224a63e02effb7c27f28602fa5128) | `` plugins/lsp: Add some LSP servers ``                                                                                  |
| [`dc7bca6d`](https://github.com/nix-community/nixvim/commit/dc7bca6d8c5ca0a56cec0c42a74819b8caca3b25) | `` update-scripts: Add a script to search for nvim-lspconfig server packages ``                                          |
| [`bef9feb4`](https://github.com/nix-community/nixvim/commit/bef9feb446a9203a1343a5026970396bcae60f6f) | `` lib/modules: pass `inputs.nixpkgs` into `evalNixvim` ``                                                               |
| [`e16d2448`](https://github.com/nix-community/nixvim/commit/e16d2448650f6ae3841198996bb795b0f4e28b79) | `` plugins/tiny-devicons-auto-colors: init ``                                                                            |
| [`d0040391`](https://github.com/nix-community/nixvim/commit/d0040391e82343ba2d4e3ca5b9485bd8e49a1896) | `` plugins/mini: configLocation mkBefore ``                                                                              |
| [`cef7414b`](https://github.com/nix-community/nixvim/commit/cef7414b034f2ac9278e5e8eeb400f8794588558) | `` plugins/web-devicons: configLocation mkBefore ``                                                                      |
| [`32027965`](https://github.com/nix-community/nixvim/commit/32027965d8ca7da03ac6215be588cc4884f4b129) | `` lib: remove dependency on `pkgs` ``                                                                                   |
| [`9e6b2074`](https://github.com/nix-community/nixvim/commit/9e6b20740192f447116951924b64649ef13d690c) | `` flake.lock: Update ``                                                                                                 |
| [`cb61e12b`](https://github.com/nix-community/nixvim/commit/cb61e12bbac08fc7fd2c672974ccf2d12cdcf236) | `` plugins/easyescape: switch to mkVimPlugin and add options ``                                                          |
| [`a658e81d`](https://github.com/nix-community/nixvim/commit/a658e81d7124987742228575234048d438548584) | `` docs/config-examples: generate dynamically from a toml list ``                                                        |
| [`8eeea073`](https://github.com/nix-community/nixvim/commit/8eeea073fcc4feec2cb62f293f53c884bcc626f0) | `` tests: call using `callPackages` ``                                                                                   |
| [`452c30f7`](https://github.com/nix-community/nixvim/commit/452c30f747b52d798d31deaa07f14b9833a8527f) | `` plugins/commentary: switch to mkVimPlugin ``                                                                          |
| [`64681ae8`](https://github.com/nix-community/nixvim/commit/64681ae84cb6f67ab62003f52c5f1e6e9fe2068a) | `` dev/list-plugins: add markdown formatting ``                                                                          |
| [`3726dbed`](https://github.com/nix-community/nixvim/commit/3726dbed68e769acdef11e1eed3ceb1b5611bd01) | `` dev/list-plugins: deprecate Kind.UNKNOWN completely ``                                                                |
| [`a7afed6b`](https://github.com/nix-community/nixvim/commit/a7afed6b45e5c5eb7d9bdc36b754bd11340587bf) | `` dev/list-plugins: update EXCLUDES and KNOWN_PATHS variables ``                                                        |
| [`bcebe05a`](https://github.com/nix-community/nixvim/commit/bcebe05a5141dcaa3dec892c31a4e7c720af0f92) | `` dev/list-plugins: add symbol for 'MISC' type plugins ``                                                               |
| [`ece37219`](https://github.com/nix-community/nixvim/commit/ece372190a51ff13e0a3af2b5797ee41ab831aab) | `` plugins/conjure: switch to mkVimPlugin ``                                                                             |