### PR TITLE
chore(flake/nixvim): `a183298b` -> `9f495dda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1743598191,
-        "narHash": "sha256-30aI8rWjX64E9vIlE4iqgQguTjItvTnQLTqHtFppF/w=",
+        "lastModified": 1743723573,
+        "narHash": "sha256-yxONmoimNU0hy0s8pF5lKCSZNqxVmbIHuag3sdk3R30=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a183298bf67307bdb7a25a2a3c565e76029f1b9e",
+        "rev": "9f495dda930ceca1653813ded11859d6b1342803",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`9f495dda`](https://github.com/nix-community/nixvim/commit/9f495dda930ceca1653813ded11859d6b1342803) | `` plugins.harpoon: refactor & switch to harpoon2 `` |
| [`af76696a`](https://github.com/nix-community/nixvim/commit/af76696a92cae8de483a83fbdec6defc3d383f53) | `` plugins/hlchunk: init ``                          |