### PR TITLE
chore(flake/nixvim): `9bc29e6a` -> `d15f5e6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1744325505,
-        "narHash": "sha256-dCmxSHzy3pcE+12Nf1slkAHYe/O6zJuCnRQrBtk4yjs=",
+        "lastModified": 1744588744,
+        "narHash": "sha256-57yF0pk7IUMiwq5XA9X/TX1fuIJYVnBfqhJWD/1+W0Q=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9bc29e6a9b2b7d5dc4c6757b17e849085f6c7a97",
+        "rev": "d15f5e6f422e353901a425f26925129929e8a38a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`d15f5e6f`](https://github.com/nix-community/nixvim/commit/d15f5e6f422e353901a425f26925129929e8a38a) | `` plugins/codeium-nvim: use dependencies ``                                    |
| [`15919567`](https://github.com/nix-community/nixvim/commit/15919567bbf9471544bb887d31cb0cd983f6dd9d) | `` modules/dependencies: add codeium, coreutils, gzip and util-linux ``         |
| [`5cacff23`](https://github.com/nix-community/nixvim/commit/5cacff2368e6c64dee9329b9dc6cac0ff4654e31) | `` plugins/codeium-nvim: remove settings options ``                             |
| [`b823b701`](https://github.com/nix-community/nixvim/commit/b823b7019970a643b0045e63057d752b858ef5f8) | `` plugins/codeium-nvim: move deprecations to dedicated file ``                 |
| [`327d4919`](https://github.com/nix-community/nixvim/commit/327d4919365dcd1cfb857b6c1ac7a3a44970e104) | `` plugins/parrot: init ``                                                      |
| [`16879e30`](https://github.com/nix-community/nixvim/commit/16879e3034fae2924b0c68422b80f2e63878af71) | `` modules/dependencies: refactor `all-examples` test ``                        |
| [`1095b7f8`](https://github.com/nix-community/nixvim/commit/1095b7f89192c1e2bc9b52d0d9660c02752afe5a) | `` lib/deprecations: use real option paths in `mkRemovedPackageOptionModule` `` |
| [`2ecd6433`](https://github.com/nix-community/nixvim/commit/2ecd643311db88f9f78f6f0e1cee47a4f3036651) | `` plugins/treesitter: cleanup build-grammar deps impl ``                       |
| [`b2e8409b`](https://github.com/nix-community/nixvim/commit/b2e8409b647009398cca2b818302f31994159592) | `` plugins/treesitter: fix `treesitterPackage` deprecation warning ``           |
| [`e537d4a6`](https://github.com/nix-community/nixvim/commit/e537d4a6b4c1c81f8b71dfd916fdf970d0d5c987) | `` plugins/whichpy: init ``                                                     |
| [`3c600e28`](https://github.com/nix-community/nixvim/commit/3c600e2876138a1fd91720be3c26472ae27de1ff) | `` maintainers: add wvffle ``                                                   |
| [`72ce6dbd`](https://github.com/nix-community/nixvim/commit/72ce6dbdf537d89556dc6721029ac9e34b391029) | `` tests/modules/dependencies: test all package examples ``                     |
| [`e9a85eed`](https://github.com/nix-community/nixvim/commit/e9a85eed8bf38bbe6deed7cbc8207f0c180dbf2e) | `` plugins/jdtls: allow rawLua in settings.cmd ``                               |
| [`e83c7fc2`](https://github.com/nix-community/nixvim/commit/e83c7fc2e71f85784c4bbc4c5137f23749c8f06a) | `` plugins/minuet: init ``                                                      |
| [`07b7f67a`](https://github.com/nix-community/nixvim/commit/07b7f67abab06ffd76bd94cb1e360390d43057b4) | `` plugins/codecompanion: fix broken upstream link ``                           |