### PR TITLE
chore(flake/nix-fast-build): `662a0e96` -> `ce8bd0c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743984373,
-        "narHash": "sha256-LsjMTldRisoxx2a9NCRxLRbEW/Nl1wc+f1PnwNt6kJk=",
+        "lastModified": 1744010047,
+        "narHash": "sha256-VblOQvp2aj7IVMGAqgLdWu/KLocKJf7l5bmONgpfa8I=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "662a0e96626a80fcece298f755d680771f6c171e",
+        "rev": "ce8bd0c16597629f567e7ec5dda8fd4a60f0e523",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`02db4961`](https://github.com/Mic92/nix-fast-build/commit/02db4961dd394ed26a11defc25d2e73e93a4191e) | `` chore(deps): update nixpkgs digest to da98c5d `` |
| [`e85548d5`](https://github.com/Mic92/nix-fast-build/commit/e85548d51e60ac6121e58d087856ee26f03df27d) | `` chore(deps): update nixpkgs digest to 06f3516 `` |