### PR TITLE
chore(flake/nixvim): `7a581099` -> `78f6ff03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745244491,
-        "narHash": "sha256-UlwXkytxGW/aokB9fZ6cSznYKM9ynDLHqhjcPve0KL4=",
+        "lastModified": 1745415369,
+        "narHash": "sha256-XcbDjFXADOGDRXq9da4gvlKBLuMdDQ32ZSem5kf9MmE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7a58109958d14bcece8ec3e2085e41ea3351e387",
+        "rev": "78f6ff036918dcb6369f8b48abcef6a8788096e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`78f6ff03`](https://github.com/nix-community/nixvim/commit/78f6ff036918dcb6369f8b48abcef6a8788096e8) | `` plugins/lsp: use vim.lsp native API ``                                                            |
| [`954e5264`](https://github.com/nix-community/nixvim/commit/954e526448afa94caf2c3020e6932f74ce6b5e14) | `` flake/dev/flake.lock: Update ``                                                                   |
| [`e91333ae`](https://github.com/nix-community/nixvim/commit/e91333ae56b6ca1d206997cad9be9fe439bfa112) | `` plugins/lsp: remove string support for plugins.lsp.enabledServers elements ``                     |
| [`60638182`](https://github.com/nix-community/nixvim/commit/60638182b8d1b0fe13631d02eafaf8903499ee60) | `` tests/none-ls: disable rego and opacheck on aarch64-linux (build failure of open-policy-agent) `` |
| [`4f72d5c4`](https://github.com/nix-community/nixvim/commit/4f72d5c43e734e489819b048f8999860638ae1b3) | `` tests/{none-ls,efmls-configs}: disable ansible-lint (build failure) ``                            |
| [`9eb03ab7`](https://github.com/nix-community/nixvim/commit/9eb03ab777d32f9cc24efa3a745a8ca20a841e17) | `` treewide: disable godot (build failure) ``                                                        |
| [`d6709382`](https://github.com/nix-community/nixvim/commit/d6709382e7188398047968f7f69a530edeeddfbf) | `` tests: disable tests depending on broken sourcekit on aarch64-linux ``                            |
| [`70a9a0d4`](https://github.com/nix-community/nixvim/commit/70a9a0d4c15950ea40dc718e57522715e08689b2) | `` plugins/none-ls: add package for opentofu_validate ``                                             |
| [`2d50e6b1`](https://github.com/nix-community/nixvim/commit/2d50e6b1f446770e887dcdc5e9848b2d64d0d8b8) | `` generated: Update ``                                                                              |
| [`3c165713`](https://github.com/nix-community/nixvim/commit/3c165713780af466c7f466d615bdd9b94833c2ec) | `` flake/dev/flake.lock: Update ``                                                                   |
| [`6c36b335`](https://github.com/nix-community/nixvim/commit/6c36b335cd6ea9f4b564e5283ba7645b47240a2c) | `` flake.lock: Update ``                                                                             |
| [`d4a0db21`](https://github.com/nix-community/nixvim/commit/d4a0db2103d52b3b8e3ae502497ef9f19b048508) | `` docs: fix typo ``                                                                                 |