### PR TITLE
chore(flake/nix-fast-build): `ec4be4cf` -> `65f8b77c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743607527,
-        "narHash": "sha256-8wCcCtRauu2qESry1a1oEXiTO8g7H/u2LuaUPkrdwV4=",
+        "lastModified": 1743779076,
+        "narHash": "sha256-RhIEwFHGqdxXsCSbhp4DicOlMSldthNRhTn2yLdTc4g=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "ec4be4cfb202a72926e53afcd6e3400ab54d99d2",
+        "rev": "65f8b77cb4c212749885bc79bafaec9b9d5c33e6",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743589519,
-        "narHash": "sha256-iBzr7Zb11nQxwX90bO1+Bm1MGlhMSmu4ixgnQFB+j4E=",
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "18bed671738e36c5504e188aadc18b7e2a6e408f",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`65f8b77c`](https://github.com/Mic92/nix-fast-build/commit/65f8b77cb4c212749885bc79bafaec9b9d5c33e6) | `` chore(deps): update nixpkgs digest to 3070507 (#113) ``     |
| [`beba6aa1`](https://github.com/Mic92/nix-fast-build/commit/beba6aa1456d1a61becf8fca3d3044a223894ffb) | `` chore(deps): update nixpkgs digest to a462b94 (#112) ``     |
| [`8a6b59d8`](https://github.com/Mic92/nix-fast-build/commit/8a6b59d8c3854552f3d2b5346e500c1fbab2d45c) | `` chore(deps): update treefmt-nix digest to 815e412 (#111) `` |
| [`84440fb1`](https://github.com/Mic92/nix-fast-build/commit/84440fb14c64dbe0b2a683bd6f89e0c68839e292) | `` chore(deps): update nixpkgs digest to 2bfc080 (#110) ``     |
| [`2098f760`](https://github.com/Mic92/nix-fast-build/commit/2098f7602e271f4dab8a39f5a41e55e36a4b921d) | `` chore(deps): update treefmt-nix digest to 57dabe2 (#109) `` |
| [`14ddba15`](https://github.com/Mic92/nix-fast-build/commit/14ddba15ecd5fcde6b2ca58199fe6c48806582fa) | `` chore(deps): update nixpkgs digest to f90d0a3 (#108) ``     |