### PR TITLE
refactor: Updating bemol function and moving to lsp on attach. creating a new on attach function for jdtls

### DIFF
--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -67,5 +67,14 @@
     initOptions = {
       bundles = helpers.mkRaw "_M.jdtls.bundles";
     };
+    extraOptions = {
+      onAttach = ''
+        function(client, bufnr)
+          jdtls.setup_dap({hotcodereplace = 'auto'})
+          jdtls.setup.add_commands()
+          bemol()
+        end
+      '';
+    };
   };
 }

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -68,7 +68,7 @@
       bundles = helpers.mkRaw "_M.jdtls.bundles";
     };
     extraOptions = {
-      onAttach = ''
+      onAttach = helpers.mkRaw ''
         function(client, bufnr)
           jdtls.setup_dap({hotcodereplace = 'auto'})
           jdtls.setup.add_commands()

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -14,14 +14,21 @@
     _M.jdtls.bundles = {}
     local java_debug_bundle = vim.split(vim.fn.glob("${java-debug}" .. "/*.jar"), "\n")
     local java_test_bundle = vim.split(vim.fn.glob("${java-test}" .. "/*.jar", true), "\n")
-    -- add jars to the bundle list if there are any
-    if java_debug_bundle[1] ~= "" then
-        vim.list_extend(_M.jdtls.bundles, java_debug_bundle)
-    end
 
-    if java_test_bundle[1] ~= "" then
-        vim.list_extend(_M.jdtls.bundles, java_test_bundle)
+    -- Following filters out unwanted bundles
+    local ignored_bundles = { "com.microsoft.java.test.runner-jar-with-dependencies.jar", "jacocoagent.jar" }
+    local find = string.find
+    local function should_ignore_bundle(bundle)
+        for _, ignored in ipairs(ignored_bundles) do
+            if find(bundle, ignored, 1, true) then
+                return true
+            end
+        end
     end
+    local filtered_java_debug_bundle = vim.tbl_filter(function(bundle) return bundle ~= "" and not should_ignore_bundle(bundle) end, java_debug_bundle)
+    local filtered_java_test_bundle = vim.tbl_filter(function(bundle) return bundle ~= "" and not should_ignore_bundle(bundle) end, java_test_bundle)
+    vim.list_extend(_M.jdtls.bundles, java_debug_bundle)
+    vim.list_extend(_M.jdtls.bundles, java_test_bundle)
   '';
 
   plugins.nvim-jdtls = {

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -10,6 +10,7 @@
   in ''
     local jdtls_dap = require("jdtls.dap")
 
+    _M.jdtls = {}
     _M.jdtls.bundles = {}
     local java_debug_bundle = vim.split(vim.fn.glob("${java-debug}" .. "/*.jar"), "\n")
     local java_test_bundle = vim.split(vim.fn.glob("${java-test}" .. "/*.jar", true), "\n")

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -48,7 +48,7 @@
       "-Dlog.level=ALL"
       "--add-modules=ALL-SYSTEM"
     ];
-    data.__raw = "os.getenv('HOME') .. '/.local/share/eclipse/' .. vim.fn.fnamemodify(_M.workspace_root_dir, ':p:h:t')";
+    data.__raw = "os.getenv('HOME') .. '/.local/share/eclipse/' .. vim.fn.fnamemodify(vim.fs.root(0, '.git'), ':p:h:t')";
     settings = {
       java = {
         signatureHelp.enable = true;

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -39,24 +39,6 @@
     end
   '';
 
-  autoCmd = [
-    {
-      event = "BufNewFile";
-      pattern = "*.java";
-      callback.__raw = ''
-        function()
-          local header = {
-            "/*",
-            " * Copyright " .. os.date("%Y") .. " Amazon.com, Inc. or its affiliates. All Rights Reserved.",
-            " * All rights reserved.",
-            " */",
-          }
-          vim.api.nvim_buf_set_lines(0, 0, 0, false, header)
-        end
-      '';
-    }
-  ];
-
   plugins.nvim-jdtls = {
     enable = true;
     rootDir = helpers.mkRaw "_M.workspace_root_dir";

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -4,26 +4,10 @@
   helpers,
   ...
 }: {
-  extraPackages = with pkgs;
-    [
-      jdt-language-server
-    ]
-    ++ (with vscode-extensions.vscjava; [
-      vscode-java-debug
-      vscode-java-test
-    ]);
-
   extraConfigLuaPre = let
     java-debug = "${pkgs.vscode-extensions.vscjava.vscode-java-debug}/share/vscode/extensions/vscjava.vscode-java-debug/server";
     java-test = "${pkgs.vscode-extensions.vscjava.vscode-java-test}/share/vscode/extensions/vscjava.vscode-java-test/server";
   in ''
-    local jdtls = require("jdtls")
-    _M.jdtls = {}
-
-    local cmp_nvim_lsp = require("cmp_nvim_lsp")
-    local client_capabilities = vim.lsp.protocol.make_client_capabilities()
-    _M.capabilities = cmp_nvim_lsp.default_capabilities(client_capabilities)
-
     local jdtls_dap = require("jdtls.dap")
 
     _M.jdtls.bundles = {}
@@ -41,7 +25,6 @@
 
   plugins.nvim-jdtls = {
     enable = true;
-    rootDir = helpers.mkRaw "_M.workspace_root_dir";
     cmd = [
       (lib.getExe pkgs.jdt-language-server)
       "-Dlog.protocol=true"
@@ -72,9 +55,6 @@
           generateComments = true;
         };
       };
-    };
-    extraOptions = {
-      capabilities = helpers.mkRaw "_M.capabilities";
     };
     initOptions = {
       bundles = helpers.mkRaw "_M.jdtls.bundles";

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -63,7 +63,6 @@
             "are.you.sure.*"
           ];
         };
-        saveActions.organizeImports = true;
         implementationsCodeLens.enable = true;
         referenceCodeLens.enable = true;
         inlayHints = {

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  lib,
   helpers,
   ...
 }: {
@@ -33,13 +32,8 @@
 
   plugins.nvim-jdtls = {
     enable = true;
-    cmd = [
-      (lib.getExe pkgs.jdt-language-server)
-      "-Dlog.protocol=true"
-      "-Dlog.level=ALL"
-      "--add-modules=ALL-SYSTEM"
-    ];
-    data.__raw = "os.getenv('HOME') .. '/.local/share/eclipse/' .. vim.fn.fnamemodify(vim.fs.root(0, '.git'), ':p:h:t')";
+    configuration.__raw = ''vim.fn.stdpath 'cache' .. "/jdtls/config"'';
+    data = helpers.mkRaw "os.getenv('HOME') .. '/.local/share/eclipse' .. vim.fn.fnamemodify(vim.fs.root(0, '.git'), ':p:h:t')";
     settings = {
       java = {
         configuration = {

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -27,8 +27,8 @@
     end
     local filtered_java_debug_bundle = vim.tbl_filter(function(bundle) return bundle ~= "" and not should_ignore_bundle(bundle) end, java_debug_bundle)
     local filtered_java_test_bundle = vim.tbl_filter(function(bundle) return bundle ~= "" and not should_ignore_bundle(bundle) end, java_test_bundle)
-    vim.list_extend(_M.jdtls.bundles, java_debug_bundle)
-    vim.list_extend(_M.jdtls.bundles, java_test_bundle)
+    vim.list_extend(_M.jdtls.bundles, filtered_java_debug_bundle)
+    vim.list_extend(_M.jdtls.bundles, filtered_java_test_bundle)
   '';
 
   plugins.nvim-jdtls = {

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -70,6 +70,7 @@
     extraOptions = {
       onAttach = helpers.mkRaw ''
         function(client, bufnr)
+          vim.lsp.set_log_level("debug")
           jdtls.setup_dap({hotcodereplace = 'auto'})
           jdtls.setup.add_commands()
           bemol()

--- a/config/lang/java.nix
+++ b/config/lang/java.nix
@@ -42,6 +42,12 @@
     data.__raw = "os.getenv('HOME') .. '/.local/share/eclipse/' .. vim.fn.fnamemodify(vim.fs.root(0, '.git'), ':p:h:t')";
     settings = {
       java = {
+        configuration = {
+          runtimes = [
+            pkgs.jdk
+            pkgs.jdk17
+          ];
+        };
         signatureHelp.enable = true;
         completion = {
           enable = true;

--- a/config/lsp/lsp.nix
+++ b/config/lsp/lsp.nix
@@ -1,22 +1,24 @@
 {
   config = {
     extraConfigLuaPre = ''
-      _M.workspace_root_dir = vim.fs.root("Config", { "packageInfo" })
-      _M.bemol_ws_folders = {}
-      if _M.workspace_root_dir then
-       local file = io.open(_M.workspace_root_dir .. "/.bemol/ws_root_folders", "r")
-       if file then
-        for line in file:lines() do
-         table.insert(_M.bemol_ws_folders, "file://" .. line)
-        end
-        file:close()
-       end
-      end
+      local function bemol()
+          local bemol_dir = vim.fs.find({ ".bemol" }, { upward = true, type = "directory" })[1]
+          local ws_folders_lsp = {}
+          if bemol_dir then
+              local file = io.open(bemol_dir .. "/ws_root_folders", "r")
+              if file then
+                  for line in file:lines() do
+                      table.insert(ws_folders_lsp, line)
+                  end
+                  file:close()
+              end
 
-      function bemol()
-       for _, line in ipairs(_M.bemol_ws_folders) do
-        vim.lsp.buf.add_workspace_folder(line)
-       end
+              for _, line in ipairs(ws_folders_lsp) do
+                  if not contains(vim.lsp.buf.list_workspace_folders(), line) then
+                      vim.lsp.buf.add_workspace_folder(line)
+                  end
+              end
+          end
       end
     '';
 

--- a/config/lsp/lsp.nix
+++ b/config/lsp/lsp.nix
@@ -50,13 +50,13 @@
             "gr" = "references";
           };
         };
+        onAttach = ''
+          bemol()
+        '';
       };
       lspkind = {
         enable = true;
       };
     };
-    extraConfigLuaPost = ''
-      bemol()
-    '';
   };
 }


### PR DESCRIPTION
- **refactor(lang/java): Remove copyright header autocommand**
- **fix(lang/java): Remove reordering imports on save**
- **feat(lang/java): Updating how jdtls configures the data directory**
- **test: Removing capabilities and removing extra packages from nvim-jdtls config to see if that fixes the debug support**
- **test: Adding missing jdtls to module**
- **test: Adding ignore bundle filter before adding bundles**
- **test: Adding specific runtimes to jdt to see if that does the trick for the debugging server since that seems to be the gradle build issue**
- **test: Adding the filtered bundles to jdtls bundles**
- **test: changing jdtls setup from using cmd to data and configuration**
- **refactor(config/lsp): Refactor bemol function to not use modules and contain function locally**
- **refactor(config/lsp): Moving bemol function to on attach**
- **test: Adding new on_attach function to jdtls**
- **fix: making the jdtls onattach function raw lua**
- **test: Adding debug log levels for lsp**
