### PR TITLE
chore(flake/nixvim): `89c94d9e` -> `7a6c5b48`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745746098,
-        "narHash": "sha256-3f6vvpa2/8XmzTaJjhUYtedlNMHIjwXJ6C2oWXBTubk=",
+        "lastModified": 1745878358,
+        "narHash": "sha256-YImreQ+dij3mLeqcjuIZZvT13Yscj7O1dxOC/+TZdJM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "89c94d9ea72d7080838981295f9b526eb3a960de",
+        "rev": "7a6c5b48031059ace82ce90b9a279ec243999554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`7a6c5b48`](https://github.com/nix-community/nixvim/commit/7a6c5b48031059ace82ce90b9a279ec243999554) | `` chore: remove empty "test" file ``                                                  |
| [`bf276f52`](https://github.com/nix-community/nixvim/commit/bf276f5223830fa48c52e38a2dad7c167d25fd30) | `` plugins/lspconfig: add HeitorAugustoLN as a maintainer ``                           |
| [`29aa22c4`](https://github.com/nix-community/nixvim/commit/29aa22c41a9b47d1d8aa78f4ef90475a24e17197) | `` modules/lsp: use relative link to `plugins.lspconfig` ``                            |
| [`5c67a96a`](https://github.com/nix-community/nixvim/commit/5c67a96a866f9a9004897e912e22b77b54a8a24a) | `` modules/lsp: get nvim-lspconfig link from `plugins.lspconfig.package` ``            |
| [`812b2b09`](https://github.com/nix-community/nixvim/commit/812b2b090343867f96e790af575821b04a352e99) | `` modules/lsp: update wording for `plugins.lspconfig` recommendation ``               |
| [`556eb295`](https://github.com/nix-community/nixvim/commit/556eb29548f02df308c414008ce028bdc97c3b04) | `` plugins/lspconfig: init ``                                                          |
| [`29aa60b4`](https://github.com/nix-community/nixvim/commit/29aa60b43ac6a3caafaa9f590365f0ac1830809f) | `` modules/lsp: add per-server `name` option ``                                        |
| [`3722f88c`](https://github.com/nix-community/nixvim/commit/3722f88c5da34c0c891108774f8e22ff7f26aea8) | `` modules/lsp: move server module to dedicated file ``                                |
| [`74368bcf`](https://github.com/nix-community/nixvim/commit/74368bcfc1dc504c903291f5b049fd3bac813bb9) | `` modules/lsp: move to dedicated directory ``                                         |
| [`70c9b3b8`](https://github.com/nix-community/nixvim/commit/70c9b3b890adc745227c51c287520dd5f8febd3d) | `` modules/lsp: init ``                                                                |
| [`9e0d2e4b`](https://github.com/nix-community/nixvim/commit/9e0d2e4bed56812bbc25adcbaa72e7dbe44c7287) | `` plugins/lsp: rename lua scope to nvim-lspconfig ``                                  |
| [`775e4d88`](https://github.com/nix-community/nixvim/commit/775e4d8856b5528317815f6f10581ce0252255a6) | `` plugins/luasnip: remove redundant jsregexp dependency ``                            |
| [`6415ae4a`](https://github.com/nix-community/nixvim/commit/6415ae4a9779286b4248a2dd2ed742d96f74bbbf) | `` tests/modules/performance/combine-plugins: improve assertion messages ``            |
| [`f28d384a`](https://github.com/nix-community/nixvim/commit/f28d384ab5729647764b740680c5b54629eed50f) | `` modules/performance/combine-plugins: propagate lua dependencies ``                  |
| [`57e19ec3`](https://github.com/nix-community/nixvim/commit/57e19ec3ecd45af908292ffd732847a64b29de51) | `` tests/modules/performance/combine-plugins: use stub plugins for tests ``            |
| [`9c39ea4c`](https://github.com/nix-community/nixvim/commit/9c39ea4ccbfbd0077a799d01ba2aab632bededfa) | `` tests/modules/performance/byte-compile-lua: fix tests ``                            |
| [`014b143f`](https://github.com/nix-community/nixvim/commit/014b143f6a78e13035c45d71061975387cde68e6) | `` tests/modules/performance/combine-plugins: restore test functionality ``            |
| [`faa31d99`](https://github.com/nix-community/nixvim/commit/faa31d994cb5c2f320869dbb21252e21abcda3fc) | `` Revert "tests/modules-performance: add nvim-cmp to extraPlugins when necessary" ``  |
| [`7bb135b0`](https://github.com/nix-community/nixvim/commit/7bb135b091f42654efc19fd1d0db9cd6c82bc314) | `` Revert "modules/performance: temporary add plenary to extraPlugins to fix tests" `` |
| [`65d3f2f4`](https://github.com/nix-community/nixvim/commit/65d3f2f4ae909f9ba597b1877c2e4fd93e04e562) | `` flake/dev/flake.lock: Update ``                                                     |
| [`3ea2ce7f`](https://github.com/nix-community/nixvim/commit/3ea2ce7ff66e040876c63028c37f906ff1748434) | `` Revert "plugins/lsp: use vim.lsp native API" ``                                     |
| [`836994b8`](https://github.com/nix-community/nixvim/commit/836994b8bc34aaced210b9ef1d005e2b0fb88381) | `` plugins/telescope/extensions: use mkExtension's dependencies parameter ``           |
| [`436fd243`](https://github.com/nix-community/nixvim/commit/436fd243cffc74ba32138c2a0647aa8954d1bd4c) | `` plugins/telescope: add dependencies parameter for mkExtension ``                    |
| [`1a646368`](https://github.com/nix-community/nixvim/commit/1a64636839aae0257af26dd7432bff0fb1e5e3e7) | `` plugins: use mk{Neovim,Vim}Plugin's dependencies parameter ``                       |
| [`b66559d8`](https://github.com/nix-community/nixvim/commit/b66559d8ef4e34e11ade974e478e1db5adc0575b) | `` lib/plugins/mk{Neovim,Vim}Plugin: add dependencies parameter ``                     |