### PR TITLE
chore(flake/flake-parts): `32ea77a0` -> `f4330d22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -164,14 +164,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1738452942,
-        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixvim": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                                                                    |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
| [`18bae3ab`](https://github.com/hercules-ci/flake-parts/commit/18bae3abd9e674e31e97ac8790eafb4f5b85647c) | `` Revert "flake-update: Get the nixpkgs/lib subtree only" ``                                                              |
| [`2a248bba`](https://github.com/hercules-ci/flake-parts/commit/2a248bba8ab12d669c7d712eaeea26a27560b35f) | `` flake.lock: Update ``                                                                                                   |
| [`f50f3753`](https://github.com/hercules-ci/flake-parts/commit/f50f3753b80a8e06215e56066bf579307f85b658) | `` dev/flake.lock: Update ``                                                                                               |
| [`545478b0`](https://github.com/hercules-ci/flake-parts/commit/545478b0b4bb1c6736f4523608bb728c1409a134) | `` flake.lock: Update ``                                                                                                   |
| [`23a8028d`](https://github.com/hercules-ci/flake-parts/commit/23a8028dda97eea7437560c8a5fae2e40943ce76) | `` flake.nix: Update nixpkgs-lib tree ``                                                                                   |
| [`0210dccc`](https://github.com/hercules-ci/flake-parts/commit/0210dccc6433f6ebeb8801ff1285e446ed5aae9d) | `` Use inputs from `github:nix-community/nixpkgs.lib` instead of the hard-coded SHA-1 hash of the subdirectory git tree `` |