### PR TITLE
chore(flake/nixvim): `7776e37b` -> `ec92a181`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1742732006,
-        "narHash": "sha256-ZIBMfPNb/hfoFf79MRnhDXGKl0yGhjlYEpy3+/jbxFI=",
+        "lastModified": 1742862631,
+        "narHash": "sha256-TGeFlONiQxKbgt39pKPnh5gD0NQ/DD8v6FRisD7q+MI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7776e37b67e7875c3cd56d9d20fd050798071706",
+        "rev": "ec92a1816e7deb33d03ff0ab7692fa504e3d1910",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`ec92a181`](https://github.com/nix-community/nixvim/commit/ec92a1816e7deb33d03ff0ab7692fa504e3d1910) | `` plugins/vimwiki: init ``                                                              |
| [`ff46e752`](https://github.com/nix-community/nixvim/commit/ff46e752a12a20c477b4813df7ab58b4df438ec0) | `` tests: add useful attrs to test passthru ``                                           |
| [`1f56d947`](https://github.com/nix-community/nixvim/commit/1f56d947afb2610bcf2c186f234589f9dbcf56f6) | `` tests: drop use of `mkTestDerivationFromNixvimModule` ``                              |
| [`3d90bc78`](https://github.com/nix-community/nixvim/commit/3d90bc786c2fee8374a24264df4823977b78b25d) | `` plugins/avante: fix incorrect option name ``                                          |
| [`9672b3d2`](https://github.com/nix-community/nixvim/commit/9672b3d217c0340bc1a10a4f0856a3c9c0bd823d) | `` plugins/git-worktree: enhance assertion error message for enableTelescope ``          |
| [`2e9afffc`](https://github.com/nix-community/nixvim/commit/2e9afffc28e85b573e950f62cfa0ff992b45bb8d) | `` plugins/git-worktree: remove useless 'mkIf cfg.enable' in extraConfig ``              |
| [`c6ed00c9`](https://github.com/nix-community/nixvim/commit/c6ed00c902b7143c9bc3fb1eca6764a1e2964f54) | `` plugins/nerdy: init ``                                                                |
| [`5fca2c2d`](https://github.com/nix-community/nixvim/commit/5fca2c2dca9f0a50175698f4170c48bb9bb8a6ea) | `` plugins/dap-rr: init ``                                                               |
| [`94dbc6ac`](https://github.com/nix-community/nixvim/commit/94dbc6acab9fb504365053711c3baab2349600f4) | `` plugins/dap (dapHelpers): allow dapHelpers.configurationType to be rawLua ``          |
| [`21e8b57a`](https://github.com/nix-community/nixvim/commit/21e8b57a119a59ffd1ee15556206708523f10298) | `` plugins/dap (dapHelpers): internal rename configurationOption -> configurationType `` |
| [`c9597b37`](https://github.com/nix-community/nixvim/commit/c9597b37d893e33aef9e18df8c916eae8974a115) | `` plugins/obsidian: adapt options (now using the obsidian-nvim community fork) ``       |
| [`db01a0dd`](https://github.com/nix-community/nixvim/commit/db01a0dd9703e002058ffd805bbe48c4c30742a0) | `` modules: add env option ``                                                            |
| [`f4f4b497`](https://github.com/nix-community/nixvim/commit/f4f4b4975abe2a77afa81ee5f873b3a121675fab) | `` flake/dev/flake.lock: Update ``                                                       |
| [`35ec52f1`](https://github.com/nix-community/nixvim/commit/35ec52f1d98c379747a5c884a54822c9508da221) | `` tests/plugins/texpresso: disable as the texpresso package is broken ``                |
| [`9aa79e0e`](https://github.com/nix-community/nixvim/commit/9aa79e0eae3430970d7916776089de12594d49d2) | `` flake/dev/flake.lock: Update ``                                                       |
| [`693c5988`](https://github.com/nix-community/nixvim/commit/693c5988686c332465ad9a5462979f711564cb7a) | `` flake.lock: Update ``                                                                 |