### PR TITLE
chore(flake/nixvim): `d86fe3df` -> `b72ba2e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745538632,
-        "narHash": "sha256-f2BzxQNoMF+wb+7b5O5p3fQ5r7I9u0ezzGBq2f38kl8=",
+        "lastModified": 1745593478,
+        "narHash": "sha256-GV0YnG6ZLW+BDsEKS2rjTtKcfTcTbdlVaf0ESQDBsK8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d86fe3df569c748b2632cfa5d27da0ea59709212",
+        "rev": "b72ba2e4e2af53269a19b99bf684480f3ad4a78f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`b72ba2e4`](https://github.com/nix-community/nixvim/commit/b72ba2e4e2af53269a19b99bf684480f3ad4a78f) | `` plugins/lsp/servers: replace `rootDir` with `rootMarkers` `` |
| [`a21504f2`](https://github.com/nix-community/nixvim/commit/a21504f2b084e7e1c5da09ca5cc87791d2564f3b) | `` flake/dev/flake.lock: Update ``                              |