### PR TITLE
chore(flake/nixvim): `c75e4ea3` -> `a39e0a65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738275749,
-        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
+        "lastModified": 1738878603,
+        "narHash": "sha256-fmhq8B3MvQLawLbMO+LWLcdC2ftLMmwSk+P29icJ3tE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
+        "rev": "433799271274c9f2ab520a49527ebfe2992dcfbd",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738277753,
-        "narHash": "sha256-iyFcCOk0mmDiv4ut9mBEuMxMZIym3++0qN1rQBg8FW0=",
+        "lastModified": 1738743987,
+        "narHash": "sha256-O3bnAfsObto6l2tQOmQlrO6Z2kD6yKwOWfs7pA0CpOc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "49b807fa7c37568d7fbe2aeaafb9255c185412f9",
+        "rev": "ae406c04577ff9a64087018c79b4fdc02468c87c",
         "type": "github"
       },
       "original": {
@@ -314,11 +314,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1738366771,
-        "narHash": "sha256-nyEBrP5t1g4vmy7YBkiGaIu19eG8zV3T4IQLQbJsVU8=",
+        "lastModified": 1739527837,
+        "narHash": "sha256-dsb5iSthp5zCWhdV0aXPunFSCkS0pCvRXMMgTEFjzew=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c75e4ea37f25ec98aa6f2035e03e748e7369662c",
+        "rev": "a39e0a651657046f3b936d842147fa51523b6818",
         "type": "github"
       },
       "original": {
@@ -337,11 +337,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737924095,
-        "narHash": "sha256-9RO/IlxiE7bpY7GYsdDMNB533PnDOBo9UvYyXXqlN4c=",
+        "lastModified": 1738508923,
+        "narHash": "sha256-4DaDrQDAIxlWhTjH6h/+xfG05jt3qDZrZE/7zDLQaS4=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "5efc9c966bb9bdad07a3c28667eac38b758c6f18",
+        "rev": "86e2038290859006e05ca7201425ea5b5de4aecb",
         "type": "github"
       },
       "original": {
@@ -425,11 +425,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738070913,
-        "narHash": "sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk=",
+        "lastModified": 1738680491,
+        "narHash": "sha256-8X7tR3kFGkE7WEF5EXVkt4apgaN85oHZdoTGutCFs6I=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
+        "rev": "64dbb922d51a42c0ced6a7668ca008dded61c483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`a39e0a65`](https://github.com/nix-community/nixvim/commit/a39e0a651657046f3b936d842147fa51523b6818) | `` docs/fix-links: handle `#anchor` targets on the same page ``   |
| [`7f29e4b2`](https://github.com/nix-community/nixvim/commit/7f29e4b2ae34c1ba5fe650d74c8f28b0d1fa21ee) | `` docs/fix-links: init ``                                        |
| [`ff63fc92`](https://github.com/nix-community/nixvim/commit/ff63fc92ed38a00e7b3ba60a828870017428436a) | `` plugins/bullets: init ``                                       |
| [`78b6f8e1`](https://github.com/nix-community/nixvim/commit/78b6f8e1e5b37a7789216e17a96ebc117660f0e7) | `` plugins/easy-dotnet: init ``                                   |
| [`13341a4c`](https://github.com/nix-community/nixvim/commit/13341a4c1238b7974e7bad9c7a6d5c51ca3cf81a) | `` plugins/blink-emoji: fix packPathName ``                       |
| [`7dfd5513`](https://github.com/nix-community/nixvim/commit/7dfd5513d84dc0e529a00190f70ec61c85246fc1) | `` plugins/blink-ripgrep: fix packPathName ``                     |
| [`e7f20a60`](https://github.com/nix-community/nixvim/commit/e7f20a602f6e08a70045f36c531bc44ba1baed07) | `` flake: remove unused 'inputs' ``                               |
| [`b5bb7ddf`](https://github.com/nix-community/nixvim/commit/b5bb7ddf8026a7cf564e2b1bc9814eb00d8c4d00) | `` flake.lock: Update ``                                          |
| [`f2f70b43`](https://github.com/nix-community/nixvim/commit/f2f70b4376874b74d9bae0df2d4bfd5292c1499e) | `` blink-cmp: Set lsp capabilities ``                             |
| [`a5147a36`](https://github.com/nix-community/nixvim/commit/a5147a36f9d3df06fd1246cf5a089678cbf59d3a) | `` plugins/schemastore: set the correct jsonls default ``         |
| [`5024ef21`](https://github.com/nix-community/nixvim/commit/5024ef216f0e5d84adf1da703445de4ca1f8f9fb) | `` flake.lock: Update ``                                          |
| [`2ecc5359`](https://github.com/nix-community/nixvim/commit/2ecc5359f804bc98901dee0c95999ac3fa308388) | `` plugins/nvim-ufo: Set lsp capabilities ``                      |
| [`56e82309`](https://github.com/nix-community/nixvim/commit/56e82309398f3d09eba7d6bc5bf04691c4483556) | `` lib/options: Add `mkEnabledOption` ``                          |
| [`7f2601ad`](https://github.com/nix-community/nixvim/commit/7f2601adc172747647235108a3ab7a07a8d19521) | `` Editorconfig: configure `indent_size` for nix files ``         |
| [`11a80c1a`](https://github.com/nix-community/nixvim/commit/11a80c1a80b16016ad03e703d1c9dea07f495cb7) | `` plugins/blink-cmp-dictionary: init ``                          |
| [`2061a9ad`](https://github.com/nix-community/nixvim/commit/2061a9ad95ca320a2bca00de6a9e30dbc5f52d74) | `` plugins/blink-cmp-git: init ``                                 |
| [`7d975e35`](https://github.com/nix-community/nixvim/commit/7d975e3598c94c8a75c605cfcfb65dd59741a8a2) | `` plugins/blink-cmp-spell: init ``                               |
| [`859a97bd`](https://github.com/nix-community/nixvim/commit/859a97bd8e54aa7e4fde0439a73dd03cf59a753a) | `` plugins/blink-ripgrep: init ``                                 |
| [`d5406e54`](https://github.com/nix-community/nixvim/commit/d5406e546b58bb7f90c1e8aecfbbd6fd74a28ac9) | `` plugins/blink-emoji: init ``                                   |
| [`cf01c024`](https://github.com/nix-community/nixvim/commit/cf01c024af844bf89c9b296fc1627abffe038ecf) | `` plugins/blink-copilot: init ``                                 |
| [`5281e8c5`](https://github.com/nix-community/nixvim/commit/5281e8c583a5fcdda7ca8373c7032bb9c5219ff3) | `` ci/update: allow disabling re-applying commits ``              |
| [`61fdbe26`](https://github.com/nix-community/nixvim/commit/61fdbe26476b031d407e9b873fffe235ff2b8364) | `` ci/update: fix re-apply commit order ``                        |
| [`d709c12c`](https://github.com/nix-community/nixvim/commit/d709c12cdd0cf449415ad8fa627cedb6516588c8) | `` tests/texpresso: re-enable test on darwin ``                   |
| [`2d4db5a4`](https://github.com/nix-community/nixvim/commit/2d4db5a41ff044415f7dd81f22e088540ef8fe0c) | `` Revert "tests/texpresso: disable test" ``                      |
| [`ba2e2a1f`](https://github.com/nix-community/nixvim/commit/ba2e2a1f694627b17f1a9abe9ec88a500081c359) | `` flake.lock: Update ``                                          |
| [`f99264c1`](https://github.com/nix-community/nixvim/commit/f99264c1fb8e98e0712cdad2744afa8b40661dcc) | `` modules/nixpkgs: don't assign elaborated platforms ``          |
| [`6288354d`](https://github.com/nix-community/nixvim/commit/6288354d43ada972480cbd10dc7102637eeafc1e) | `` plugins/blink-cmp: remove setting warning ``                   |
| [`563ea558`](https://github.com/nix-community/nixvim/commit/563ea5586dc243f1d3ba776b7593a2637b99e691) | `` plugins/blink-cmp: add rawLua support more provider options `` |
| [`e77af9f8`](https://github.com/nix-community/nixvim/commit/e77af9f81b220e46a5dc1f1faa592c10753a46a6) | `` flake.lock: Update ``                                          |
| [`c284a509`](https://github.com/nix-community/nixvim/commit/c284a509952eee265519674e67e70e73ddcbfd05) | `` dev/list-plugins: remove various outdated overrides ``         |
| [`56d0c457`](https://github.com/nix-community/nixvim/commit/56d0c4579e022b44a3e324f722fa23a6f4295798) | `` plugins/typescript-tools: use plugin's luaConfig ``            |
| [`b0906aca`](https://github.com/nix-community/nixvim/commit/b0906aca2e5e3bb41602ef968c60c0ae363220b2) | `` plugins/mark-radar: migrate to mkNeovimPlugin ``               |
| [`0827c5cb`](https://github.com/nix-community/nixvim/commit/0827c5cb6caf32f3b917d2fb6c67340435d07f68) | `` plugins/notify: migrate to mkNeovimPlugin ``                   |
| [`10ea28ff`](https://github.com/nix-community/nixvim/commit/10ea28fff49ec4f0452b4544a0003b187d38d5f4) | `` plugins/lastplace: migrate to mkNeovimPlugin ``                |
| [`a3eed84e`](https://github.com/nix-community/nixvim/commit/a3eed84e1e62ab399897d8314f7a67892091f47c) | `` flake.lock: Update ``                                          |
| [`8104356a`](https://github.com/nix-community/nixvim/commit/8104356af6536df366eea4b8bcc409320323b959) | `` plugins/startify: options -> settings-options ``               |
| [`e0f838b5`](https://github.com/nix-community/nixvim/commit/e0f838b58da8f0a2458d349d8fb8a57f5013fd29) | `` plugins/neotest: options -> settings-options ``                |
| [`09e857bf`](https://github.com/nix-community/nixvim/commit/09e857bfdd17489b66e3f4ec75ae342938deef2b) | `` plugins/neogit: options -> settings-options ``                 |
| [`f6182890`](https://github.com/nix-community/nixvim/commit/f6182890279ed06eb139121db49c8ac1e463821c) | `` dev/list-plugins: remove redundant exclude ``                  |
| [`0d160c19`](https://github.com/nix-community/nixvim/commit/0d160c19d6c515eeca6c3620cd3b64534a4bfb97) | `` plugins/obsidian: options -> settings-options ``               |
| [`86cc0386`](https://github.com/nix-community/nixvim/commit/86cc03863f91a959fbc477009eaa8e19a917b68a) | `` plugins/obsidian: move deprecations ``                         |
| [`e68b8e9c`](https://github.com/nix-community/nixvim/commit/e68b8e9c9196a55fccf491b19aa8e8f47ba7ef6b) | `` plugins/obsidian: remove with lib and helpers ``               |
| [`2b039331`](https://github.com/nix-community/nixvim/commit/2b03933101012cc5830d5dd7167d4544902a51b1) | `` plugins/clipboard-image: migrate to mkneovimplugin ``          |
| [`3aabd321`](https://github.com/nix-community/nixvim/commit/3aabd321817cfcfce14690badf79c9bf1901b58a) | `` plugins/cursorline: migrate to mkNeovimPlugin ``               |
| [`ccd00929`](https://github.com/nix-community/nixvim/commit/ccd009298879f555b2a051fca02911b2a90a7b96) | `` plugins/autoclose: migrate to mkNeovimPlugin ``                |
| [`8f8f5024`](https://github.com/nix-community/nixvim/commit/8f8f50243ea803304b1bd04aa56bd736fe2c28eb) | `` plugins/java: init ``                                          |
| [`e75f0aac`](https://github.com/nix-community/nixvim/commit/e75f0aac9071ddbb7ff7944ec47b7aff647d5227) | `` tests/texpresso: disable test ``                               |
| [`a86d1150`](https://github.com/nix-community/nixvim/commit/a86d11507f1c5b6396b32d9b8e3bb436d6975a62) | `` flake.lock: Update ``                                          |