### PR TITLE
chore(flake/nixvim): `4282b73a` -> `c75e4ea3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,12 +23,12 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "revCount": 57,
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -121,11 +121,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735882644,
-        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736508663,
-        "narHash": "sha256-ZOaGwa+WnB7Zn3YXimqjmIugAnHePdXCmNu+AHkq808=",
+        "lastModified": 1738275749,
+        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2532b500c3ed2b8940e831039dcec5a5ea093afc",
+        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736370755,
-        "narHash": "sha256-iWcjToBpx4PUd74uqvIGAfqqVfyrvRLRauC/SxEKIF0=",
+        "lastModified": 1738277753,
+        "narHash": "sha256-iyFcCOk0mmDiv4ut9mBEuMxMZIym3++0qN1rQBg8FW0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "57733bd1dc81900e13438e5b4439239f1b29db0e",
+        "rev": "49b807fa7c37568d7fbe2aeaafb9255c185412f9",
         "type": "github"
       },
       "original": {
@@ -314,11 +314,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736876796,
-        "narHash": "sha256-Z7zxkh7b7Nfcryir3W2+wy7Ju1i1wSABGX01fA3+3hM=",
+        "lastModified": 1738366771,
+        "narHash": "sha256-nyEBrP5t1g4vmy7YBkiGaIu19eG8zV3T4IQLQbJsVU8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4282b73ac0dbea03ad74ee8975c33ec41b0a7f25",
+        "rev": "c75e4ea37f25ec98aa6f2035e03e748e7369662c",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735854821,
-        "narHash": "sha256-Iv59gMDZajNfezTO0Fw6LHE7uKAShxbvMidmZREit7c=",
+        "lastModified": 1737924095,
+        "narHash": "sha256-9RO/IlxiE7bpY7GYsdDMNB533PnDOBo9UvYyXXqlN4c=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "836908e3bddd837ae0f13e215dd48767aee355f0",
+        "rev": "5efc9c966bb9bdad07a3c28667eac38b758c6f18",
         "type": "github"
       },
       "original": {
@@ -425,11 +425,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736154270,
-        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "lastModified": 1738070913,
+        "narHash": "sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`c75e4ea3`](https://github.com/nix-community/nixvim/commit/c75e4ea37f25ec98aa6f2035e03e748e7369662c) | `` plugins/lean: migrate to mkNeovimPlugin ``                                                    |
| [`0e92aaf3`](https://github.com/nix-community/nixvim/commit/0e92aaf3f2f0c1b6789a408584486ff4f03abde9) | `` plugins/blink-cmp: support raw lua for settings.sources.providers.enabled ``                  |
| [`a2f01876`](https://github.com/nix-community/nixvim/commit/a2f01876f721d3361f33845397de77ca19e5734a) | `` lib: Harmonize package options which may not exist in nixpkgs ``                              |
| [`eb611349`](https://github.com/nix-community/nixvim/commit/eb611349a70df9f87001752aa7c49e9672099415) | `` flake.lock: Update ``                                                                         |
| [`93df574b`](https://github.com/nix-community/nixvim/commit/93df574b42928d631d31fe312cadb3899eb5b1bd) | `` ci/update: fix create pr step not having `$pr_num` ``                                         |
| [`7f5dc96b`](https://github.com/nix-community/nixvim/commit/7f5dc96b83e915e84029c0dc6ce4e2c4e59a9cad) | `` ci/update: re-apply manual commits from open PR ``                                            |
| [`f9904d22`](https://github.com/nix-community/nixvim/commit/f9904d22df5a15d280bd6313bcec6259097a8a9c) | `` ci/update: don't request review on the PR ``                                                  |
| [`f0282018`](https://github.com/nix-community/nixvim/commit/f028201847f771802c3b6fe574beb9d0b854c91a) | `` ci/update: don't assign a team to the PR ``                                                   |
| [`8bf206eb`](https://github.com/nix-community/nixvim/commit/8bf206eb751ba33daf0f62b7c782e3f90ec19295) | `` ci/update: drop dependency on peter-evans/create-pull-request ``                              |
| [`e4ed227f`](https://github.com/nix-community/nixvim/commit/e4ed227f99be42cd0ce28b6ae0c85c306ef70d40) | `` plugins/gitsigns: remove deprecated option 'show_deleted' ``                                  |
| [`d997bec0`](https://github.com/nix-community/nixvim/commit/d997bec044b0c13440e4fd4354917b91207db69d) | `` plugins/lsp: add oxlint package ``                                                            |
| [`d9c8897c`](https://github.com/nix-community/nixvim/commit/d9c8897cbc7330c77a12b4ba4cbf4012cd03f6cb) | `` generated: Updated lspconfig-servers.json ``                                                  |
| [`8efa326c`](https://github.com/nix-community/nixvim/commit/8efa326c74c41e67f1635304bcd81e17a4adec71) | `` flake.lock: Update ``                                                                         |
| [`bffee37f`](https://github.com/nix-community/nixvim/commit/bffee37f57dc6e3b04ed574f8dc2aaf9dc9769b8) | `` ci/update: use `if then else` for setting `cancelled` step output ``                          |
| [`f584d1d7`](https://github.com/nix-community/nixvim/commit/f584d1d70d36cd29d45abce91776f8425398a97f) | `` docs/mdbook: support `visible = "shallow"` ``                                                 |
| [`2f5374c3`](https://github.com/nix-community/nixvim/commit/2f5374c3dcd06c750c36798bce6bccdf8a25bc89) | `` plugins/lexima: init ``                                                                       |
| [`1a5f1b43`](https://github.com/nix-community/nixvim/commit/1a5f1b43930807e1faa30c6fba814f8f2cfa3c37) | `` lib/plugins: introduce `mkMetaModule` ``                                                      |
| [`e908e344`](https://github.com/nix-community/nixvim/commit/e908e344f4cd7b3eb629b93e8af312888f3ee681) | `` treewide: use boolean comparison to simplify the code base ``                                 |
| [`5066c715`](https://github.com/nix-community/nixvim/commit/5066c71549b17042dfdbbf0faae07688c971cdae) | `` misc/statix: disable the "bool_comparison" lint ``                                            |
| [`d4170423`](https://github.com/nix-community/nixvim/commit/d41704233a8d863843590571dda386b15ade1e27) | `` misc: delete useless statix.toml config file ``                                               |
| [`ce82e585`](https://github.com/nix-community/nixvim/commit/ce82e5859d8f5cdc72e5b4137c5355efec16450a) | `` treewide: use mkAssertions where possible ``                                                  |
| [`12e658ec`](https://github.com/nix-community/nixvim/commit/12e658eca85e149a23d55ec48078367928c4c544) | `` treewide: use mkWarnings where possible ``                                                    |
| [`abba4af1`](https://github.com/nix-community/nixvim/commit/abba4af10b52ed7f9c02b615dfab487e24a52db3) | `` lib/utils: fix typo in example of mkAssertions ``                                             |
| [`eeafe2a7`](https://github.com/nix-community/nixvim/commit/eeafe2a7153197982ccd6ad6678192bca1df446e) | `` plugins/zotcite: init ``                                                                      |
| [`b6c0cfab`](https://github.com/nix-community/nixvim/commit/b6c0cfab819e351b230fe0ac019e7735e88a53c5) | `` plugins/zotcite: init ``                                                                      |
| [`818c2906`](https://github.com/nix-community/nixvim/commit/818c2906e9a51082da7f2ec70565702d622c2987) | `` ci/update: cleanup summary step ``                                                            |
| [`62a0dfbe`](https://github.com/nix-community/nixvim/commit/62a0dfbe5dceddc6901a71f9b7ad1712279ac8f9) | `` ci/update: cancel gracefully ``                                                               |
| [`4652e38e`](https://github.com/nix-community/nixvim/commit/4652e38ee679c90f484e46d1bdd22831329a6863) | `` ci/update: add input checkbox for checking `nixpkgs` was bumped ``                            |
| [`c3d95240`](https://github.com/nix-community/nixvim/commit/c3d95240c46f36a71fe6d15f74da4a2a11cf94e1) | `` ci/update: check against base branch if no PR is open ``                                      |
| [`635adc07`](https://github.com/nix-community/nixvim/commit/635adc07fa3c09c0c9aa9e43ebb0874abe002292) | `` flake.lock: Update ``                                                                         |
| [`a64048e9`](https://github.com/nix-community/nixvim/commit/a64048e9f5f323c9bc5de29e759ff0531a114604) | `` Fix: example of plugins.bufferline.settings.options.get_element_icon used a wrong variable `` |
| [`8b09c4a8`](https://github.com/nix-community/nixvim/commit/8b09c4a8294f520deec07597864cc4d87a0fd4aa) | `` plugins/clangd-extensions: remove inlay_hints option ``                                       |
| [`af4483c0`](https://github.com/nix-community/nixvim/commit/af4483c025ecf02ba36b2013eed0062ccd629809) | `` docs/lazy-loading: add extra examples ``                                                      |
| [`a879adb2`](https://github.com/nix-community/nixvim/commit/a879adb2088d3b20819782a818bf609c7373744b) | `` dev/list-plugins: fix dap state ``                                                            |
| [`32aa73af`](https://github.com/nix-community/nixvim/commit/32aa73af4742dce6532abe7a181370290fe8a727) | `` plugins/dap-virtual-text: migrate to mkNeovimPlugin ``                                        |
| [`9eae5db2`](https://github.com/nix-community/nixvim/commit/9eae5db29abfbe1f737ad635519b010216f3af92) | `` plugins/dap-ui: migrate to mkNeovimPlugin ``                                                  |
| [`a70168e0`](https://github.com/nix-community/nixvim/commit/a70168e0faa9648a8ac7785fd4f422aeff770617) | `` plugins/dap-python: migrate to mkNeovimPlugin ``                                              |
| [`6ff71272`](https://github.com/nix-community/nixvim/commit/6ff71272915b99218de615ad25fce33d10c79b84) | `` plugins/dap-go: migrate to mkNeovimPlugin ``                                                  |
| [`4d1bd375`](https://github.com/nix-community/nixvim/commit/4d1bd375c7b2d69a05e12d9d41629da09ffaefa8) | `` plugins/dap: migrate to mkNeovimPlugin ``                                                     |
| [`216ae2bf`](https://github.com/nix-community/nixvim/commit/216ae2bf40777d907953ae8d273268e615f2a7ea) | `` plugins/dap: remove helpers ``                                                                |
| [`e48dda4f`](https://github.com/nix-community/nixvim/commit/e48dda4fe4ae7ac22ba718467202f5785a7ee2fc) | `` plugins/dap: remove with lib ``                                                               |
| [`fe2789e4`](https://github.com/nix-community/nixvim/commit/fe2789e40730039cba4e5f3e9770fc48d254adb8) | `` flake.lock: Update ``                                                                         |
| [`8e5422bf`](https://github.com/nix-community/nixvim/commit/8e5422bf3e76f410b97d2da640d0829e87657de9) | `` plugins/base16: fix packPathName ``                                                           |
| [`63d9bb0d`](https://github.com/nix-community/nixvim/commit/63d9bb0d774f548261effa290c5d4456352f0637) | `` plugins/lsp: mark typst_lsp as unpackaged as the package has been removed from nixpkgs ``     |
| [`97a58e94`](https://github.com/nix-community/nixvim/commit/97a58e944782a8717180090fee29cdb4f9426c2b) | `` flake.lock: Update ``                                                                         |
| [`d7df5832`](https://github.com/nix-community/nixvim/commit/d7df58321110d3b0e12a829bbd110db31ccd34b1) | `` docs: eval modules without access to `pkgs` ``                                                |
| [`0b4a4e83`](https://github.com/nix-community/nixvim/commit/0b4a4e83277de46b39c4c80d01e11f980d2d9a55) | `` docs: don't set `allowUnfree` ``                                                              |
| [`796ace65`](https://github.com/nix-community/nixvim/commit/796ace65f71755fab62e9a316341e6a72c5e8961) | `` plugins/lsp: set a `defaultText` for `cmd` ``                                                 |
| [`88652ce6`](https://github.com/nix-community/nixvim/commit/88652ce69a9ced055eb9998db484e9bb8a9acf30) | `` plugins/efmls: package option defaultText should not depend on pkgs ``                        |
| [`09733a55`](https://github.com/nix-community/nixvim/commit/09733a5539e9e57ebc3ac5c945e03cf0e108f1bf) | `` plugins/fzf-lua: use `literalExpression` for `keymaps` example ``                             |
| [`1c137a73`](https://github.com/nix-community/nixvim/commit/1c137a73f08d5f1a59e8ceb6aa4c12e5e4b7acef) | `` plugins/clipboard-image: use `mkPackageOption` for `clipboardPackage` ``                      |
| [`dbcdff7b`](https://github.com/nix-community/nixvim/commit/dbcdff7bbb101bbb8cc1cb16630f80e71ac5947b) | `` plugins/copilot-vim: set `defaultText` for `node_command` ``                                  |
| [`758bdd8d`](https://github.com/nix-community/nixvim/commit/758bdd8dd112dda7fbe6d0a12fc75c7b85613189) | `` plugins/codeium-vim: set `defaultText` for `bin` ``                                           |
| [`0d230038`](https://github.com/nix-community/nixvim/commit/0d23003878d2df87647667e96450bfc39b102c21) | `` plugins/dap-python: set `defaultText` for `adapterPythonPath` ``                              |
| [`30c2292b`](https://github.com/nix-community/nixvim/commit/30c2292b293e31f419ea52a715abe21ac21e6873) | `` ci/update-other: use a job matrix ``                                                          |
| [`5121c309`](https://github.com/nix-community/nixvim/commit/5121c309b37ab2c8d884d18711d53fc7bda8ff77) | `` ci/update-other: remove redundant condition ``                                                |
| [`91e2e6fa`](https://github.com/nix-community/nixvim/commit/91e2e6fa032ad4906c2e48c06d96474a08f3f94f) | `` ci/update-other: pass `--repo` to `gh` ``                                                     |
| [`4751cb55`](https://github.com/nix-community/nixvim/commit/4751cb55f745150152d6e4999f99f297007b8352) | `` docs/user-guide: Add an entry for collisions with combinePlugins ``                           |
| [`086c154c`](https://github.com/nix-community/nixvim/commit/086c154cc0ad7bca758b656f5fef7362a61d59ec) | `` generated: Updated rust-analyzer.nix ``                                                       |
| [`ea02d3e1`](https://github.com/nix-community/nixvim/commit/ea02d3e187a5c988c79f28d7935a82ee2cef9af2) | `` flake.lock: Update ``                                                                         |
| [`5fda6e09`](https://github.com/nix-community/nixvim/commit/5fda6e093da13f37c63a5577888a668c38f30dc7) | `` ci/update: slightly cleanup cancellation summary ``                                           |
| [`0b6be867`](https://github.com/nix-community/nixvim/commit/0b6be867566ae79aaac4e1a05202765868cafcad) | `` ci/update: fix graphql formatting ``                                                          |
| [`f4ba4422`](https://github.com/nix-community/nixvim/commit/f4ba44225e661323e61fa4b2c92ca0547477951e) | `` ci/update: slightly simplify jq query ``                                                      |
| [`bd3184f4`](https://github.com/nix-community/nixvim/commit/bd3184f4957d5484bb5ebef4b9bc6f9cc53cfad5) | `` ci/update: check whether a PR is already open ``                                              |
| [`16f92ff8`](https://github.com/nix-community/nixvim/commit/16f92ff8a6fe3681a8286e377054296c585935f4) | `` plugins/gx: init ``                                                                           |
| [`683e5ea4`](https://github.com/nix-community/nixvim/commit/683e5ea4b52092aa5318b5a2f0aec70681831636) | `` flake.lock: Update ``                                                                         |
| [`c7a600c3`](https://github.com/nix-community/nixvim/commit/c7a600c3f3878f3c60b03b2f68c2080c742793e8) | `` plugins/git-worktree: migrate to mkNeovimPlugin ``                                            |
| [`4ae6136d`](https://github.com/nix-community/nixvim/commit/4ae6136d12e16990b07ba262c961ae994d9afed7) | `` plugins/git-worktree: remove helpers ``                                                       |
| [`7dd96842`](https://github.com/nix-community/nixvim/commit/7dd9684264a9ced32c01684f16be841d48cb2e7d) | `` plugins/git-worktree: remove with lib ``                                                      |
| [`ff7570d7`](https://github.com/nix-community/nixvim/commit/ff7570d781f7ccd5a611008246ffa36627c9341e) | `` plugins/markdown-preview: move deprecations to separate file ``                               |
| [`c269e1b9`](https://github.com/nix-community/nixvim/commit/c269e1b9670dbd8166152a9208e1e02ecbc8ccc4) | `` plugins/markdown-preview: remove helpers ``                                                   |
| [`c0dda6cf`](https://github.com/nix-community/nixvim/commit/c0dda6cf49b1582838a864fdf667fc4d2bbc35b3) | `` plugins/markdown-preview: remove with lib ``                                                  |
| [`aab2b817`](https://github.com/nix-community/nixvim/commit/aab2b81792567237c104b90c3936e073d28a9ac6) | `` plugins/git-conflict: fix packPath name ``                                                    |
| [`32bf82eb`](https://github.com/nix-community/nixvim/commit/32bf82ebe8d4469c17f3c55a4226498f7d1abe82) | `` flake.lock: Update ``                                                                         |
| [`e22bb46c`](https://github.com/nix-community/nixvim/commit/e22bb46c8863c30a791a4183aa9013d542cc5be5) | `` plugins/quicker: init ``                                                                      |
| [`85bef9e1`](https://github.com/nix-community/nixvim/commit/85bef9e19191000db4a13337198266359cefb9b6) | `` ci/update: fix `getFlake` expecting an absolute path ``                                       |
| [`7dc67410`](https://github.com/nix-community/nixvim/commit/7dc67410bbfa82d7650b80401219f864fa077542) | `` ci/update: cancel scheduled runs that don't bump nixpkgs ``                                   |
| [`a2a4befd`](https://github.com/nix-community/nixvim/commit/a2a4befdaf825d36a50e2fda4a004682ea6b1a22) | `` ci/update: cleanup names & comments ``                                                        |
| [`6046ad79`](https://github.com/nix-community/nixvim/commit/6046ad79f0f83c828a4edde5b3c4594a4bbcd002) | `` ci/update: schedule main branch daily, other branches weekly ``                               |
| [`5bd71b24`](https://github.com/nix-community/nixvim/commit/5bd71b247437156df7e644d2f959bdf83fa1dceb) | `` Revert "[TO-REVERT] tests: disable failing-tests" ``                                          |
| [`e7d827bb`](https://github.com/nix-community/nixvim/commit/e7d827bb321ad26a4562757c2e3adffc256f7f39) | `` flake.nix: follow nixpkgs-unstable instead of nixos-unstable ``                               |
| [`31b0e360`](https://github.com/nix-community/nixvim/commit/31b0e36087e939844d6e5f0f332389b4094d124a) | `` [TO-REVERT] tests: disable failing-tests ``                                                   |
| [`e935f7a4`](https://github.com/nix-community/nixvim/commit/e935f7a4076cf15d890ffe15b5c1f8b00c76a8a9) | `` plugins/none-ls: update packages ``                                                           |
| [`c289e10a`](https://github.com/nix-community/nixvim/commit/c289e10a0f09846c053511c66a53ce9e2e1e25b3) | `` plugins/lsp: update packages ``                                                               |
| [`89260014`](https://github.com/nix-community/nixvim/commit/89260014265da20c325b78ee466da241da189f4b) | `` tests/lsp-servers: disable bitbake_language_server (build failure) ``                         |
| [`5a980d02`](https://github.com/nix-community/nixvim/commit/5a980d02fad353fa9850222f80ff0dc28acd7be8) | `` plugins/lsp: add atlas and cue ``                                                             |
| [`24144954`](https://github.com/nix-community/nixvim/commit/241449544992e7c62b8271310ee5a6deaa1188fb) | `` generated: Updated none-ls.nix ``                                                             |
| [`9b6c15e4`](https://github.com/nix-community/nixvim/commit/9b6c15e41e3bdeaa542ad4bd7fca4c237e36edf6) | `` generated: Updated lspconfig-servers.json ``                                                  |
| [`7f27c464`](https://github.com/nix-community/nixvim/commit/7f27c464a654c07ca50ef76cad0195801f55eb85) | `` flake.lock: Update ``                                                                         |
| [`e60ea678`](https://github.com/nix-community/nixvim/commit/e60ea678ac9a4154b641fdaacf03c600d1c661d8) | `` plugins/emmet: cosmetic refactoring ``                                                        |
| [`342161bf`](https://github.com/nix-community/nixvim/commit/342161bf525dd64eb53fea295a2180f71ed06de1) | `` templates: add experimental-flake-parts template ``                                           |
| [`e3938e94`](https://github.com/nix-community/nixvim/commit/e3938e9464c2f860bfe303dd986243880c0b4075) | `` templates: inherit `checks` from _all_ templates ``                                           |
| [`53bfadc2`](https://github.com/nix-community/nixvim/commit/53bfadc2c2a6cdc12b8f8cf5b4e24701e213cb34) | `` lib/modules: work-around a submodule type-merging issue ``                                    |
| [`77c78bd0`](https://github.com/nix-community/nixvim/commit/77c78bd04e6a1f600d5ce94c869e11b44cee1b7d) | `` tests/platforms: move out of flake `wrappers` module ``                                       |
| [`115994f1`](https://github.com/nix-community/nixvim/commit/115994f18e439a1cca9cdaaf15c004870256814d) | `` flake/auto: `nameFunction` default to `lib.id` ``                                             |
| [`780d3eec`](https://github.com/nix-community/nixvim/commit/780d3eec7209c7a08a585f5b680ed359ed68e62c) | `` wrappers/standalone: simplify `extend` ``                                                     |
| [`00586f8f`](https://github.com/nix-community/nixvim/commit/00586f8f1b9880db79e9304a9415e157f3d5a9be) | `` modules/output: move `symlinkJoin` to `build.package` ``                                      |
| [`731699a2`](https://github.com/nix-community/nixvim/commit/731699a24c9a6400aebba179c0156be14b5ec217) | `` plugins/gitsigns: cosmetic refactoring ``                                                     |
| [`af6e4b0b`](https://github.com/nix-community/nixvim/commit/af6e4b0bad72e8bbdcafc4dd7655539e4aa5c557) | `` treewide: use mkAssertions wherever possible ``                                               |
| [`a7e516b3`](https://github.com/nix-community/nixvim/commit/a7e516b322fbdbe62ad15ea3d0cd3d82f21c42a3) | `` lib/utils: add mkAssertions ``                                                                |
| [`60adb6c5`](https://github.com/nix-community/nixvim/commit/60adb6c56b9153d73e6275321017eaf19f0be424) | `` treewide: use mkWarnings wherever possible ``                                                 |
| [`2ec6218f`](https://github.com/nix-community/nixvim/commit/2ec6218f87a7ddeaa1887424d5883b3d0d9b3a23) | `` treewide: use mkWarnings wherever possible ``                                                 |
| [`02e16b2a`](https://github.com/nix-community/nixvim/commit/02e16b2a761f79058d3635d50579edb41cf6f46c) | `` lib/utils: add mkWarnings ``                                                                  |
| [`1036b8f8`](https://github.com/nix-community/nixvim/commit/1036b8f8b6c2983b03849f7ded79865eb457ddc7) | `` ci/update: remove nixos-24.05 update action ``                                                |
| [`a70b1697`](https://github.com/nix-community/nixvim/commit/a70b16976bac7d5baf5ce735ac7d0f9db1641d7d) | `` lib: export `evalNixvim` as top-level alias ``                                                |
| [`e793c5cd`](https://github.com/nix-community/nixvim/commit/e793c5cdc608cfe998319cff56b99a73a70f33f8) | `` flake: add `auto` flake-parts module ``                                                       |
| [`8fb2fe22`](https://github.com/nix-community/nixvim/commit/8fb2fe22c237b25b8af346870e126fdaeaff688b) | `` flake: add `nixvimModules` flake-parts module ``                                              |
| [`5426c9dd`](https://github.com/nix-community/nixvim/commit/5426c9dd83151c39fd8ad88f69b2b3fad40f8a38) | `` flake: add `nixvimConfigurations` flake-parts module ``                                       |
| [`9aa6d0f6`](https://github.com/nix-community/nixvim/commit/9aa6d0f6e62d9a179d20bcb364917eb30bb52adf) | `` flake: add initial flake-parts module ``                                                      |
| [`1654f97a`](https://github.com/nix-community/nixvim/commit/1654f97a79455efe9e578c5b70243e8333b126eb) | `` docs: use README as a source for the docs ``                                                  |
| [`ab693bb1`](https://github.com/nix-community/nixvim/commit/ab693bb1cd63d83e6a4653715f2475a45789246c) | `` plugins/vim-suda: add back the smart_edit option ``                                           |
| [`85e4e16d`](https://github.com/nix-community/nixvim/commit/85e4e16de8690eedd136c59900771991e77951ee) | `` docs: notify `useGlobalPackages` breaking change ``                                           |
| [`82415eaa`](https://github.com/nix-community/nixvim/commit/82415eaa5d0f3e71e7fcbc0b4038aef1220737f0) | `` modules/nixpkgs: warn about changing defaults ``                                              |
| [`3a22953b`](https://github.com/nix-community/nixvim/commit/3a22953bea77bf3b8f6559de0c55838cd5fc76bc) | `` modules/nixpkgs: `useGlobalPackages` default to false ``                                      |
| [`fecc8921`](https://github.com/nix-community/nixvim/commit/fecc8921459578c32eb371341c2c14e3c70424ba) | `` flake: remove `pkgsUnfree` arg ``                                                             |
| [`998bae9d`](https://github.com/nix-community/nixvim/commit/998bae9daceeb9bcad8126a3c4d159d9a677ba2c) | `` flake-modules -> flake ``                                                                     |
| [`cf647bc0`](https://github.com/nix-community/nixvim/commit/cf647bc045567f27e9c5eabaa26111b4c7bbc169) | `` ci: drop 24.05 support ``                                                                     |
| [`cbf960e5`](https://github.com/nix-community/nixvim/commit/cbf960e5659054b2ccf27b67218782e69016bef5) | `` plugins/flutter-tools: update options ``                                                      |
| [`4f2d78fc`](https://github.com/nix-community/nixvim/commit/4f2d78fcaf3550c1f5d98f2f8af78a2011e5354e) | `` plugins/flutter-tools: update settingsExample ``                                              |
| [`a1b44cfd`](https://github.com/nix-community/nixvim/commit/a1b44cfdf48019d69713328ac28e12c1789ef21c) | `` templates: remove `_wrapper` ``                                                               |
| [`aa839cf9`](https://github.com/nix-community/nixvim/commit/aa839cf994f6b9a6b38e755597452087beac0567) | `` generated: Update rust-analyzer options ``                                                    |
| [`d63ac3eb`](https://github.com/nix-community/nixvim/commit/d63ac3eb39161a63a14f54f0be388a9f082a1af3) | `` update-scripts: Handle missing descriptions for enums ``                                      |
| [`674790db`](https://github.com/nix-community/nixvim/commit/674790dbf90166ef9c9cb9e55bae967e4956fcd9) | `` update-scripts: Correctly handle propreties without a 'type' ``                               |
| [`8e9458ea`](https://github.com/nix-community/nixvim/commit/8e9458eacfbe54b0b9b9f31d24c041236cfaba9a) | `` update-scripts: Add more verbose errors for rust-analyzer ``                                  |
| [`e4484133`](https://github.com/nix-community/nixvim/commit/e4484133d662ca7cd0f4e15c35100330ddf5d8d0) | `` docs/user-guide: slightly simplify lib-overlay example ``                                     |
| [`51474292`](https://github.com/nix-community/nixvim/commit/51474292cd0c5ace056a0b26df6c38e997338399) | `` modules/nixpkgs: remove `pkgs` default text ``                                                |
| [`3172e48d`](https://github.com/nix-community/nixvim/commit/3172e48dbbc1f98020894afa3027811ace46508b) | `` lib/tests: simplify access to default `system` ``                                             |
| [`9bf4c9d5`](https://github.com/nix-community/nixvim/commit/9bf4c9d55b4fad12dae8f6dfea7d3d43f0a92513) | `` wrappers/standalone: make `pkgs` arg optional, allow specifying `system` ``                   |
| [`8c6f9ed8`](https://github.com/nix-community/nixvim/commit/8c6f9ed8c45576a3dc26e32f341b2ff8aebb0824) | `` lib/modules: allow specifying `system` as an `evalNixvim` arg ``                              |
| [`7790746d`](https://github.com/nix-community/nixvim/commit/7790746d38856872ecaa1b8e69f18044d9a16031) | `` modules/nixpkgs: add `useGlobalPackages` option ``                                            |
| [`912841c1`](https://github.com/nix-community/nixvim/commit/912841c1a766271cbf6604f3ced44b080474951c) | `` modules/nixpkgs: construct an instance of `nixpkgs.source` ``                                 |
| [`8dc8fa38`](https://github.com/nix-community/nixvim/commit/8dc8fa38b0d17953d0d760d3ac267e154f7b1497) | `` modules/nixpkgs: add `hostPlatform` & `buildPlatform` options ``                              |
| [`5bd04ce0`](https://github.com/nix-community/nixvim/commit/5bd04ce09a0cef1d90ef5a22c481645f80ed9b5e) | `` modules/nixpkgs: add `config` option ``                                                       |
| [`2d68ef84`](https://github.com/nix-community/nixvim/commit/2d68ef843a98aad059c037c13e69e940601de0bf) | `` flake.lock: Update ``                                                                         |
| [`30842191`](https://github.com/nix-community/nixvim/commit/30842191e030f4110d8dc12b668d4734f55f9c1f) | `` docs: enable `warningsAreErrors` ``                                                           |
| [`c19daee4`](https://github.com/nix-community/nixvim/commit/c19daee4534833b364f101c147a93c22d688c9a4) | `` docs/user-guide: document nixvim's lib overlay ``                                             |
| [`b28ebf25`](https://github.com/nix-community/nixvim/commit/b28ebf253592eaf97516a7bcfd231d7d76a5608e) | `` docs/user-guide: add sub-headings to `helpers.md` ``                                          |
| [`ff29c977`](https://github.com/nix-community/nixvim/commit/ff29c977236a0cd1ccd4144d4eab8ef2333e079d) | `` modules/test: provide access to `expect` function ``                                          |
| [`16662760`](https://github.com/nix-community/nixvim/commit/16662760a92d777ef73d3b54e507455bc66dc114) | `` lib/modules: specify `modulesPath` ``                                                         |
| [`b5efe91c`](https://github.com/nix-community/nixvim/commit/b5efe91c5215aaaeefbb117d1951ea773e96ddd1) | `` lib/modules: remove explicit `specialArgs.lib` ``                                             |
| [`d4c67764`](https://github.com/nix-community/nixvim/commit/d4c67764a7d4e5dbda611933005560cc5bfcfb3f) | `` tests/nixpkgs-module: only import the minimal modules for test ``                             |
| [`e13b2a51`](https://github.com/nix-community/nixvim/commit/e13b2a51296cccc6bc975ab2dbd6a4e2c2b60efc) | `` tests/nixpkgs-module: split up helper fn ``                                                   |
| [`5192a85f`](https://github.com/nix-community/nixvim/commit/5192a85f3224cd2ef49da53162c0138823afd4e9) | `` test/nixpkgs-module: use a fixed `runCommand` function ``                                     |
| [`7854d5f1`](https://github.com/nix-community/nixvim/commit/7854d5f18c750eb7b2df3d3511eb17224ec0e835) | `` modules/test: fix expectations `lib.toJSON` -> `builtins.toJSON` ``                           |
| [`5b068e7f`](https://github.com/nix-community/nixvim/commit/5b068e7f8f2b6beaa1fafe0c8b3604b63bcccc2d) | `` tests/nixpkgs: move nixpkgs module test to dedicated drv ``                                   |
| [`54e6dbd8`](https://github.com/nix-community/nixvim/commit/54e6dbd8c83586d9553f61c21fa639b500e51f93) | `` user-configs: add Yohh's configuration ``                                                     |
| [`33ad2c72`](https://github.com/nix-community/nixvim/commit/33ad2c729dd9b629b0d49ce8ebb4b466105c315c) | `` plugins/flutter-tools: add warnings for dap integration ``                                    |
| [`d9c4e154`](https://github.com/nix-community/nixvim/commit/d9c4e154a8279de9e5ff37c4b40e28a1d496dc7c) | `` plugins/flutter-tools: add flutterPackageOption ``                                            |