### PR TITLE
chore(flake/nix-fast-build): `0e5cbf40` -> `fc256b5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1745781855,
-        "narHash": "sha256-0y0x9VF7UgNXyWZpgR55fVjzAxp1hd6aEwcff9NEFfs=",
+        "lastModified": 1745850287,
+        "narHash": "sha256-YsVPbA+6ytOz4hh7lSHieRzHGBw7uglWNQ47tPo2jIU=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "0e5cbf407f2189941a766906bafe919b71f9126f",
+        "rev": "fc256b5e39013bb147e230a4fec513bd72c3b699",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745780832,
-        "narHash": "sha256-jGzkZoJWx+nJnPe0Z2xQBUOqMKuR1slVFQrMjFTKgeM=",
+        "lastModified": 1745848521,
+        "narHash": "sha256-gNrTO3pEjmu3WiuYrUHJrTGCFw9v+qZXCFmX/Vjf5WI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "b2b6c027d708fbf4b01c9c11f6e80f2800b5a624",
+        "rev": "763f1ce0dd12fe44ce6a5c6ea3f159d438571874",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`fc256b5e`](https://github.com/Mic92/nix-fast-build/commit/fc256b5e39013bb147e230a4fec513bd72c3b699) | `` chore(deps): update treefmt-nix digest to 763f1ce (#132) `` |
| [`920f706a`](https://github.com/Mic92/nix-fast-build/commit/920f706ac442a3c8f969c8d9b3d0fdf91af21daf) | `` chore(deps): update treefmt-nix digest to d1863f3 (#131) `` |
| [`f05cc1dd`](https://github.com/Mic92/nix-fast-build/commit/f05cc1dd146de0ab4bd9a6972e28f7eecf853a15) | `` chore(deps): update treefmt-nix digest to c6d3010 (#130) `` |