### PR TITLE
chore(flake/nixvim): `ee965563` -> `d4dada28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1744669903,
-        "narHash": "sha256-gtfLmGx/N+BzIck9sGLIfzETxocYjVKo4gmSeH6zfaY=",
+        "lastModified": 1744753228,
+        "narHash": "sha256-Re8g2pby4sr4hgzJmQJxeH/9PtgX85nivkWibapRI5s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ee9655637cbf898415e09c399bc504180e246d42",
+        "rev": "d4dada282aeac94b5d53dd70e276a2f5f534f783",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`d4dada28`](https://github.com/nix-community/nixvim/commit/d4dada282aeac94b5d53dd70e276a2f5f534f783) | `` plugins/molten: add ipykernel python dependency ``                       |
| [`0bdc32e3`](https://github.com/nix-community/nixvim/commit/0bdc32e331f36ff354cb3d10fc7ff6847eb8096f) | `` plugins/supermaven: init ``                                              |
| [`f8ed4247`](https://github.com/nix-community/nixvim/commit/f8ed424711d58bfa65f026fce109a12255d8d609) | `` maintainers: add PoCo ``                                                 |
| [`d94956e5`](https://github.com/nix-community/nixvim/commit/d94956e5da55accc975c0013e510b186634a55e8) | `` lib/deprecation: implement aliases for `mkRemovedPackageOptionModule` `` |