### PR TITLE
chore(flake/nix-fast-build): `cb773b11` -> `3df8aa89`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1744417489,
-        "narHash": "sha256-U4q1QbP2UyfOppw9vlLBWMeJnjl/z0StMlYZ+ct7irU=",
+        "lastModified": 1744505656,
+        "narHash": "sha256-Isfhju0ZZD8nWxwQ1l8wEuNPF6HlR4UcBmczKm0XLjQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "cb773b118e64a69aa52451e40ada6e16d78ca6c0",
+        "rev": "3df8aa89f7279746d790c014edc5208eb668c272",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`3df8aa89`](https://github.com/Mic92/nix-fast-build/commit/3df8aa89f7279746d790c014edc5208eb668c272) | `` chore(deps): update nixpkgs digest to 208645b (#122) `` |
| [`b01f2559`](https://github.com/Mic92/nix-fast-build/commit/b01f2559cdcef1f9c42ce3cac324256bd2b7955d) | `` chore(deps): update nixpkgs digest to a931801 (#121) `` |