### PR TITLE
chore(flake/nixvim): `6c4e2d92` -> `7a581099`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745182672,
-        "narHash": "sha256-xh4O19Hre9LiJk0Aa3ZY/XlN00gAGhRUxCRz15j00JU=",
+        "lastModified": 1745244491,
+        "narHash": "sha256-UlwXkytxGW/aokB9fZ6cSznYKM9ynDLHqhjcPve0KL4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6c4e2d9279e57369203ecfa159696c6a2af22130",
+        "rev": "7a58109958d14bcece8ec3e2085e41ea3351e387",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`7a581099`](https://github.com/nix-community/nixvim/commit/7a58109958d14bcece8ec3e2085e41ea3351e387) | `` tests/dependencies: extend the disabled logic to the "examples" test case `` |
| [`91073486`](https://github.com/nix-community/nixvim/commit/91073486b29c2e98a91e810bd7e0a37112996161) | `` tests/dependencies: add disabled list to skip testing broken dependencies `` |
| [`75efaa0a`](https://github.com/nix-community/nixvim/commit/75efaa0a97c7684609fa7c9a020b4ec940a1b7f5) | `` tests: move away from string comparisons with stdenv.hostPlatform ``         |
| [`d3c9dedb`](https://github.com/nix-community/nixvim/commit/d3c9dedbddc955dc22ded362aa1e2067f022b31f) | `` contributing: add "Writing option examples" section ``                       |
| [`199a3004`](https://github.com/nix-community/nixvim/commit/199a300488f6bfb5847fe906f0e8e183e0bf02c9) | `` Revert "tests/lsp: disable golangci_lint_ls" ``                              |
| [`86a88702`](https://github.com/nix-community/nixvim/commit/86a887025fbf46c0c077f4ce372502adce5d8cbf) | `` contributing: reduce emphasis on `settingsOptions` ``                        |
| [`55ad604d`](https://github.com/nix-community/nixvim/commit/55ad604d4417bfc514298913b955846d17ab563b) | `` modules/dependencies: restore literal expression example support ``          |
| [`fb80e0d0`](https://github.com/nix-community/nixvim/commit/fb80e0d0b58c567f3bde2cdc0a66225fdabddbe5) | `` modules/dependencies: coerce `__depPackages` attr-paths to list ``           |
| [`1164b399`](https://github.com/nix-community/nixvim/commit/1164b39963dbb0730af3dc25d2aff20c878055b5) | `` modules/dependencies: add `__depPackages` example ``                         |
| [`af2f4266`](https://github.com/nix-community/nixvim/commit/af2f4266e295f4fb5771a310afd5fad4df8f5949) | `` modules/dependencies: add description to `__depPackages` ``                  |
| [`490bb4e2`](https://github.com/nix-community/nixvim/commit/490bb4e2bdc64276c09856f3137044b48f68bf69) | `` plugins/lilypond-suite: init ``                                              |