### PR TITLE
chore(flake/nixvim): `c9802712` -> `7776e37b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1742559284,
-        "narHash": "sha256-PSSjCCqpJPkCagkkdLODBVVonGxgwU5dN2CYlFPNVNw=",
+        "lastModified": 1742732006,
+        "narHash": "sha256-ZIBMfPNb/hfoFf79MRnhDXGKl0yGhjlYEpy3+/jbxFI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c980271267ef146a6c30394c611a97e077471cf2",
+        "rev": "7776e37b67e7875c3cd56d9d20fd050798071706",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741886583,
-        "narHash": "sha256-sScfYKtxp3CYv5fJcHQDvQjqBL+tPNQqS9yf9Putd+s=",
+        "lastModified": 1742659553,
+        "narHash": "sha256-i/JCrr/jApVorI9GkSV5to+USrRCa0rWuQDH8JSlK2A=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "2974bc5fa3441a319fba943f3ca41f7dcd1a1467",
+        "rev": "508752835128a3977985a4d5225ff241f7756181",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`7776e37b`](https://github.com/nix-community/nixvim/commit/7776e37b67e7875c3cd56d9d20fd050798071706) | `` flake/dev/flake.lock: Update ``                                       |
| [`c0952df4`](https://github.com/nix-community/nixvim/commit/c0952df40805b37174e1e5d9a3d1fc8e6e101735) | `` flake.lock: Update ``                                                 |
| [`3d84c137`](https://github.com/nix-community/nixvim/commit/3d84c137eab329ec1a6d4c4b0a067bfa8eea0bb5) | `` plugins/git-worktree: adapt implem to the underlying plugin change `` |
| [`8176b3f5`](https://github.com/nix-community/nixvim/commit/8176b3f52ef0204cf0bd8b1a6d259d03e75f71cb) | `` plugins/lsp/packages: remove qml_lsp ``                               |
| [`9bdc870f`](https://github.com/nix-community/nixvim/commit/9bdc870ff71893a8a1a46fcd6ce4b7a17457b89c) | `` plugins/lsp/packages: add muon ``                                     |
| [`5a12e283`](https://github.com/nix-community/nixvim/commit/5a12e283bd962d4a388aaa6188fe0751ac19e07d) | `` generated: Updated lspconfig-servers.json ``                          |
| [`33539ce1`](https://github.com/nix-community/nixvim/commit/33539ce13f5ae470b5ddeca1c9454927909c88f4) | `` flake/dev/flake.lock: Update ``                                       |
| [`62c194af`](https://github.com/nix-community/nixvim/commit/62c194af8afe6564ecd8f3e534db8958350b0b85) | `` flake.lock: Update ``                                                 |