### PR TITLE
chore(flake/nixvim): `6f8d8f7a` -> `3a3abf11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -183,11 +183,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1740520037,
-        "narHash": "sha256-TpZMYjOre+6GhKDVHFwoW2iBWqpNQppQTuqIAo+OBV8=",
+        "lastModified": 1741709061,
+        "narHash": "sha256-G1YTksB0CnVhpU1gEmvO3ugPS5CAmUpm5UtTIUIPnEI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6f8d8f7aee84f377f52c8bb58385015f9168a666",
+        "rev": "3a3abf11700f76738d8ad9d15054ceaf182d2974",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`3a3abf11`](https://github.com/nix-community/nixvim/commit/3a3abf11700f76738d8ad9d15054ceaf182d2974) | `` ci: bump cachix/install-nix-action from 30 to 31 ``         |
| [`268c2680`](https://github.com/nix-community/nixvim/commit/268c2680a3bda31d3594950abd348559bd3a24bb) | `` ci: add dependabot and track github-actions dependencies `` |
| [`bc340997`](https://github.com/nix-community/nixvim/commit/bc34099731a7e3799c0d52ccdf4599409a2ef9b9) | `` ci/documentation: bump cachix action to v16 ``              |
| [`03065fd4`](https://github.com/nix-community/nixvim/commit/03065fd4708bfdf47dd541d655392a60daa25ded) | `` tests/none-ls: remove beautysh test (removed upstream) ``   |
| [`98512462`](https://github.com/nix-community/nixvim/commit/98512462414c39ab404facb88a5bec061e8495b9) | `` tests: re-enable tests that work ``                         |