### PR TITLE
chore(flake/nixpkgs): `88195a94` -> `9abb87b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1736798957,
+        "narHash": "sha256-qwpCtZhSsSNQtK4xYGzMiyEDhkNzOCz/Vfu4oL2ETsQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "9abb87b552b7f55ac8916b6fc9e5cb486656a2f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`01c1ec8f`](https://github.com/NixOS/nixpkgs/commit/01c1ec8f5fb4c95653afe0984df9bd9a948286d1) | `` osmium-tool: fix build ``                                                                   |
| [`2686ec7e`](https://github.com/NixOS/nixpkgs/commit/2686ec7e75c3912056075a83d50079b3ebeb5cd1) | `` xilinx-bootgen: xilinx_v2024.1 -> xilinx_v2024.2 ``                                         |
| [`7fb6d596`](https://github.com/NixOS/nixpkgs/commit/7fb6d5962d1712845c9a1915c4681892861ac8f9) | `` xilinx-bootgen: add updateScript to passthru ``                                             |
| [`ad0c2301`](https://github.com/NixOS/nixpkgs/commit/ad0c23019c380694edc9a3418d65d874e021aa6f) | `` {libqalculate,qalculate-gtk,qalculate-qt}: 5.4.0 -> 5.5.0 ``                                |
| [`53acf883`](https://github.com/NixOS/nixpkgs/commit/53acf883e86fed123fe3c84b7dd48aff8ca6fef3) | `` python312Packages.netbox-qrcode: init at 0.0.15 (#369931) ``                                |
| [`748aaf41`](https://github.com/NixOS/nixpkgs/commit/748aaf41aad8f9a7336c0d2d236f7998730248f3) | `` kubecolor: 0.4.0 -> 0.5.0 ``                                                                |
| [`251a8758`](https://github.com/NixOS/nixpkgs/commit/251a8758b4c666db8742ef509c867d491129ff5a) | `` alacarte: 3.54.0 -> 3.54.1 ``                                                               |
| [`1beac390`](https://github.com/NixOS/nixpkgs/commit/1beac390f98ecc7eb745d6c54f74d80052d3944a) | `` riffdiff: 3.3.7 -> 3.3.8 ``                                                                 |
| [`7fed512f`](https://github.com/NixOS/nixpkgs/commit/7fed512fbc6fb9f080a73505d7968c959d11682a) | `` libosmium: 2.20.0 → 2.21.0 ``                                                               |
| [`1706ef6e`](https://github.com/NixOS/nixpkgs/commit/1706ef6e5145c8db0a5d505e5196aa3397cb0c56) | `` molden: fix GCC 14 build ``                                                                 |
| [`5b5048da`](https://github.com/NixOS/nixpkgs/commit/5b5048daf4bef2cb89e5e5b9447d2a11f4a3390d) | `` python3Packages.kestra: init at 0.20.0 ``                                                   |
| [`e85ca752`](https://github.com/NixOS/nixpkgs/commit/e85ca752493348fb50e86fed0a47e564ebf7ac36) | `` nixos/calibre-web: customize data directory (#350617) ``                                    |
| [`2a4d344b`](https://github.com/NixOS/nixpkgs/commit/2a4d344b9a682a19c7f559e327d7ce88c9f2ef77) | `` protozero: modernize ``                                                                     |
| [`41ab0f7a`](https://github.com/NixOS/nixpkgs/commit/41ab0f7accfcdfb939f9ee1b7b882a8b1a6cf288) | `` swiften: fix GCC 14 build ``                                                                |
| [`98fdeec1`](https://github.com/NixOS/nixpkgs/commit/98fdeec1614acab1c15cd878300e6bd61c9c4af5) | `` appium-inspector: init at 2024.12.1 ``                                                      |
| [`30df88e4`](https://github.com/NixOS/nixpkgs/commit/30df88e4e0eb82e2a8d03c50ba712cd02bf7615e) | `` librecad: enable on darwin ``                                                               |
| [`0b07ca72`](https://github.com/NixOS/nixpkgs/commit/0b07ca72c25ec9f89ad77bc02850df242dce7e45) | `` librecad: adopt, modernize, migrate to by-name ``                                           |
| [`bbcb2771`](https://github.com/NixOS/nixpkgs/commit/bbcb27714f0871129156aae99dd427da97604b30) | `` nixos/home-assistant: allow amshan to access serial ports ``                                |
| [`f194e743`](https://github.com/NixOS/nixpkgs/commit/f194e743c271619fa2149b8999f7ad71175756d2) | `` home-assistant-custom-components.amshan: init at 2024.12.0 ``                               |
| [`d0c3e76e`](https://github.com/NixOS/nixpkgs/commit/d0c3e76e335361ba04e8b72b15691b5c60339ecc) | `` python312Packages.flask-limiter: 3.9.2 -> 3.10.0 ``                                         |
| [`fa5f8ef6`](https://github.com/NixOS/nixpkgs/commit/fa5f8ef65760c0d6186ccdbb29e65e5df9659e73) | `` gtkradiant: fix GCC 14 build ``                                                             |
| [`0b60aea1`](https://github.com/NixOS/nixpkgs/commit/0b60aea1a711a29eac554dee552e1ceb113b1f6d) | `` python312Packages.mmcv: disable failing tests on aarch64-linux ``                           |
| [`cb821851`](https://github.com/NixOS/nixpkgs/commit/cb821851f7a625ea477b1df5ae3f8b12e57a2a15) | `` oelint-adv: 6.6.6 -> 6.6.9 ``                                                               |
| [`8d545799`](https://github.com/NixOS/nixpkgs/commit/8d545799d7f592eaaa63fe370277dacd1d041b32) | `` factoriolab: 3.8.10 -> 3.9.2 ``                                                             |
| [`a3d10adf`](https://github.com/NixOS/nixpkgs/commit/a3d10adfe0acbc097daf4a6b43bf90116142eb47) | `` whisper-ctranslate2: 0.5.1 -> 0.5.2 ``                                                      |
| [`c6f41fa6`](https://github.com/NixOS/nixpkgs/commit/c6f41fa69a1b3de5dbe389d02450d334c43c5966) | `` endless-sky: fix cross build ``                                                             |
| [`98e46c26`](https://github.com/NixOS/nixpkgs/commit/98e46c26f28f6de9461f721dd790e46657b1afda) | `` renode-dts2repl: 0-unstable-2024-12-28 -> 0-unstable-2025-01-13 ``                          |
| [`12d4b564`](https://github.com/NixOS/nixpkgs/commit/12d4b5648f69cd6d7a71a385e4ad8f675b7be328) | `` fastfetch: 2.34.0 -> 2.34.1 ``                                                              |
| [`0741b8fd`](https://github.com/NixOS/nixpkgs/commit/0741b8fdcef52c20d870df728f7cedcd3cb59a5f) | `` protozero: 1.7.1 -> 1.8.0 ``                                                                |
| [`ef5a0d00`](https://github.com/NixOS/nixpkgs/commit/ef5a0d00c08bdecc1766dac5848a9c86465714b7) | `` oauth2c: 1.17.0 -> 1.17.1 ``                                                                |
| [`59396491`](https://github.com/NixOS/nixpkgs/commit/59396491c598bb63970d0071aedfa85f483c7113) | `` m4ri: do not autodetect some SIMD cpuflags ``                                               |
| [`d9ff154b`](https://github.com/NixOS/nixpkgs/commit/d9ff154b746708267cedb1dd6fffee1afb563754) | `` nixos/wyoming-faster-whisper: remove ProcSubset protection ``                               |
| [`a8d7d4d4`](https://github.com/NixOS/nixpkgs/commit/a8d7d4d47d863442473160529cfcd61661388c6d) | `` kubernetes-controller-tools: 0.17.0 -> 0.17.1 ``                                            |
| [`3538481b`](https://github.com/NixOS/nixpkgs/commit/3538481bb308642592213378f1dc5f32151b511d) | `` havn: 0.1.17 -> 0.1.18 ``                                                                   |
| [`fb6e3f5d`](https://github.com/NixOS/nixpkgs/commit/fb6e3f5ddb2542e120521e853cfa12b855866577) | `` iotop-c: 1.26 -> 1.27 ``                                                                    |
| [`95ccc479`](https://github.com/NixOS/nixpkgs/commit/95ccc479de5dd984ecaf56cbf1342376651bf0ee) | `` bitcoin: 28.0 -> 28.1 ``                                                                    |
| [`58a7d305`](https://github.com/NixOS/nixpkgs/commit/58a7d305896b859292085167e16790052f12be47) | `` cntr: 1.5.4 -> 1.6.0 ``                                                                     |
| [`14fdc6d4`](https://github.com/NixOS/nixpkgs/commit/14fdc6d450cbcc346c8cf37e5492035530df6fcb) | `` python312Packages.dvc: 3.58.0 -> 3.59.0 ``                                                  |
| [`5fe676f6`](https://github.com/NixOS/nixpkgs/commit/5fe676f6a03c4c02a19944055cf18ca524882f89) | `` python313Packages.alexapy: 1.28.0 -> 1.29.5 ``                                              |
| [`24f9d187`](https://github.com/NixOS/nixpkgs/commit/24f9d18729e5b46c5150c3ad8d9573cc9d68d119) | `` awsbck: 0.3.9 -> 0.3.10 ``                                                                  |
| [`eb804e33`](https://github.com/NixOS/nixpkgs/commit/eb804e33c417fbdcbe53bc9ae8ce0b9fcebfac86) | `` uv: 0.5.17 -> 0.5.18 ``                                                                     |
| [`b3391c0b`](https://github.com/NixOS/nixpkgs/commit/b3391c0bf4bb86651f6d9e10285888f164a68e71) | `` ronin: 2.0.5 -> 2.1.0 ``                                                                    |
| [`9bd26814`](https://github.com/NixOS/nixpkgs/commit/9bd268142995c99cc83e25030cdfb3c73259b5cd) | `` cross-seed: 6.8.4 -> 6.8.5 ``                                                               |
| [`483beec5`](https://github.com/NixOS/nixpkgs/commit/483beec52ff9096881f4febd8f8cfe02f4b3019a) | `` astal.io: 0-unstable-2025-01-12 -> 0-unstable-2025-01-13 ``                                 |
| [`b8711737`](https://github.com/NixOS/nixpkgs/commit/b8711737b53b1f8932ddee882247bc483d04d039) | `` blackfire: 2.28.21 -> 2.28.22 ``                                                            |
| [`6e6be766`](https://github.com/NixOS/nixpkgs/commit/6e6be766010b911c69ac096735199f13344b1df1) | `` nixos/image.modules: siplify type for better UX ``                                          |
| [`fc747102`](https://github.com/NixOS/nixpkgs/commit/fc747102592a3cdd6fc89c6e60d6e51d235e8bef) | `` python312Packages.mmengine: 0.10.5 -> 0.10.6 ``                                             |
| [`dda2b8c3`](https://github.com/NixOS/nixpkgs/commit/dda2b8c3accd04995db2cc895d1a4f9be1079593) | `` v2ray: 5.23.0 -> 5.24.0 ``                                                                  |
| [`c254691a`](https://github.com/NixOS/nixpkgs/commit/c254691a5b97601ddb6b3fa7c0f449fa0a5f606c) | `` build(deps): bump actions/upload-artifact from 4.5.0 to 4.6.0 ``                            |
| [`52a46447`](https://github.com/NixOS/nixpkgs/commit/52a4644715079950a61222806a1e860c75447150) | `` virglrenderer: trim dependencies on darwin ``                                               |
| [`2c4cfe8a`](https://github.com/NixOS/nixpkgs/commit/2c4cfe8a8436b68642959887de6e84f98cba0b9a) | `` virglrenderer: build on darwin ``                                                           |
| [`616f5fad`](https://github.com/NixOS/nixpkgs/commit/616f5fad9782ce007f812d838791f691f2d6b758) | `` woodpecker-server: 2.8.2 -> 2.8.3 ``                                                        |
| [`e19a3277`](https://github.com/NixOS/nixpkgs/commit/e19a327757e96707601eb67907d04951b34efa42) | `` nvitop: 1.4.0 -> 1.4.1 ``                                                                   |
| [`8eef2ac6`](https://github.com/NixOS/nixpkgs/commit/8eef2ac6ef0970938c8963a08563f33bada8e7cb) | `` python312Packages.versionfinder: refactor ``                                                |
| [`35102ae1`](https://github.com/NixOS/nixpkgs/commit/35102ae16360b9e632534631ce3cdeb9234f6bee) | `` python312Packages.yahooweather: remove ``                                                   |
| [`3ebf0068`](https://github.com/NixOS/nixpkgs/commit/3ebf00684c3bff1d999245814ed1726dcd8d2794) | `` python312Packages.python-hpilo: refactor ``                                                 |
| [`792b1dd7`](https://github.com/NixOS/nixpkgs/commit/792b1dd7c7cf0edd418de8f31e09bee496c1d121) | `` python312Packages.facedancer: 3.0.6 -> 3.1.0 ``                                             |
| [`ab675375`](https://github.com/NixOS/nixpkgs/commit/ab675375b53d26f93f5bc5e091bfebfe281f1957) | `` kphotoalbum: 5.11.0 -> 6.0.1 ``                                                             |
| [`31353417`](https://github.com/NixOS/nixpkgs/commit/3135341706cf26dc63caddf21b3729d7a0ac3468) | `` pixi: 0.39.5 -> 0.40.0 ``                                                                   |
| [`3978e1f7`](https://github.com/NixOS/nixpkgs/commit/3978e1f7b149f0416e49efe1e546eda172ff2ae3) | `` python3Packages.amshan: init at 2.1.1 ``                                                    |
| [`91618081`](https://github.com/NixOS/nixpkgs/commit/916180810bfb46a5aa2fb0afc6242b3f0cb03e10) | `` dracula-theme: 4.0.0-unstable-2024-12-05 -> 4.0.0-unstable-2025-01-10 ``                    |
| [`f7d70999`](https://github.com/NixOS/nixpkgs/commit/f7d70999a37e2cb5ce449f647836ae49cb7230c5) | `` python313Packages.pypalazzetti: 0.1.16 -> 0.1.19 ``                                         |
| [`d9b2b97a`](https://github.com/NixOS/nixpkgs/commit/d9b2b97a0db7cfa5aa430c51d9d9ca4ab200f7cb) | `` roslyn-ls: 4.13.0-3.24577.4 -> 4.13.0-3.25051.1 ``                                          |
| [`772f02c2`](https://github.com/NixOS/nixpkgs/commit/772f02c2319c5b01f51ce9725622b8f8fc347f3a) | `` python313Packages.tplink-omada-client: 1.4.3 -> 1.4.4 ``                                    |
| [`251f8be4`](https://github.com/NixOS/nixpkgs/commit/251f8be4245a0ce6b5f24d440a8c60455dff19c0) | `` python313Packages.pyexploitdb: 0.2.62 -> 0.2.63 ``                                          |
| [`9ec238ac`](https://github.com/NixOS/nixpkgs/commit/9ec238ac9981c10e3b5e1e29f577672fadee8cf3) | `` python313Packages.tencentcloud-sdk-python: 3.0.1300 -> 3.0.1301 ``                          |
| [`cd8a8726`](https://github.com/NixOS/nixpkgs/commit/cd8a8726da5b3dbbd7d2cd717f6922c89b419bf9) | `` python313Packages.switchbot-api: 2.2.1 -> 2.3.1 ``                                          |
| [`8d06f4d0`](https://github.com/NixOS/nixpkgs/commit/8d06f4d0c86f43cb58d7c4a348743839642c902b) | `` gh-ost: 1.1.6 -> 1.1.7 ``                                                                   |
| [`5c30f8ca`](https://github.com/NixOS/nixpkgs/commit/5c30f8caf44ff3ec6ab17977db4ad2e6f087a248) | `` nixos/test-instrumentation: fix shellcheck findings with enableStrictShellChecks enabled `` |
| [`f70b3a2a`](https://github.com/NixOS/nixpkgs/commit/f70b3a2afa6323a17896f7a8ee40c4712c5bf2c2) | `` tests/taler: init basic test ``                                                             |
| [`6f35a685`](https://github.com/NixOS/nixpkgs/commit/6f35a68586680447db6bef301fd7ca20a9d8bcd1) | `` nixos/libeufin: init module ``                                                              |
| [`7c51b855`](https://github.com/NixOS/nixpkgs/commit/7c51b855f7188c7169252be578e1f61773579442) | `` nixos/taler: init module ``                                                                 |
| [`0c8f128c`](https://github.com/NixOS/nixpkgs/commit/0c8f128cfffef0af8d2d552aff72424f727fefb4) | `` asymptote: fix Darwin build ``                                                              |
| [`1b378150`](https://github.com/NixOS/nixpkgs/commit/1b37815083cad8072bd59272b0c73b5f44f925bc) | `` shiori: 1.7.3 -> 1.7.4 ``                                                                   |
| [`91c0a313`](https://github.com/NixOS/nixpkgs/commit/91c0a313d5ca5b1c407db2213ce7836ffddc4ec4) | `` mieru: 3.10.0 -> 3.11.0 ``                                                                  |
| [`c02e9074`](https://github.com/NixOS/nixpkgs/commit/c02e9074ff839f3f49d033f0777b57ee357a4010) | `` python312Packages.pbs-installer: 2024.10.16 -> 2025.01.06 ``                                |
| [`477f09ef`](https://github.com/NixOS/nixpkgs/commit/477f09ef7fccc1d8d47cfd9649b2bcfaf341e2f2) | `` python312Packages.casbin: 1.37.0 -> 1.38.0 ``                                               |
| [`48a95e4c`](https://github.com/NixOS/nixpkgs/commit/48a95e4cbb4cdc1bb1ead4db82d143c54f0aa4d0) | `` papeer: 0.8.2 -> 0.8.3 ``                                                                   |
| [`171cf4b6`](https://github.com/NixOS/nixpkgs/commit/171cf4b6caee3b12e2d968ea83c1afb1c6802c64) | `` roddhjav-apparmor-rules: 0-unstable-2024-12-25 -> 0-unstable-2025-01-12 (#373363) ``        |
| [`f4ed82ae`](https://github.com/NixOS/nixpkgs/commit/f4ed82ae03a98502851ddf8096579cda794eb56f) | `` python312Packages.tornado_5: remove ``                                                      |
| [`3ca089be`](https://github.com/NixOS/nixpkgs/commit/3ca089be45cfde6bcac89645b24a6d9eee14f35a) | `` python312Packages.tornado_4: remove ``                                                      |
| [`bfd10a78`](https://github.com/NixOS/nixpkgs/commit/bfd10a780ff11769ead7f19aeec7b27b1d480772) | `` chirp: 0.4.0-unstable-2024-12-26 -> 0.4.0-unstable-2025-01-12 ``                            |
| [`fd4a3925`](https://github.com/NixOS/nixpkgs/commit/fd4a3925c656f90268611fdaf0dea42412a5618d) | `` wastebin: 2.5.0 -> 2.6.0 ``                                                                 |
| [`c4a6fba1`](https://github.com/NixOS/nixpkgs/commit/c4a6fba1c9aef037c076a3d294ae1b1fd241b63b) | `` cataclysm-dda-git: 2024-07-28 -> 2024-12-11 ``                                              |
| [`cd321ca9`](https://github.com/NixOS/nixpkgs/commit/cd321ca9a4476d462b3f0bbe22719b56f51bbf90) | `` cataclysm-dda: 0.G -> 0.H ``                                                                |
| [`69aeb0ee`](https://github.com/NixOS/nixpkgs/commit/69aeb0ee595111bd3b7565de16547b2fff6ea9ca) | `` serie: 0.4.1 -> 0.4.2 ``                                                                    |
| [`f01320b9`](https://github.com/NixOS/nixpkgs/commit/f01320b9abfd00bbb4e2e04d8e2de7005977ebb1) | `` albert: 0.26.11 -> 0.26.13 ``                                                               |
| [`d75556db`](https://github.com/NixOS/nixpkgs/commit/d75556db47e93abcc724c9fb11f9be3bf774b8e9) | `` bruno: 1.37.0 -> 1.38.1 ``                                                                  |
| [`c034dd9a`](https://github.com/NixOS/nixpkgs/commit/c034dd9a1f392c8fe84b92b689f11176f904dd53) | `` maintainers: update numinit's email and keys ``                                             |
| [`3d5cd863`](https://github.com/NixOS/nixpkgs/commit/3d5cd8639b04c8af83a153b62cf6d7c85ae39284) | `` kdlfmt: 0.0.8 -> 0.0.10 ``                                                                  |
| [`e337f76c`](https://github.com/NixOS/nixpkgs/commit/e337f76cab1360dace456783544b4072c731d920) | `` tautulli: 2.15.0 -> 2.15.1 ``                                                               |
| [`db6fed4b`](https://github.com/NixOS/nixpkgs/commit/db6fed4bd24ad461133b1f6761127ead3b428983) | `` pv: 1.9.25 -> 1.9.27 ``                                                                     |
| [`b932736f`](https://github.com/NixOS/nixpkgs/commit/b932736fab893dd9bd81494c5771c2bf999e8114) | `` kor: 0.5.7 -> 0.5.8 ``                                                                      |
| [`c730e633`](https://github.com/NixOS/nixpkgs/commit/c730e633c905707a9fafad7846fd8669b7d74df3) | `` cargo-temp: 0.3.0 -> 0.3.1 ``                                                               |
| [`8eafc30b`](https://github.com/NixOS/nixpkgs/commit/8eafc30b44c90bcb03af0c768bb09e74f49f98e5) | `` tflint: 0.54.0 -> 0.55.0 ``                                                                 |