### PR TITLE
chore(flake/nixvim): `cd3cbb1e` -> `a072e3c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745933874,
-        "narHash": "sha256-K/bEekSd3iibHoTUgytBYJZd0/e4xQ4IyKkS+NI1XyI=",
+        "lastModified": 1746056201,
+        "narHash": "sha256-IAOfL/Cc3PaLXlQkBhRBEMZ9BSRImbb36VMOIBWS3pg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cd3cbb1e26f463543dc4710548ed35b0ac711370",
+        "rev": "a072e3c3a710ee2c76c971a29cca5ae700fc96da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`a072e3c3`](https://github.com/nix-community/nixvim/commit/a072e3c3a710ee2c76c971a29cca5ae700fc96da) | `` modules/lsp: enable `servers."*"` by default ``                                |
| [`b6e2016b`](https://github.com/nix-community/nixvim/commit/b6e2016b7fa5dba2f7f62e71828fba5db505b4cf) | `` modules/lsp: check if server `settings` is empty ``                            |
| [`f2e96b67`](https://github.com/nix-community/nixvim/commit/f2e96b67a30859ae21fc626bd33cc74c4d95d356) | `` modules/lsp: declare a stripped down `servers."*"` option ``                   |
| [`04c32471`](https://github.com/nix-community/nixvim/commit/04c3247144ca8cf8eb138d3bca0ee65da41df494) | `` docs: ensure path is escaped when copying module docs ``                       |
| [`6297f4c0`](https://github.com/nix-community/nixvim/commit/6297f4c01a70c9af30b1678ca238976b9e2bf4aa) | `` plugins/vimade: init ``                                                        |
| [`913a3521`](https://github.com/nix-community/nixvim/commit/913a3521ab9ce9223957a1679914e71498a4be43) | `` plugins/ident-tools: init ``                                                   |
| [`eeae3620`](https://github.com/nix-community/nixvim/commit/eeae36203848b34a7ef3f8710d357c7dce84cfa4) | `` modules/lsp: add `enable = true` to wildcard config section ``                 |
| [`2d65c66a`](https://github.com/nix-community/nixvim/commit/2d65c66a1a4354230ce72fdde89cc05b5d4ec741) | `` modules/lsp: don't enable wildcard server ``                                   |
| [`1df98b66`](https://github.com/nix-community/nixvim/commit/1df98b6636e64b88d765370ceeff5bf158c602ee) | `` modules/diagnostic: rename `diagnostic.config` -> `diagnostic.settings` ``     |
| [`405a564f`](https://github.com/nix-community/nixvim/commit/405a564f3dea151ec86794b68a5ce18c85c3be47) | `` plugins/actions-preview: init ``                                               |
| [`21688b1d`](https://github.com/nix-community/nixvim/commit/21688b1d2a1f3f351fb95ab4301ac1968ce8ee4a) | `` modules/lsp/server: rename `config` -> `settings` ``                           |
| [`fc6f00a7`](https://github.com/nix-community/nixvim/commit/fc6f00a7fd3bde993145de19b5a71f89da36ec33) | `` flake/dev/flake.lock: Update ``                                                |
| [`edc9a469`](https://github.com/nix-community/nixvim/commit/edc9a469c978b8758938617791d97c8ce127440d) | `` flake.lock: Update ``                                                          |
| [`e34eaf83`](https://github.com/nix-community/nixvim/commit/e34eaf8395855bf8b1b1a40b38f4c9e9abe2a38d) | `` modules/lsp/server: declare `package` defaults ``                              |
| [`276abde2`](https://github.com/nix-community/nixvim/commit/276abde28827aa339343fa08b71505fa60a9f386) | `` plugins/peek: init ``                                                          |
| [`76a319c5`](https://github.com/nix-community/nixvim/commit/76a319c5ab0055d224d07511c0d19f133cbd2186) | `` Revert "tests/lsp-servers: disable bitbake_language_server (build failure)" `` |
| [`0c4ef8e0`](https://github.com/nix-community/nixvim/commit/0c4ef8e01b118887cea86afb4170a085d56b5259) | `` flake/dev/flake.lock: Update ``                                                |
| [`ce10295d`](https://github.com/nix-community/nixvim/commit/ce10295ddfe5bbc48d059e0994508c3f7d7c84b8) | `` flake.lock: Update ``                                                          |