### PR TITLE
chore(flake/nixvim): `500b56f0` -> `710f9cbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,16 +130,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1729958008,
-        "narHash": "sha256-EiOq8jF4Z/zQe0QYVc3+qSKxRK//CFHMB84aYrYGwEs=",
+        "lastModified": 1737371634,
+        "narHash": "sha256-fTVAWzT1UMm1lT+YxHuVPtH+DATrhYfea3B0MxG/cGw=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "9fd01aad037f345350eab2cd45e1946cc66da4eb",
+        "rev": "a1176e2a10ce745ff8f63e4af124ece8fe0b1648",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.0.6",
+        "ref": "v0.0.7",
         "repo": "ixx",
         "type": "github"
       }
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1744874965,
-        "narHash": "sha256-eOnMgAWsjqOhGRoY9smkKlNQcCz9R89mgiKwLrCIYBE=",
+        "lastModified": 1745099712,
+        "narHash": "sha256-fj/S+L9nQyJYdWFk3+8BGPp4tg5rY3uaF6jGADm7OA0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "500b56f023e0f095ffee2d4f79e58aa09e6b0719",
+        "rev": "710f9cbd520b8e78fa95d4c5d255891e2b14a277",
         "type": "github"
       },
       "original": {
@@ -251,11 +251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743683223,
-        "narHash": "sha256-LdXtHFvhEC3S64dphap1pkkzwjErbW65eH1VRerCUT0=",
+        "lastModified": 1745046075,
+        "narHash": "sha256-8v4y6k16Ra/fiecb4DxhsoOGtzLKgKlS+9/XJ9z0T2I=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "56a49ffef2908dad1e9a8adef1f18802bc760962",
+        "rev": "066afe8643274470f4a294442aadd988356a478f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`710f9cbd`](https://github.com/nix-community/nixvim/commit/710f9cbd520b8e78fa95d4c5d255891e2b14a277) | `` tests/cmp: disable codeium ``                                                         |
| [`b541c364`](https://github.com/nix-community/nixvim/commit/b541c36468c803cc4ae6e2a32585162e62cb80ef) | `` tests/windsurf-nvim: dont run nvim ``                                                 |
| [`c8cd3a94`](https://github.com/nix-community/nixvim/commit/c8cd3a946721f62e6d3d2a1dedb294feecb59841) | `` tests/efmls-configs: disable php tools ``                                             |
| [`ca5145cd`](https://github.com/nix-community/nixvim/commit/ca5145cdb69f6f7d40ae8b1b5ef00773000992f2) | `` plugins/lsp-packages: add unpackaged ``                                               |
| [`cf141c07`](https://github.com/nix-community/nixvim/commit/cf141c07a8012c89a0edcddd250a12781ecd926c) | `` plugins/deprecations: move codeium enable option renames to top level deprecations `` |
| [`7f4efe62`](https://github.com/nix-community/nixvim/commit/7f4efe62e05ccf4181a4d44e961417adb93d3b70) | `` plugins/windsurf-vim: rename codeium-vim ``                                           |
| [`1971ec5b`](https://github.com/nix-community/nixvim/commit/1971ec5b2b451da52bf3165ec15ef06fd45e25f1) | `` plugins/windsurf-nvim: rename codeium-nvim ``                                         |
| [`662a7c8d`](https://github.com/nix-community/nixvim/commit/662a7c8dc7b498d892b6b7ddf53cd114b865dfec) | `` generated: Updated lspconfig-servers.json ``                                          |
| [`f9f11601`](https://github.com/nix-community/nixvim/commit/f9f11601cca211765197394e1344ccff6aa5fb00) | `` flake/dev/flake.lock: Update ``                                                       |
| [`1e75f6d8`](https://github.com/nix-community/nixvim/commit/1e75f6d83344d790de98fb8f25622eb661018f43) | `` flake.lock: Update ``                                                                 |
| [`85c99eae`](https://github.com/nix-community/nixvim/commit/85c99eaebad22859962239a1fe42a3ba74a0ab02) | `` plugins/spider: include luautf8 ``                                                    |