### PR TITLE
chore(flake/nixvim): `a072e3c3` -> `0ec7ea3d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1746056201,
-        "narHash": "sha256-IAOfL/Cc3PaLXlQkBhRBEMZ9BSRImbb36VMOIBWS3pg=",
+        "lastModified": 1746138649,
+        "narHash": "sha256-mLtPx5Zb6b3iMmypaYsxzA8vjiI6DQObpbmGcn5QDjo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a072e3c3a710ee2c76c971a29cca5ae700fc96da",
+        "rev": "0ec7ea3d6242de84c8a18b228b963064751cb56d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`0ec7ea3d`](https://github.com/nix-community/nixvim/commit/0ec7ea3d6242de84c8a18b228b963064751cb56d) | `` user-configs: add @LudovicDeMatteis's config `` |
| [`c91753bb`](https://github.com/nix-community/nixvim/commit/c91753bbe57781e08226829b9e354facd50caf1b) | `` flake/dev/flake.lock: Update ``                 |
| [`6ae7753c`](https://github.com/nix-community/nixvim/commit/6ae7753cfd07848a8821e30de37257dc487a55d0) | `` flake.lock: Update ``                           |