### PR TITLE
chore(flake/nixvim): `7a6c5b48` -> `cd3cbb1e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745878358,
-        "narHash": "sha256-YImreQ+dij3mLeqcjuIZZvT13Yscj7O1dxOC/+TZdJM=",
+        "lastModified": 1745933874,
+        "narHash": "sha256-K/bEekSd3iibHoTUgytBYJZd0/e4xQ4IyKkS+NI1XyI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7a6c5b48031059ace82ce90b9a279ec243999554",
+        "rev": "cd3cbb1e26f463543dc4710548ed35b0ac711370",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`cd3cbb1e`](https://github.com/nix-community/nixvim/commit/cd3cbb1e26f463543dc4710548ed35b0ac711370) | `` tests/lsp-servers: disable bitbake_language_server (build failure) `` |
| [`8ffba233`](https://github.com/nix-community/nixvim/commit/8ffba233d604bb6c7a3e539b5c7f95078d3dc937) | `` generated: Update ``                                                  |
| [`24353257`](https://github.com/nix-community/nixvim/commit/2435325720af8ff87166654b78d1648ea7352806) | `` flake/dev/flake.lock: Update ``                                       |
| [`947621fe`](https://github.com/nix-community/nixvim/commit/947621fe926ab4ff0a9e5ceeb7054e77a79f1533) | `` flake.lock: Update ``                                                 |
| [`944a3168`](https://github.com/nix-community/nixvim/commit/944a3168813367bb71389c53b94992f69b5be79f) | `` plugins/goto-preview: init ``                                         |
| [`9caeb512`](https://github.com/nix-community/nixvim/commit/9caeb51238748d885a91562e753d41b74155ff59) | `` docs: don't remove freeform sub-options ``                            |
| [`19528509`](https://github.com/nix-community/nixvim/commit/19528509e514fb25de9f07e0b976792f4e03643b) | `` plugins/dial: init ``                                                 |