### PR TITLE
chore(flake/nix-fast-build): `93b318c2` -> `cb773b11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1744182287,
-        "narHash": "sha256-o9O4KA7R/evL/KT7UsdKHTT+em+BvnxuGa0vn9U3U60=",
+        "lastModified": 1744417489,
+        "narHash": "sha256-U4q1QbP2UyfOppw9vlLBWMeJnjl/z0StMlYZ+ct7irU=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "93b318c24112dd435a265ecc6bf09401e63ade63",
+        "rev": "cb773b118e64a69aa52451e40ada6e16d78ca6c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`cb773b11`](https://github.com/Mic92/nix-fast-build/commit/cb773b118e64a69aa52451e40ada6e16d78ca6c0) | `` chore(deps): update nixpkgs digest to e58dd8c (#120) `` |