### PR TITLE
chore(flake/nix-fast-build): `ed736c65` -> `906af17f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1734716067,
-        "narHash": "sha256-BCpd50t/3JU4ydiNfJxH3LzQDzyGbBI0CKWaeplnkVg=",
+        "lastModified": 1736592044,
+        "narHash": "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc",
+        "rev": "906af17fcd50c84615a4660d9c08cf89c01cef7d",
         "type": "github"
       },
       "original": {
@@ -425,11 +425,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734543842,
-        "narHash": "sha256-/QceWozrNg915Db9x/Ie5k67n9wKgGdTFng+Z1Qw0kE=",
+        "lastModified": 1736154270,
+        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "76159fc74eeac0599c3618e3601ac2b980a29263",
+        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`906af17f`](https://github.com/Mic92/nix-fast-build/commit/906af17fcd50c84615a4660d9c08cf89c01cef7d) | `` bump version 1.1.0 ``                                          |
| [`be543d30`](https://github.com/Mic92/nix-fast-build/commit/be543d30c2eb44936a2713a032a8790a4ab8a5c3) | `` add release script ``                                          |
| [`d9dc56ab`](https://github.com/Mic92/nix-fast-build/commit/d9dc56ab1ae7a270361f649f597300b93ce66acf) | `` flake.lock: Update ``                                          |
| [`a06a8b2c`](https://github.com/Mic92/nix-fast-build/commit/a06a8b2c079f7b6dab491a12555387bdb737cc44) | `` flake.lock: Update ``                                          |
| [`19e76bc7`](https://github.com/Mic92/nix-fast-build/commit/19e76bc7cad95248befdce9c86fb6e1e088056c6) | `` mergify: delete old merge branches ``                          |
| [`908c3aca`](https://github.com/Mic92/nix-fast-build/commit/908c3aca3486120a575b6057bcddef07a810224f) | `` check for new cacheStatus attribute in nix-eval-jobs output `` |