### PR TITLE
chore(flake/nixvim): `78f6166c` -> `1ca0ec3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738453229,
-        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
         "type": "github"
       },
       "original": {
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1742255305,
-        "narHash": "sha256-XxygfriVXQt+5Iqh6AOjZL5Aes5dH2xzVKpHpL8pDQg=",
+        "lastModified": 1742341882,
+        "narHash": "sha256-ftbTPOg53Ez5smPgQhj4aut4c2QBKuNqlqyr1k2iFpM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "78f6166c23f80bdfbcc8c44b20f7f4132299a33f",
+        "rev": "1ca0ec3d798ddc5b37d68bca86119d258a02a17b",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738508923,
-        "narHash": "sha256-4DaDrQDAIxlWhTjH6h/+xfG05jt3qDZrZE/7zDLQaS4=",
+        "lastModified": 1741886583,
+        "narHash": "sha256-sScfYKtxp3CYv5fJcHQDvQjqBL+tPNQqS9yf9Putd+s=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "86e2038290859006e05ca7201425ea5b5de4aecb",
+        "rev": "2974bc5fa3441a319fba943f3ca41f7dcd1a1467",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`1ca0ec3d`](https://github.com/nix-community/nixvim/commit/1ca0ec3d798ddc5b37d68bca86119d258a02a17b) | `` tests/efmls-configs: disable bashate on aarch64-darwin (broken package) ``              |
| [`3ba96f19`](https://github.com/nix-community/nixvim/commit/3ba96f193431e197563ecc9c7bfbea96aee7e4da) | `` tests/none-ls: disable broken terragrunt_fmt on aarch64-linux ``                        |
| [`708f8a17`](https://github.com/nix-community/nixvim/commit/708f8a179bcc9018a7ec7a4cf15c1149fadc43ff) | `` plugins/none-ls: treefmt2 -> treefmt ``                                                 |
| [`122375e7`](https://github.com/nix-community/nixvim/commit/122375e7644c3ad48a88f2c7a8c551144b517f14) | `` tests/none-ls: disable broken semgrep ``                                                |
| [`c15e93c1`](https://github.com/nix-community/nixvim/commit/c15e93c157277c4d9e53336ffe04ff15834a5f78) | `` plugins/lsp/packages: mark coqPackages.{coq-lsp,vscoq-language-server} as unpackaged `` |
| [`4d5e3b33`](https://github.com/nix-community/nixvim/commit/4d5e3b335b02852af19a51c3892aff5c5342b4a3) | `` tests/plugins/headlines: disable org-related tests ``                                   |
| [`1681cc38`](https://github.com/nix-community/nixvim/commit/1681cc3869dd3ff3df74a6229945a1571cfd7a38) | `` lib/maintainers: remove jolars as he became a nixpkgs maintainer ``                     |
| [`3feb4b4b`](https://github.com/nix-community/nixvim/commit/3feb4b4b4be47063d21cc6eef6bbe9dba7129dc9) | `` plugins/markview: v25 migration ``                                                      |
| [`ade9e131`](https://github.com/nix-community/nixvim/commit/ade9e131cd5d6957f29de6e468db8c863c78c2c5) | `` tests/lsp-servers: update ignores ``                                                    |
| [`34f82315`](https://github.com/nix-community/nixvim/commit/34f823151f7cf50f4cd3e76cfdc87d11b1bc14d8) | `` plugins/copilot-chat: update test ``                                                    |
| [`e8025891`](https://github.com/nix-community/nixvim/commit/e8025891b24036bcc76fd355a5edec9fbf2e359b) | `` plugins/lsp/packages: mark graphql as unpackaged ``                                     |
| [`b8f8d4c8`](https://github.com/nix-community/nixvim/commit/b8f8d4c81beac7b63826cae45d2ee9e05cbfdba2) | `` plugins/lsp/packages: mark dts_lsp and wasm_language_tools as unpackaged ``             |
| [`2a3cf1bd`](https://github.com/nix-community/nixvim/commit/2a3cf1bd55618b6cffd5c6d875eff2701548478a) | `` plugins/lsp: marked scry as unpackaged ``                                               |
| [`72365ae5`](https://github.com/nix-community/nixvim/commit/72365ae5a1f112ce6eb3b33dcb46516eff27f7af) | `` plugins/lsp: skip failing pylsp test ``                                                 |
| [`32c63161`](https://github.com/nix-community/nixvim/commit/32c63161d74a4dd1ae20fdc7a37b1edb8319a988) | `` generated: Update ``                                                                    |
| [`40630df6`](https://github.com/nix-community/nixvim/commit/40630df6942d2f5e3fa372ab80edb39429ee4f58) | `` flake/dev/flake.lock: Update ``                                                         |
| [`db436fad`](https://github.com/nix-community/nixvim/commit/db436fad2f7ac0da387320c88bb69152e811f324) | `` flake.lock: Update ``                                                                   |