### PR TITLE
chore(flake/pre-commit-hooks): `a5a96138` -> `9364dc02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -359,11 +359,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735882644,
-        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`9364dc02`](https://github.com/cachix/git-hooks.nix/commit/9364dc02281ce2d37a1f55b6e51f7c0f65a75f17) | `` feat: Change `terraform-format` to support both Terraform and OpenTofu packages (#419) `` |
| [`b24ef710`](https://github.com/cachix/git-hooks.nix/commit/b24ef710754ce68f2aa56e594e4d36419944ea30) | `` check: set HOME to a tmp dir to avoid polluting the working dir ``                        |
| [`46171f0a`](https://github.com/cachix/git-hooks.nix/commit/46171f0a3611501c72e0380e399af1bbb891d8d5) | `` hooks: add note for flake-based projects using paths ``                                   |
| [`baf942ec`](https://github.com/cachix/git-hooks.nix/commit/baf942ec75b17c77f02413a96ad61426a896e18a) | `` hooks: add examples ``                                                                    |
| [`bad35860`](https://github.com/cachix/git-hooks.nix/commit/bad358603b4ac83bb48840cb310dcf4138bf3793) | `` hooks: allow strings for path-based options ``                                            |
| [`586b2df6`](https://github.com/cachix/git-hooks.nix/commit/586b2df6cb6f63947fefee7d12af4e8358cfdda4) | `` docs: add `trufflehog` entry ``                                                           |