### PR TITLE
chore(flake/nixvim): `ec92a181` -> `6b95b825`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1742862631,
-        "narHash": "sha256-TGeFlONiQxKbgt39pKPnh5gD0NQ/DD8v6FRisD7q+MI=",
+        "lastModified": 1742916868,
+        "narHash": "sha256-2eN75OsaNpL3FzAs3hz9Xm3+htIP3iLdfRP6PGfOoS8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ec92a1816e7deb33d03ff0ab7692fa504e3d1910",
+        "rev": "6b95b825529aa2d8536f7684fe64382ef4d15d84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`6b95b825`](https://github.com/nix-community/nixvim/commit/6b95b825529aa2d8536f7684fe64382ef4d15d84) | `` tests/none-ls: re-enable semgrep test `` |
| [`3cc58f0c`](https://github.com/nix-community/nixvim/commit/3cc58f0c7412813244ea7f613223b762fc1cb332) | `` flake/dev/flake.lock: Update ``          |
| [`1d218caf`](https://github.com/nix-community/nixvim/commit/1d218caf1c321f73141d0e858fa2a3136574a3e4) | `` flake.lock: Update ``                    |