### PR TITLE
chore(flake/nixvim): `bc87d912` -> `4282b73a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
+        "lastModified": 1735644329,
+        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
+        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -118,18 +118,14 @@
         "nixpkgs": [
           "nixvim",
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixvim",
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1734797603,
-        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
+        "lastModified": 1735882644,
+        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {
@@ -189,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735381016,
-        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
+        "lastModified": 1736508663,
+        "narHash": "sha256-ZOaGwa+WnB7Zn3YXimqjmIugAnHePdXCmNu+AHkq808=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
+        "rev": "2532b500c3ed2b8940e831039dcec5a5ea093afc",
         "type": "github"
       },
       "original": {
@@ -238,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735478292,
-        "narHash": "sha256-Ys9pSP9ch0SthhpbjnkCSJ9ZLfaNKnt/dcy7swjmS1A=",
+        "lastModified": 1736370755,
+        "narHash": "sha256-iWcjToBpx4PUd74uqvIGAfqqVfyrvRLRauC/SxEKIF0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "71a3a075e3229a7518d76636bb762aef2bcb73ac",
+        "rev": "57733bd1dc81900e13438e5b4439239f1b29db0e",
         "type": "github"
       },
       "original": {
@@ -334,11 +330,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1735656123,
-        "narHash": "sha256-AnTW4OA8vW6CGqNJQZ/jV+i9ei7h7g+htGGdshWmQSo=",
+        "lastModified": 1736876796,
+        "narHash": "sha256-Z7zxkh7b7Nfcryir3W2+wy7Ju1i1wSABGX01fA3+3hM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "bc87d91273928c97a47eab0df9b303bb45adc6f4",
+        "rev": "4282b73ac0dbea03ad74ee8975c33ec41b0a7f25",
         "type": "github"
       },
       "original": {
@@ -357,11 +353,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733773348,
-        "narHash": "sha256-Y47y+LesOCkJaLvj+dI/Oa6FAKj/T9sKVKDXLNsViPw=",
+        "lastModified": 1735854821,
+        "narHash": "sha256-Iv59gMDZajNfezTO0Fw6LHE7uKAShxbvMidmZREit7c=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "3051be7f403bff1d1d380e4612f0c70675b44fc9",
+        "rev": "836908e3bddd837ae0f13e215dd48767aee355f0",
         "type": "github"
       },
       "original": {
@@ -446,11 +442,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735135567,
-        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
+        "lastModified": 1736154270,
+        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
+        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`4282b73a`](https://github.com/nix-community/nixvim/commit/4282b73ac0dbea03ad74ee8975c33ec41b0a7f25) | `` plugins/flutter-tools: move settings to dedicated file ``                               |
| [`a54b7522`](https://github.com/nix-community/nixvim/commit/a54b752259ff16d340d270928ee603b4b9599192) | `` plugins/femaco: init ``                                                                 |
| [`b3d85757`](https://github.com/nix-community/nixvim/commit/b3d857573b92e1cc7b9b9c7c242c8dee61ebf359) | `` plugins/papis: init ``                                                                  |
| [`b7f783a8`](https://github.com/nix-community/nixvim/commit/b7f783a8dc733df2d33b5d32665339216cd04177) | `` plugins/tailwind-tools: init ``                                                         |
| [`67bbdf93`](https://github.com/nix-community/nixvim/commit/67bbdf9318aa27961ebb18b4581aad7cc4c87598) | `` plugins/cornelis: init ``                                                               |
| [`8f7600ac`](https://github.com/nix-community/nixvim/commit/8f7600aca0b859b7d2c25ce8d6000b7ea87d4c82) | `` plugins/lazydev: init ``                                                                |
| [`35d6c126`](https://github.com/nix-community/nixvim/commit/35d6c12626f9895cd5d8ccf5d19c3d00de394334) | `` plugins/clangd-extensions: convert to mkNeovimPlugin ``                                 |
| [`56877b8f`](https://github.com/nix-community/nixvim/commit/56877b8f763d6cadd42981d6c2bbf1222d621300) | `` plugins/llm: init ``                                                                    |
| [`8f4bf6d3`](https://github.com/nix-community/nixvim/commit/8f4bf6d300195da9dfa60df999c254d866e4d4ff) | `` plugins/sg: init ``                                                                     |
| [`5f3785fe`](https://github.com/nix-community/nixvim/commit/5f3785feb8564354a6fa9359fddcd38b32bd6efd) | `` plugins/projections: init ``                                                            |
| [`4527abba`](https://github.com/nix-community/nixvim/commit/4527abba5870b5650604eece6020a5d0361fe4cf) | `` plugins/visual-multi: init ``                                                           |
| [`8db6c517`](https://github.com/nix-community/nixvim/commit/8db6c5176242c2049d57bb9b30d1faac7c0cc2b1) | `` plugins/lir: init ``                                                                    |
| [`2fc2132a`](https://github.com/nix-community/nixvim/commit/2fc2132a78753fc3d7ec732044eff7ad69530055) | `` flake.lock: Update ``                                                                   |
| [`67de8484`](https://github.com/nix-community/nixvim/commit/67de84848e43ca6a5025e4f8eddc2f6684a51f2b) | `` tests/lean: disable lean tests on x86_64-darwin ``                                      |
| [`bca43a2a`](https://github.com/nix-community/nixvim/commit/bca43a2a8ed137a760c51ddc05442ea940e4cf73) | `` tests/lsp/all-servers: disable autotools_ls on aarch64-linux ``                         |
| [`574e78bb`](https://github.com/nix-community/nixvim/commit/574e78bb76f9de79f7f325f716445e4d479d9df5) | `` flake.lock: Update ``                                                                   |
| [`83153e96`](https://github.com/nix-community/nixvim/commit/83153e96c25d989020d028af51cf947aa843dc3c) | `` plugins/blink-cmp: add khaneliman maintainer ``                                         |
| [`2f9b103d`](https://github.com/nix-community/nixvim/commit/2f9b103d2ea5c3a127d883fc1965b620cc83dd72) | `` plugins/blink-cmp: update completion.list.selection type ``                             |
| [`20540945`](https://github.com/nix-community/nixvim/commit/2054094544f03daf746160cd47e1860ebbb129e9) | `` plugins/dropbar: init ``                                                                |
| [`592e9eaf`](https://github.com/nix-community/nixvim/commit/592e9eaff04fab033427d8c5fb747866b68d6f18) | `` plugins/inc-rename: convert to mkNeovimPlugin and add option ``                         |
| [`092a46a1`](https://github.com/nix-community/nixvim/commit/092a46a1ca8697a4f0420099fd2d610a951ea5d4) | `` plugins/neoconf: setup before lspconfig ``                                              |
| [`8899663b`](https://github.com/nix-community/nixvim/commit/8899663b5928c1326a4d8f721430da7e947f4dc1) | `` plugins/persistence: convert to mkNeovimPlugin and fix settings ``                      |
| [`0ebc64a2`](https://github.com/nix-community/nixvim/commit/0ebc64a2328fc0a0532f9544eb6c6e297135962e) | `` plugins/blink-cmp: remove forced version override ``                                    |
| [`73303938`](https://github.com/nix-community/nixvim/commit/73303938ee2e8cdc7138db6fc6e42d83cc546a56) | `` plugins/copilot-lua: migrate to mkNeovimPlugin ``                                       |
| [`a352bb89`](https://github.com/nix-community/nixvim/commit/a352bb89b0cd180f5c767689c4cc310109cd4ad8) | `` plugins/blink-cmp: fix `sources.per_filetype` option type ``                            |
| [`81c1ef20`](https://github.com/nix-community/nixvim/commit/81c1ef2090928715b9c17529880b9b60fe3abfc8) | `` tests/fidget: update to new format ``                                                   |
| [`038f5656`](https://github.com/nix-community/nixvim/commit/038f5656d8739fb18461aad3e47968e6bb0f361f) | `` plugins/fidget: migrate to mkNeovimPlugin ``                                            |
| [`1e564fae`](https://github.com/nix-community/nixvim/commit/1e564fae7d0d41ca9710da81c3165feb17df5054) | `` colorschemes/monokai-pro: init ``                                                       |
| [`8968da16`](https://github.com/nix-community/nixvim/commit/8968da1617b09b6a2be1bc77cb1917ce713db446) | `` plugins/smear-cursor: init ``                                                           |
| [`e59e9931`](https://github.com/nix-community/nixvim/commit/e59e99314b0a74af844bb0189182784b1af5a729) | `` plugins/lsp: add support for mode in non-extra keymaps ``                               |
| [`a74897d0`](https://github.com/nix-community/nixvim/commit/a74897d03381659bf609aa8b4bb1201c23fe3eec) | `` mkLsp: remove `with lib;` ``                                                            |
| [`5201bb2f`](https://github.com/nix-community/nixvim/commit/5201bb2f6f265300465228b87d75b1684fc2bc78) | `` mkLsp: `helpers` -> `lib.nixvim` ``                                                     |
| [`48eeef58`](https://github.com/nix-community/nixvim/commit/48eeef58e1ec2e92c246b953e53fbe5fc76cce99) | `` plugins/lsp: migrate to mkNeovimPlugin ``                                               |
| [`65d08206`](https://github.com/nix-community/nixvim/commit/65d082069e0cf1edffe0a39dddfac6a2ea870d46) | `` plugins/treesitter: injections support luaConfig strings ``                             |
| [`31139e06`](https://github.com/nix-community/nixvim/commit/31139e0605fd886d981e0a197e30ceac4b859d6e) | `` plugins/vimux: init ``                                                                  |
| [`2d18a774`](https://github.com/nix-community/nixvim/commit/2d18a774328d50ca76b48966e1b658a65bc0479f) | `` Revert "tests/lsp-servers: disable ruby_lsp (broken package)" ``                        |
| [`7915efce`](https://github.com/nix-community/nixvim/commit/7915efce0f5b07ab20606832887342d69f072993) | `` flake.lock: Update ``                                                                   |
| [`7896856d`](https://github.com/nix-community/nixvim/commit/7896856db1de897e95333aed381f06fa8788fff7) | `` plugins/treesj: init ``                                                                 |
| [`974b1d2c`](https://github.com/nix-community/nixvim/commit/974b1d2ce577bf07df22f61e0c167fa54dc3e879) | `` plugins/telescope: add project extension ``                                             |
| [`e07a482f`](https://github.com/nix-community/nixvim/commit/e07a482fd86eed90fd9378b97a2f938f07da1499) | `` flake: remove unneeded follows after git-hooks dropped their nixpkgs-stable input ``    |
| [`9fec1059`](https://github.com/nix-community/nixvim/commit/9fec10597383c024a2a1a8b71fb58d6b1f30ebb9) | `` flake.lock: Update ``                                                                   |
| [`91227dca`](https://github.com/nix-community/nixvim/commit/91227dca9e0bb2eab1f165ce05538f38065d37c0) | `` lib/options: add defaultNullOpts.mkFloat ``                                             |
| [`24ac8f65`](https://github.com/nix-community/nixvim/commit/24ac8f651dc0e65cb26553760c39b9c6f9de732b) | `` plugins.*: use defaultNullOpts.mkProportion wherever possible ``                        |
| [`2e600f57`](https://github.com/nix-community/nixvim/commit/2e600f579621aacfce084057e0d80b97f9949080) | `` lib/options: add defaultNullOpts.mkProportion ``                                        |
| [`4f4917be`](https://github.com/nix-community/nixvim/commit/4f4917be697e7ef39ebada3737e51cb42e0cbe79) | `` plugins/csvview: init ``                                                                |
| [`6c93c52d`](https://github.com/nix-community/nixvim/commit/6c93c52dc1958a2e17313480e2fc68601bcbb0a6) | `` Revert "tests/lsp-servers: disable solc (broken package)" ``                            |
| [`153ddee6`](https://github.com/nix-community/nixvim/commit/153ddee666c59ed6b6e3b33d18d711fd2a3639e6) | `` Revert "tests/{efmls-configs,none-ls}: disable ansible_lint test (broken package)" ``   |
| [`647b1de9`](https://github.com/nix-community/nixvim/commit/647b1de9b9954a3a70b29e7e6291b2e28a6deb5f) | `` Revert "tests/efmls-configs: disable cppcheck test on darwin (broken package)" ``       |
| [`9eb21bbd`](https://github.com/nix-community/nixvim/commit/9eb21bbdeab94831d8f4815be0d7575e72f31028) | `` Revert "tests/openscad: disable on darwin (broken package)" ``                          |
| [`49f9176f`](https://github.com/nix-community/nixvim/commit/49f9176f8016fab132357f8615eec021be2755c8) | `` Revert "tests/{efmls-configs,none-ls}: disable clazy test (broken package)" ``          |
| [`2ef0818d`](https://github.com/nix-community/nixvim/commit/2ef0818d2e632d897141f60cf75f3fc11001adf7) | `` generated: Updated rust-analyzer.nix ``                                                 |
| [`696e5e5c`](https://github.com/nix-community/nixvim/commit/696e5e5ca0681aff52c6cf910b79cc8475d28241) | `` flake.lock: Update ``                                                                   |
| [`93b5fb04`](https://github.com/nix-community/nixvim/commit/93b5fb04783b58afa691977dcbb90b58483b3d82) | `` plugins/distant: init ``                                                                |
| [`e1b39b72`](https://github.com/nix-community/nixvim/commit/e1b39b725e779cdcf674bd1389b79691600c67a2) | `` plugins/fugit2: init ``                                                                 |
| [`3285bbda`](https://github.com/nix-community/nixvim/commit/3285bbda0aa0151c3b1914758e6950dfb554962f) | `` flake/dev/new-plugin: add '# TODO' next to the maintainers line ``                      |
| [`87ee6609`](https://github.com/nix-community/nixvim/commit/87ee660991fa0e1b7b4e3f43a6dd1d126e64f3fa) | `` plugins/flit: init ``                                                                   |
| [`cbddd58c`](https://github.com/nix-community/nixvim/commit/cbddd58c6987e674dbbf9fc20e3f14b7c8f1232b) | `` lib/maintainers: add jolars ``                                                          |
| [`3399ebfe`](https://github.com/nix-community/nixvim/commit/3399ebfedd741456f45de6148fc36e7fcc74fcfa) | `` fix: use proper auto_insert option in `blink-cmp.settings.completion.list.selection` `` |
| [`d608bccd`](https://github.com/nix-community/nixvim/commit/d608bccddd810482495d5ba4134ea824879cf118) | `` Replace runCommandNoCCLocal alias with runCommandLocal ``                               |