### PR TITLE
chore(flake/nixvim): `d81f3725` -> `754b8df7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1743362786,
-        "narHash": "sha256-XbXIRDbb8/vLBX1M096l7lM5wfzBTp1ZXfUl9bUhVGU=",
+        "lastModified": 1743536158,
+        "narHash": "sha256-/jlBU7EGIfaa5VKwvVyrSspuuNmgKYOjAuTd2ywyevg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d81f37256d0a8691b837b74979d27bf89be8ecdd",
+        "rev": "754b8df7e37be04b7438decee5a5aa18af72cbe1",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742659553,
-        "narHash": "sha256-i/JCrr/jApVorI9GkSV5to+USrRCa0rWuQDH8JSlK2A=",
+        "lastModified": 1743201766,
+        "narHash": "sha256-bb/dqoIjtIWtJRzASOe8g4m8W2jUIWtuoGPXdNjM/Tk=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "508752835128a3977985a4d5225ff241f7756181",
+        "rev": "2651dbfad93d6ef66c440cbbf23238938b187bde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`754b8df7`](https://github.com/nix-community/nixvim/commit/754b8df7e37be04b7438decee5a5aa18af72cbe1) | `` tests: remove `type` passthrough ``                                                       |
| [`5a491f4b`](https://github.com/nix-community/nixvim/commit/5a491f4b2bc132cea2b56bfad0d445708c223113) | `` modules/performance: temporary add plenary to extraPlugins to fix tests ``                |
| [`5d833a16`](https://github.com/nix-community/nixvim/commit/5d833a1692bdd0eac50d66d7d512b6567f31e7cf) | `` plugins/packer: remove (deprecated) ``                                                    |
| [`ada161d0`](https://github.com/nix-community/nixvim/commit/ada161d0bb47f8156dd17cc01936b138b7a98d4f) | `` plugins/pckr: init ``                                                                     |
| [`77c5fe80`](https://github.com/nix-community/nixvim/commit/77c5fe808afd6d60ebbd87fa71f70cfcadef411f) | `` modules/lua-loader: use new 0.11 API for enabling/disabling ``                            |
| [`0ff025c2`](https://github.com/nix-community/nixvim/commit/0ff025c210f266131902f89f4cad9ef5efc480b0) | `` tests/{none-ls,efmls-configs}: disable tools requiring php-cs-fixer (marked as broken) `` |
| [`e1e0e6f0`](https://github.com/nix-community/nixvim/commit/e1e0e6f0240327143d82086ccff5142b0f463685) | `` tests/lsp: disable golangci_lint_ls ``                                                    |
| [`4945e634`](https://github.com/nix-community/nixvim/commit/4945e634bcc6d46d60a83922e2180b097f6af744) | `` Revert "tests/plugins/texpresso: disable as the texpresso package is broken" ``           |
| [`3f73a301`](https://github.com/nix-community/nixvim/commit/3f73a301d69e0ad6074ae478ea020d6cec6d8e3e) | `` generated: Updated lspconfig-servers.json ``                                              |
| [`c55f0cad`](https://github.com/nix-community/nixvim/commit/c55f0cadeac5b22b77f1e492a1c10bb265325943) | `` flake/dev/flake.lock: Update ``                                                           |
| [`43d5f257`](https://github.com/nix-community/nixvim/commit/43d5f25727f0f63da573c5456bb7bedb59d83c88) | `` flake.lock: Update ``                                                                     |
| [`efb24d78`](https://github.com/nix-community/nixvim/commit/efb24d78bd01ed83651616e470e9c73853e7472d) | `` modules: refactor plugins code in top-level ``                                            |