### PR TITLE
chore(flake/nixvim): `1ca0ec3d` -> `d44b33a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1742341882,
-        "narHash": "sha256-ftbTPOg53Ez5smPgQhj4aut4c2QBKuNqlqyr1k2iFpM=",
+        "lastModified": 1742488644,
+        "narHash": "sha256-vXpu7G4aupNCPlv8kAo7Y/jocfSUwglkvNx5cR0XjBo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1ca0ec3d798ddc5b37d68bca86119d258a02a17b",
+        "rev": "d44b33a1ea1a3e584a8c93164dbe0ba2ad4f3a13",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`d44b33a1`](https://github.com/nix-community/nixvim/commit/d44b33a1ea1a3e584a8c93164dbe0ba2ad4f3a13) | `` plugins/faust: init ``                                                                 |
| [`7e51c72d`](https://github.com/nix-community/nixvim/commit/7e51c72da2107ff0c1c04e9c6bbce4f624b7dfc8) | `` plugins/image: remove unneeded magick dependency (already propagated by image-nvim) `` |
| [`279d2570`](https://github.com/nix-community/nixvim/commit/279d2570b5bc808809aee810c4f8d825c665ecee) | `` plugins/image: migrate to mkNeovimPlugin ``                                            |
| [`c5967bf6`](https://github.com/nix-community/nixvim/commit/c5967bf6a566deff2cabb4f0474333cbf0e06e01) | `` plugins/devdocs: init ``                                                               |
| [`695add12`](https://github.com/nix-community/nixvim/commit/695add12fc25c5de975c7e93207e9442bde625e6) | `` plugins/diagram: init ``                                                               |
| [`ea6df31d`](https://github.com/nix-community/nixvim/commit/ea6df31d30df0049fb1451ce62fc3025e10def4b) | `` flake/dev/flake.lock: Update ``                                                        |
| [`d79c291d`](https://github.com/nix-community/nixvim/commit/d79c291d5d80d587d518e0f530cc55adb0638c80) | `` tests/none-ls: re-enable terragrunt tests ``                                           |
| [`bd99575a`](https://github.com/nix-community/nixvim/commit/bd99575a1f407dd0765069c4218b5ebdf7fddeb5) | `` flake/dev/flake.lock: Update ``                                                        |
| [`afe93ad3`](https://github.com/nix-community/nixvim/commit/afe93ad385d880ae70f25619d7ee75ae732a5287) | `` flake.lock: Update ``                                                                  |
| [`fab8f811`](https://github.com/nix-community/nixvim/commit/fab8f811218541932edf76120ebb28041eea49e9) | `` plugins/typst-preview: init ``                                                         |
| [`f78adb09`](https://github.com/nix-community/nixvim/commit/f78adb09182dc6edf3f2a443c548ae4e0bf789f1) | `` plugins/lsp: enable dolmenls and ocamllsp ``                                           |