### PR TITLE
chore(flake/flake-parts): `205b12d8` -> `b905f6fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -293,14 +293,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
     "nixpkgs-stable": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                     |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`21ac911b`](https://github.com/hercules-ci/flake-parts/commit/21ac911b1d0a92b60d4a2b957ed78670872e436f) | `` Add custom merge error for unknown flake output attrs `` |
| [`6fa1340a`](https://github.com/hercules-ci/flake-parts/commit/6fa1340a633ad4519f131c4c6376d0ae89c9a791) | `` dev/flake.lock: Update ``                                |
| [`6ddb1346`](https://github.com/hercules-ci/flake-parts/commit/6ddb1346c88686719ed25f51c17ebad9804c54c7) | `` flake.lock: Update ``                                    |
| [`e324ad1f`](https://github.com/hercules-ci/flake-parts/commit/e324ad1f60cc1d3317ba77502d8c792fbd1d06f0) | `` flake.nix: Update nixpkgs-lib tree ``                    |