### PR TITLE
chore(flake/nixvim): `d44b33a1` -> `c9802712`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1742488644,
-        "narHash": "sha256-vXpu7G4aupNCPlv8kAo7Y/jocfSUwglkvNx5cR0XjBo=",
+        "lastModified": 1742559284,
+        "narHash": "sha256-PSSjCCqpJPkCagkkdLODBVVonGxgwU5dN2CYlFPNVNw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d44b33a1ea1a3e584a8c93164dbe0ba2ad4f3a13",
+        "rev": "c980271267ef146a6c30394c611a97e077471cf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`c9802712`](https://github.com/nix-community/nixvim/commit/c980271267ef146a6c30394c611a97e077471cf2) | `` flake/dev/flake.lock: Update `` |
| [`bd0c98d9`](https://github.com/nix-community/nixvim/commit/bd0c98d9f65ac9f911beddaa986f13cda5604e2d) | `` flake.lock: Update ``           |