### PR TITLE
chore(flake/nix-fast-build): `65f8b77c` -> `662a0e96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743779076,
-        "narHash": "sha256-RhIEwFHGqdxXsCSbhp4DicOlMSldthNRhTn2yLdTc4g=",
+        "lastModified": 1743984373,
+        "narHash": "sha256-LsjMTldRisoxx2a9NCRxLRbEW/Nl1wc+f1PnwNt6kJk=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "65f8b77cb4c212749885bc79bafaec9b9d5c33e6",
+        "rev": "662a0e96626a80fcece298f755d680771f6c171e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`662a0e96`](https://github.com/Mic92/nix-fast-build/commit/662a0e96626a80fcece298f755d680771f6c171e) | `` chore(deps): lock file maintenance (#116) ``            |
| [`2fadd869`](https://github.com/Mic92/nix-fast-build/commit/2fadd8696095bde39531e3815deea894a00b9b4a) | `` chore(deps): update nixpkgs digest to 250b695 (#114) `` |