### PR TITLE
chore(flake/nix-fast-build): `fc256b5e` -> `477f87d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1745850287,
-        "narHash": "sha256-YsVPbA+6ytOz4hh7lSHieRzHGBw7uglWNQ47tPo2jIU=",
+        "lastModified": 1745931313,
+        "narHash": "sha256-JFbvSvTNWCVtUyjzWyGVlMN/ZhLYrWUCEiJZDddnAoQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "fc256b5e39013bb147e230a4fec513bd72c3b699",
+        "rev": "477f87d03723596693cc15afc89a098d089a9efa",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745848521,
-        "narHash": "sha256-gNrTO3pEjmu3WiuYrUHJrTGCFw9v+qZXCFmX/Vjf5WI=",
+        "lastModified": 1745929750,
+        "narHash": "sha256-k5ELLpTwRP/OElcLpNaFWLNf8GRDq4/eHBmFy06gGko=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "763f1ce0dd12fe44ce6a5c6ea3f159d438571874",
+        "rev": "82bf32e541b30080d94e46af13d46da0708609ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`477f87d0`](https://github.com/Mic92/nix-fast-build/commit/477f87d03723596693cc15afc89a098d089a9efa) | `` chore(deps): update treefmt-nix digest to 82bf32e (#133) `` |