### PR TITLE
chore(flake/nixpkgs): `9abb87b5` -> `9d3ae807`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -273,11 +273,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736798957,
-        "narHash": "sha256-qwpCtZhSsSNQtK4xYGzMiyEDhkNzOCz/Vfu4oL2ETsQ=",
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9abb87b552b7f55ac8916b6fc9e5cb486656a2f3",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`200775eb`](https://github.com/NixOS/nixpkgs/commit/200775eb115347c6b66fa10c666436eabb1f41d2) | `` clock-rs: init at 0.1.213 ``                                                          |
| [`e1dd5d5b`](https://github.com/NixOS/nixpkgs/commit/e1dd5d5b1f98fa3f7cbf729265accfd8f2c7fcb1) | `` sdcc: 4.4.0 -> 4.5.0 ``                                                               |
| [`11c8e6ae`](https://github.com/NixOS/nixpkgs/commit/11c8e6aebf3a42be1f824200c98250b00f854814) | `` can-utils: 2023.03 -> 2025.01 ``                                                      |
| [`917754ea`](https://github.com/NixOS/nixpkgs/commit/917754eaa5825c0590a59f99923cad662c2beabd) | `` waypipe: 0.10.1 -> 0.10.2 ``                                                          |
| [`74942708`](https://github.com/NixOS/nixpkgs/commit/74942708f6f41920d6c43dd05eb772056afb4263) | `` python312Packages.llama-cpp-python: adding new maintainer (@booxter) ``               |
| [`2c7e15d8`](https://github.com/NixOS/nixpkgs/commit/2c7e15d81795e08b156fb64f3c455835d4c5c86e) | `` batmon: enable useFetchCargoVendor ``                                                 |
| [`443cb1ec`](https://github.com/NixOS/nixpkgs/commit/443cb1ec56d8188f1249ad18656aee6d9dc5021f) | `` python312Packages.llama-cpp-python: fix linux build ``                                |
| [`09df97d7`](https://github.com/NixOS/nixpkgs/commit/09df97d71ac9a72291981fe95f60cd0091e4715c) | `` python312Packages.skops: 0.10 -> 0.11.0 ``                                            |
| [`de0e0b0b`](https://github.com/NixOS/nixpkgs/commit/de0e0b0b62b714b444f232bb384fe3950b3a0ca4) | `` hyprland-qtutils: 0.1.2 -> 0.1.3 ``                                                   |
| [`c15f5066`](https://github.com/NixOS/nixpkgs/commit/c15f50665dbec6842829ee674784472b816c1ec6) | `` home-assistant-custom-lovelace-modules.bubble-card: 2.3.4 -> 2.4.0 ``                 |
| [`571525c8`](https://github.com/NixOS/nixpkgs/commit/571525c839920ec97471b7161564ca8cc28a2e17) | `` tiled: 1.11.1 -> 1.11.2 ``                                                            |
| [`7d0d02fc`](https://github.com/NixOS/nixpkgs/commit/7d0d02fc3b5e73881a214e9b97a01046556c8fa2) | `` nodePackages.@commitlint/config-conventional: drop ``                                 |
| [`8fc82970`](https://github.com/NixOS/nixpkgs/commit/8fc82970a826f9bc2ed79a4d0a1f9159af11d2d7) | `` frankenphp: 1.4.1 -> 1.4.2 ``                                                         |
| [`69a71b72`](https://github.com/NixOS/nixpkgs/commit/69a71b724db4bff6e9c3c8a14512c6663b150ba4) | `` libspelling: 0.4.5 → 0.4.6 ``                                                         |
| [`c4a47d4f`](https://github.com/NixOS/nixpkgs/commit/c4a47d4f9460996f7bd2291661505bd1348bd146) | `` gnome-terminal: 3.54.2 → 3.54.3 ``                                                    |
| [`2f41b5ee`](https://github.com/NixOS/nixpkgs/commit/2f41b5ee5cd43731ca72a5b4fbecfa2948f9fcd7) | `` vte: 0.78.2 → 0.78.3 ``                                                               |
| [`5d9cba28`](https://github.com/NixOS/nixpkgs/commit/5d9cba2836d3ddd9739476a22f374891b11e377b) | `` xdg-desktop-portal-gnome: 47.1 → 47.2 ``                                              |
| [`1422fcac`](https://github.com/NixOS/nixpkgs/commit/1422fcac310e9974c6896bb4c37d093a66f5dbbe) | `` gupnp_1_6: 1.6.7 → 1.6.8 ``                                                           |
| [`1d37230a`](https://github.com/NixOS/nixpkgs/commit/1d37230a68ecd25babfce54bf549addb41171353) | `` c3-lsp: 0.3.3 -> 0.4.0 ``                                                             |
| [`41c93870`](https://github.com/NixOS/nixpkgs/commit/41c93870d07bc81849f942faaa86a8894174a109) | `` cirrus-cli: 0.134.0 -> 0.135.0 ``                                                     |
| [`2a70a906`](https://github.com/NixOS/nixpkgs/commit/2a70a906f6f3bb1ac41126d6a0c2095db1e32d10) | `` nezha-theme-nazhua: 0.5.1 -> 0.5.6 ``                                                 |
| [`d0ae116e`](https://github.com/NixOS/nixpkgs/commit/d0ae116eafef7444cd826bc92a57c1e4f9ac2805) | `` screen: remove unused configureFlags ``                                               |
| [`a2f04a39`](https://github.com/NixOS/nixpkgs/commit/a2f04a39ea91f9f79ef8c4b0280a6a94dc7860f5) | `` screen: fix darwin build ``                                                           |
| [`d5ea40e1`](https://github.com/NixOS/nixpkgs/commit/d5ea40e125589d37677f0d90b205152aade6ad79) | `` screen: mark as broken on darwin ``                                                   |
| [`dc0e094b`](https://github.com/NixOS/nixpkgs/commit/dc0e094b331a3a5cbdef44e5ea7a2b718e9f8680) | `` nixos/installer: replace substituteAll with replaceVarsWith for tools ``              |
| [`b9ea4817`](https://github.com/NixOS/nixpkgs/commit/b9ea4817840da216d258b37a7f1cc475d19ec861) | `` nixos/systemd-boot: replace substituteAll with replaceVarsWith ``                     |
| [`90ba4a93`](https://github.com/NixOS/nixpkgs/commit/90ba4a93ee4dc9cac852c589e50079421395aa2c) | `` vimPlugins: move non-github plugins to separate files ``                              |
| [`bb017341`](https://github.com/NixOS/nixpkgs/commit/bb0173418cb92402aa30f19c796974dd51e1afdc) | `` xdg-desktop-portal-hyprland: add debug flag ``                                        |
| [`aaea2a60`](https://github.com/NixOS/nixpkgs/commit/aaea2a60ae2ecc547dbf0dfcc0224089b7292044) | `` hyprsysteminfo: init at 0.1.3 ``                                                      |
| [`9b4e99d0`](https://github.com/NixOS/nixpkgs/commit/9b4e99d0ea079606e2dd798e896a044ead5867fd) | `` hyprpolkitagent: add missing hyprland-qt-support dependency ``                        |
| [`cc65975d`](https://github.com/NixOS/nixpkgs/commit/cc65975d47529d8cf91da44306d3b42746f2596b) | `` hyprland-qt-support: init at 0.1.0 ``                                                 |
| [`8c852617`](https://github.com/NixOS/nixpkgs/commit/8c852617ee6fc19f339bd4d16042fd3a533fea8d) | `` python312Packages.inference-gym: 0.0.4 -> 0.0.5 ``                                    |
| [`966c9e8a`](https://github.com/NixOS/nixpkgs/commit/966c9e8a21e24487dc9fbf065160fa79e0be388f) | `` home-assistant-custom-lovelace-modules.versatile-thermostat-ui-card: init at 1.1.2 `` |
| [`5555b70e`](https://github.com/NixOS/nixpkgs/commit/5555b70e3026e84dd0e166906eb8ca1e038749c6) | `` nixosTests.hound: migrate from 'config' to 'settings' ``                              |
| [`4460c6bf`](https://github.com/NixOS/nixpkgs/commit/4460c6bfe9e70be02d6119a930906c3bc723a7a4) | `` nixos/hound: add .json extension to the generated config file ``                      |
| [`56bfc578`](https://github.com/NixOS/nixpkgs/commit/56bfc5782d9c61b2c542abbfc08a38533fa18148) | `` nixos/hound: restart service on config changes ``                                     |
| [`402d9281`](https://github.com/NixOS/nixpkgs/commit/402d9281fe3a8f5daebb46056e99af891f49d634) | `` ddclient: 3.11.2 -> 4.0.0 ``                                                          |
| [`ad2b5133`](https://github.com/NixOS/nixpkgs/commit/ad2b51333ff27073d6a70ececde66bd7c229eef7) | `` waytrogen: use fetchCargoVendor ``                                                    |
| [`4a3faa5e`](https://github.com/NixOS/nixpkgs/commit/4a3faa5e86f524d955186f05a762b6bcec01cb94) | `` waytrogen: 0.5.8 -> 0.6.3 ``                                                          |
| [`030d5a06`](https://github.com/NixOS/nixpkgs/commit/030d5a061ffee620e0d9fc3b6c52a52531699c08) | `` maintainers: add nikolaizombie1 ``                                                    |
| [`1194a142`](https://github.com/NixOS/nixpkgs/commit/1194a142876a75e283d45ff329f51524c9bfa86c) | `` vital: add missing runtime dependency (#377598) ``                                    |
| [`ad936706`](https://github.com/NixOS/nixpkgs/commit/ad9367061b292f5b954ff4cd690686f77de2e22d) | `` treewide: adopt hypr ecosytem by Hyprland team ``                                     |
| [`dc06b9b4`](https://github.com/NixOS/nixpkgs/commit/dc06b9b4581a3b97fbddb35a986e795d94360879) | `` python312Packages.bindep: 2.11.0 -> 2.12.0 ``                                         |
| [`759b2dd8`](https://github.com/NixOS/nixpkgs/commit/759b2dd812b175c24b0ab7af1ccc847643a803f6) | `` oxipng: fix tests on aarch64-linux ``                                                 |
| [`2aeb61a7`](https://github.com/NixOS/nixpkgs/commit/2aeb61a7d8b277c3954064fb413ddae273477c69) | `` zed-editor: remove explicit stripDebugList ``                                         |
| [`e41b7ced`](https://github.com/NixOS/nixpkgs/commit/e41b7ced512507ba5cbffb7dcb918df9ab3f2417) | `` ut1999: fix Darwin build ``                                                           |
| [`9ea3d39e`](https://github.com/NixOS/nixpkgs/commit/9ea3d39e33b61301aa958ecf43fa968bd188134a) | `` xfce.xfdesktop: Backport monitor chooser UI resource path fix ``                      |
| [`f91eb562`](https://github.com/NixOS/nixpkgs/commit/f91eb5626d8674e3e9ee14d798dda1728f9d7cee) | `` team-list: create Hyprland team (#377573) ``                                          |
| [`ff911239`](https://github.com/NixOS/nixpkgs/commit/ff911239dfadbfcd58eec356bfc18e15bd542eae) | `` python312Packages.pcffont: 0.0.15 -> 0.0.16 ``                                        |
| [`2a93bd11`](https://github.com/NixOS/nixpkgs/commit/2a93bd11d9a318b9e6fd618e57081cc03c4d6043) | `` python312Packages.scrap-engine: 1.4.1 -> 1.4.2 ``                                     |
| [`af7b39ad`](https://github.com/NixOS/nixpkgs/commit/af7b39ad6eae1b9b82ce8ee51eb5bcea5cbeab8e) | `` paperless-ngx: disable flaky test ``                                                  |
| [`586285a3`](https://github.com/NixOS/nixpkgs/commit/586285a35618cbdb9aed4d5e90a2e6c00a70cd84) | `` netbird: disable shell completion generation when cross compiling (#377572) ``        |
| [`279c3ee6`](https://github.com/NixOS/nixpkgs/commit/279c3ee623fa110b359cfc6bba5a525471631f0d) | `` python312Packages.pcbnewtransition: 0.4.2 -> 0.5.0 ``                                 |
| [`71ec0e85`](https://github.com/NixOS/nixpkgs/commit/71ec0e85649a8530d80856cec59272250c9b77af) | `` immich: 1.125.3 -> 1.125.6 ``                                                         |
| [`a6f0d2df`](https://github.com/NixOS/nixpkgs/commit/a6f0d2df0ef68a8993350f40d32956aee378bbc0) | `` element-{desktop,web}: 1.11.89 -> 1.11.91 ``                                          |
| [`82824748`](https://github.com/NixOS/nixpkgs/commit/82824748ec9c92f81de68c2fe275265605d52e3d) | `` python312Packages.flux-led: 1.1.0 -> 1.1.3 ``                                         |
| [`93f86b0d`](https://github.com/NixOS/nixpkgs/commit/93f86b0dfebe49aadce23835ebd1448db9346f7f) | `` kanata: useFetchCargoVendor ``                                                        |
| [`3b7f0311`](https://github.com/NixOS/nixpkgs/commit/3b7f0311a5732aed4a17d939c52008820e849547) | `` team-list: add johnrtitor to android team ``                                          |
| [`e5c691f3`](https://github.com/NixOS/nixpkgs/commit/e5c691f343ae0094b23b8d24798df6e6873f56af) | `` vanguards: init at 0.3.1 ``                                                           |
| [`60a77c14`](https://github.com/NixOS/nixpkgs/commit/60a77c147e3670bd7a93a4041249217cc1fb5efd) | `` nimlangserver: 1.8.0 -> 1.8.1 ``                                                      |
| [`1b2902c8`](https://github.com/NixOS/nixpkgs/commit/1b2902c85cfd99c19e7b63580938dda66bde382d) | `` oauth2c: 1.17.1 -> 1.17.2 ``                                                          |
| [`14fb0b8c`](https://github.com/NixOS/nixpkgs/commit/14fb0b8cea8aeb6a9ff28655564f2440fc56c90b) | `` python312Packages.jupyter-server: disable failing test on x86_64-darwin ``            |
| [`5d3b0399`](https://github.com/NixOS/nixpkgs/commit/5d3b03992b1b4783b6cd6a60f4852dfa57f861a6) | `` minijinja: 2.6.0 -> 2.7.0 ``                                                          |
| [`ca64dcbe`](https://github.com/NixOS/nixpkgs/commit/ca64dcbeef3c78d3cd0ed183038ac539c70e89d7) | `` bacon: 3.9.0 -> 3.9.1 ``                                                              |
| [`6b80d2f0`](https://github.com/NixOS/nixpkgs/commit/6b80d2f0042fd0acc5a601cf824b3edfea408803) | `` polaris: useFetchCargoVendor ``                                                       |
| [`a5cfe1dc`](https://github.com/NixOS/nixpkgs/commit/a5cfe1dcfdae5aa45f72c00108194c35251f7648) | `` kanidm_1_3,kanidm_1_4: useFetchCargoVendor ``                                         |
| [`8e0f332b`](https://github.com/NixOS/nixpkgs/commit/8e0f332b430441694d50fdec5083ea9cbbb500e7) | `` darklua: 0.15.0 -> 0.16.0 ``                                                          |
| [`831c4b8a`](https://github.com/NixOS/nixpkgs/commit/831c4b8aeb99461b4e04e7733c66e55ebc16a696) | `` go-migrate: 4.18.1 -> 4.18.2 ``                                                       |
| [`860d3b8f`](https://github.com/NixOS/nixpkgs/commit/860d3b8fbe1c63739eb02803771a35010cfd3d16) | `` vimPlugins.LuaSnip-snippets-nvim: init at 2022-03-17 ``                               |
| [`87b4b848`](https://github.com/NixOS/nixpkgs/commit/87b4b84885e37c46b7fea4c15fd6c8e8808b995c) | `` slurm: make nvml configurable ``                                                      |
| [`6d3947dc`](https://github.com/NixOS/nixpkgs/commit/6d3947dc3e624c09e90c705b6a524d17a77a6be6) | `` vimPlugins.repolink-nvim: init at 2023-12-08 ``                                       |
| [`d4262f6c`](https://github.com/NixOS/nixpkgs/commit/d4262f6ce2ef501a44556ed1ac6c67a65fdb39b3) | `` mdbook-linkcheck: use fetchCargoVendor ``                                             |
| [`fd3338c8`](https://github.com/NixOS/nixpkgs/commit/fd3338c8bef5f7f9c2004e37cf784210605c641b) | `` mdbook: use fetchCargoVendor ``                                                       |
| [`f07977cf`](https://github.com/NixOS/nixpkgs/commit/f07977cfd2645273d6626f276bedf30755c053af) | `` rustPlatform.fetchCargoVendor: add allowGitDependencies ``                            |
| [`50d16c29`](https://github.com/NixOS/nixpkgs/commit/50d16c29d7d20dd784ca83ad45018e0dda59a3bb) | `` webmetro: remove ``                                                                   |
| [`a5fc7c25`](https://github.com/NixOS/nixpkgs/commit/a5fc7c2513f51944c40cda2f440b9250d1d5b79b) | `` void: remove ``                                                                       |
| [`40d30991`](https://github.com/NixOS/nixpkgs/commit/40d3099157256f6fa0933ccfd00ca8d4f0f82a38) | `` trunk-ng: useFetchCargoVendor ``                                                      |
| [`5d65de40`](https://github.com/NixOS/nixpkgs/commit/5d65de406e316f8b8b77627278202669d8b2bb62) | `` termplay: remove ``                                                                   |
| [`baae676b`](https://github.com/NixOS/nixpkgs/commit/baae676bf2da18661968af0d11799bdf26b06879) | `` immich-public-proxy: 1.6.2 -> 1.6.3 ``                                                |
| [`d563b8c3`](https://github.com/NixOS/nixpkgs/commit/d563b8c325c4234bceb94aa3ca0c8f09eac084ac) | `` vim: migrate homepage URL to https:// schema ``                                       |
| [`ad21af31`](https://github.com/NixOS/nixpkgs/commit/ad21af31297c73531073f4ba36c4db317dcb7767) | `` fum: 0.4.3 -> 0.6.4 ``                                                                |
| [`73d6ed2c`](https://github.com/NixOS/nixpkgs/commit/73d6ed2c86382672c30c1a4e9d8add3f10e4bd21) | `` autoadb: remove ``                                                                    |
| [`9962b33f`](https://github.com/NixOS/nixpkgs/commit/9962b33f513ef5edc71a6209b16a85443126d19b) | `` nixos/netbird: update docs & release notes ``                                         |
| [`49a26eda`](https://github.com/NixOS/nixpkgs/commit/49a26eda2aa9bfe4658482f4a4c82f4aee9348f3) | `` nixos/netbird: harden and extend options ``                                           |
| [`8ff3eb73`](https://github.com/NixOS/nixpkgs/commit/8ff3eb73e6d4ba8d3d55eb633cb8e5ed69916b44) | `` gpsprune: 24.5 -> 25 ``                                                               |
| [`adc3ad67`](https://github.com/NixOS/nixpkgs/commit/adc3ad67d050783f9687007f1e20656a6e8f13fc) | `` strawberry: 1.2.4 -> 1.2.6 ``                                                         |
| [`4ec9383f`](https://github.com/NixOS/nixpkgs/commit/4ec9383f6d326110582f96dd0133fc6d72f802f1) | `` sshx,sshx-server: useFetchCargoVendor ``                                              |
| [`28053b81`](https://github.com/NixOS/nixpkgs/commit/28053b8114bcdcf5cf7d23b18f86aeaa4fc0a76d) | `` cargo-web: remove ``                                                                  |
| [`3e5b2351`](https://github.com/NixOS/nixpkgs/commit/3e5b235146f3b6d73e9a6aa999c0bd8a011cb221) | `` doc: recommend fetchCargoVendor ``                                                    |
| [`b0cc9f5a`](https://github.com/NixOS/nixpkgs/commit/b0cc9f5a8bc59dd02af19cc5e8c85a314136ed76) | `` nextcloud-notify_push.test_client: useFetchCargoVendor ``                             |
| [`7eae2506`](https://github.com/NixOS/nixpkgs/commit/7eae2506461cc5aa3b78f0a55de1d3224f6a0045) | `` python312Packages.pyiskra: 0.1.14 -> 0.1.15 ``                                        |
| [`f4a55406`](https://github.com/NixOS/nixpkgs/commit/f4a5540680856aa63653c72eb32c8ec9aa39b4b4) | `` motif: fix and enable strictDeps, fix cross build ``                                  |
| [`e6443544`](https://github.com/NixOS/nixpkgs/commit/e6443544dc92f08a8bd50404b90668e0c498da0c) | `` treewide: fix ac_cv_func_setpgrp_void configure flag for BSD ``                       |
| [`ef81992b`](https://github.com/NixOS/nixpkgs/commit/ef81992b5e1fde75abdea81e338480cf8b0abf56) | `` gitlab: fetchCargoTarball -> fetchCargoVendor ``                                      |
| [`36f8c333`](https://github.com/NixOS/nixpkgs/commit/36f8c333b8d3a21f20eb5d4241b7219e3c1cf76b) | `` swapview: useFetchCargoVendor ``                                                      |
| [`534ca346`](https://github.com/NixOS/nixpkgs/commit/534ca34636ffc3f824ac8b489e52fdb46a548626) | `` swapview: 0.1.0 -> 0.1.0-unstable-2023-12-03 ``                                       |
| [`6ec9df59`](https://github.com/NixOS/nixpkgs/commit/6ec9df5984f6d8023503dff017713f325e66aec9) | `` parinfer-rust: useFetchCargoVendor ``                                                 |
| [`a29d94a0`](https://github.com/NixOS/nixpkgs/commit/a29d94a0f16d8c442d7e89b764b8028a01167101) | `` parinfer: 0.4.3 -> 0.4.3-unstable-2024-05-07 ``                                       |
| [`fae5da3a`](https://github.com/NixOS/nixpkgs/commit/fae5da3aa323f6710619e17b5eae7fcf00de78c3) | `` tensorman: useFetchCargoVendor ``                                                     |
| [`c671d1cf`](https://github.com/NixOS/nixpkgs/commit/c671d1cf3dd133934c26d8784b1b64146b5fc986) | `` tensorman: unstable-2023-03-13 -> 0.1.0-unstable-2024-06-24 ``                        |