### PR TITLE
chore(flake/nixvim): `a39e0a65` -> `6f8d8f7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,41 +1,6 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1735644329,
-        "narHash": "sha256-tO3HrHriyLvipc4xr+Ewtdlo7wM1OjXNjlWRgmM7peY=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "f7795ede5b02664b57035b3b757876703e2c3eac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "flake-compat": {
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "revCount": 69,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
-      }
-    },
-    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -108,55 +73,7 @@
         "type": "github"
       }
     },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "nixvim",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
       "inputs": {
         "nixpkgs": [
           "pre-commit-hooks",
@@ -174,27 +91,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1738878603,
-        "narHash": "sha256-fmhq8B3MvQLawLbMO+LWLcdC2ftLMmwSk+P29icJ3tE=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "433799271274c9f2ab520a49527ebfe2992dcfbd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
         "type": "github"
       }
     },
@@ -223,27 +119,6 @@
         "owner": "NuschtOS",
         "ref": "v0.0.6",
         "repo": "ixx",
-        "type": "github"
-      }
-    },
-    "nix-darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1738743987,
-        "narHash": "sha256-O3bnAfsObto6l2tQOmQlrO6Z2kD6yKwOWfs7pA0CpOc=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "rev": "ae406c04577ff9a64087018c79b4fdc02468c87c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lnl7",
-        "repo": "nix-darwin",
         "type": "github"
       }
     },
@@ -301,24 +176,18 @@
     },
     "nixvim": {
       "inputs": {
-        "devshell": "devshell",
-        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts_2",
-        "git-hooks": "git-hooks",
-        "home-manager": "home-manager",
-        "nix-darwin": "nix-darwin",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nuschtosSearch": "nuschtosSearch",
-        "treefmt-nix": "treefmt-nix_2"
+        "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1739527837,
-        "narHash": "sha256-dsb5iSthp5zCWhdV0aXPunFSCkS0pCvRXMMgTEFjzew=",
+        "lastModified": 1740520037,
+        "narHash": "sha256-TpZMYjOre+6GhKDVHFwoW2iBWqpNQppQTuqIAo+OBV8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a39e0a651657046f3b936d842147fa51523b6818",
+        "rev": "6f8d8f7aee84f377f52c8bb58385015f9168a666",
         "type": "github"
       },
       "original": {
@@ -352,8 +221,8 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore_2",
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -409,27 +278,6 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1738680491,
-        "narHash": "sha256-8X7tR3kFGkE7WEF5EXVkt4apgaN85oHZdoTGutCFs6I=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "64dbb922d51a42c0ced6a7668ca008dded61c483",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`6f8d8f7a`](https://github.com/nix-community/nixvim/commit/6f8d8f7aee84f377f52c8bb58385015f9168a666) | `` docs/fix-links: generalise checks for links targeting `.` `` |
| [`53f9d242`](https://github.com/nix-community/nixvim/commit/53f9d242ffdf0997109d0b5b8bbbcc67a4296077) | `` ci/update: link to workflow run in PR body ``                |
| [`5cd74b54`](https://github.com/nix-community/nixvim/commit/5cd74b54ad5843a078277783487568f0bf5779c8) | `` ci/update: document how to re-update in PR body ``           |
| [`723630ca`](https://github.com/nix-community/nixvim/commit/723630ca403cc2dcc163656fe4051edb2c6b3147) | `` ci/update: write PR body dynamically ``                      |
| [`977b7a9f`](https://github.com/nix-community/nixvim/commit/977b7a9fa3fb87098de1841ed14ce3d004d7a125) | `` docs/fix-links: pandoc `markdown` -> `gfm` ``                |
| [`4b0de83c`](https://github.com/nix-community/nixvim/commit/4b0de83c39718e6fca0c80fdeae7c4a9b2cb6c10) | `` ci/update: drop empty commits on re-apply ``                 |
| [`05981008`](https://github.com/nix-community/nixvim/commit/05981008b77496a93837c00da3f9306ecd52b760) | `` ci/update: fix `inputs.nixpkgs.rev` eval ``                  |
| [`6d10fc0c`](https://github.com/nix-community/nixvim/commit/6d10fc0c871a93164bd473fe7de9dbcc41439799) | `` flake: partition dev dependencies ``                         |
| [`0ab99471`](https://github.com/nix-community/nixvim/commit/0ab9947137cd034ec64eb5cd9ede94e53af21f50) | `` plugins/neotest: fix adapters assertion message (#3022) ``   |
| [`3a66c8a3`](https://github.com/nix-community/nixvim/commit/3a66c8a33001d8bd79388c6b15eb1039f43f4192) | `` plugins/lightline: fix formatting of code example ``         |
| [`d636d254`](https://github.com/nix-community/nixvim/commit/d636d254088a2fa49b585b79097a2766d4e3af80) | `` plugins/mini:  Fix typo in error message ``                  |
| [`b8c55873`](https://github.com/nix-community/nixvim/commit/b8c55873998948bf14a2b6cf30f9ad5ecdf79818) | `` lib/keymaps: make `mode` type's description more readable `` |
| [`bd46d896`](https://github.com/nix-community/nixvim/commit/bd46d896a8eb517314163264606bd70859082339) | `` lib/keymaps: add a link to `:h map-modes` ``                 |
| [`d3a25cb9`](https://github.com/nix-community/nixvim/commit/d3a25cb97f8e8c4b77949b1e9fcf26b7ded42fbc) | `` lib/keymaps: add abbreviation support to `modes` enum ``     |
| [`a1e168a2`](https://github.com/nix-community/nixvim/commit/a1e168a2a01e7b5c67ebf9183e1a27804a6add86) | `` lib/keymaps: replace `modes` attrs with list ``              |
| [`d542e373`](https://github.com/nix-community/nixvim/commit/d542e373f16cfa03ef7ad71f4cf6d479144a08a6) | `` readme: use `:h map-table` for mapping modes ``              |