### PR TITLE
chore(flake/nixpkgs): `46e634be` -> `91bf6dff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745930157,
-        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "lastModified": 1746064326,
+        "narHash": "sha256-r7IZkN9NhK/IO9/J6D9ih2P1OXb67nr5HaQ1YAte18w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "rev": "91bf6dffa21c7709607c9fdbf9a6acb44e7a0a5d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                        |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| [`b6867610`](https://github.com/NixOS/nixpkgs/commit/b686761047077698d9f22e3a9429a842dc045037) | `` ungoogled-chromium: 135.0.7049.114-1 -> 136.0.7103.59-1 ``                                                  |
| [`bcb6da4a`](https://github.com/NixOS/nixpkgs/commit/bcb6da4a2346d3c745ac39ef5784dfa295652394) | `` luaPackages.http: 0.3.0->0.4.0 ``                                                                           |
| [`2e9f1c1b`](https://github.com/NixOS/nixpkgs/commit/2e9f1c1b700a662ba427b4963bcb822d5366c240) | `` thunderbird-unwrapped: 137.0.2 -> 138.0 ``                                                                  |
| [`9de82e99`](https://github.com/NixOS/nixpkgs/commit/9de82e992cd9b5b09941f8e46c75adc3b024e3b8) | `` frigate: fix platform-based condition ``                                                                    |
| [`0aa88a9e`](https://github.com/NixOS/nixpkgs/commit/0aa88a9e315d2ad1cf599ea599da75e7b7dcdd46) | `` foot: update 1.22.0 -> 1.22.2 ``                                                                            |
| [`699c9444`](https://github.com/NixOS/nixpkgs/commit/699c9444857729da85237bc1736aec785d8cc7ee) | `` foot: use tag over rev in fetcher ``                                                                        |
| [`79721c69`](https://github.com/NixOS/nixpkgs/commit/79721c691f1d0a6c45e108de9416bbe155f4c2f2) | `` foot: add `passthru.updateScript` ``                                                                        |
| [`640dc34d`](https://github.com/NixOS/nixpkgs/commit/640dc34dac13f8a222fb2f7098a63e3514564f05) | `` gdevelop: add darwin maintainer ``                                                                          |
| [`e559000e`](https://github.com/NixOS/nixpkgs/commit/e559000e937f3a6c0fc9600b42c1c47dbf049e76) | `` gdevelop: darwin support ``                                                                                 |
| [`8b049280`](https://github.com/NixOS/nixpkgs/commit/8b049280b18daf3005e5b72376e365ebf76a9a05) | `` python313Packages.pyiceberg: fix on python 3.13 ``                                                          |
| [`e391f3d1`](https://github.com/NixOS/nixpkgs/commit/e391f3d1ca58c8ac6850b76df5b17d85f95bd192) | `` h2o: 2.3.0.20250421 → 2.3.0.20250430 ``                                                                     |
| [`a57be8c6`](https://github.com/NixOS/nixpkgs/commit/a57be8c651afe82372f4507dba126d88a5c1ea45) | `` python312Packages.ray: 2.44.0 -> 2.45.0 ``                                                                  |
| [`8bcc2256`](https://github.com/NixOS/nixpkgs/commit/8bcc2256c01d0ba090cc96a72bafb7f1ddd02705) | `` yaziPlugins.yatline: 0-unstable-2025-04-11 -> 0-unstable-2025-04-22 ``                                      |
| [`c0a2db75`](https://github.com/NixOS/nixpkgs/commit/c0a2db752eee295709fa27e8806e0e91272abeeb) | `` doc: add knownVulnerabilities ``                                                                            |
| [`8da969f2`](https://github.com/NixOS/nixpkgs/commit/8da969f2a195c50f4247627b7f7ccc0e2ee1750e) | `` albedo: 0.1.0 -> 0.2.0 ``                                                                                   |
| [`5c15c23b`](https://github.com/NixOS/nixpkgs/commit/5c15c23b2b831e4c64fa747a0fba6a64922df83f) | `` wiremock: 3.12.1 -> 3.13.0 ``                                                                               |
| [`c3eb844a`](https://github.com/NixOS/nixpkgs/commit/c3eb844a39ad3877b115b84e78d81e00efa5e05c) | `` python312Packages.snapcast: 2.3.6 -> 2.3.7 ``                                                               |
| [`0de31cfe`](https://github.com/NixOS/nixpkgs/commit/0de31cfe1b94f99a1ead920648374de56a1a9228) | `` moonlight: 1.3.14 -> 1.3.16 ``                                                                              |
| [`59ce228c`](https://github.com/NixOS/nixpkgs/commit/59ce228cf96c01f08ebeb5338ac8ec2660adeb30) | `` tomcat: 11.0.5 -> 11.0.6 ``                                                                                 |
| [`6bbeee24`](https://github.com/NixOS/nixpkgs/commit/6bbeee244cb725efe3016cb105d3732614ddeed1) | `` uv: 0.7.1 -> 0.7.2 ``                                                                                       |
| [`8fcae5ec`](https://github.com/NixOS/nixpkgs/commit/8fcae5ece56da0d5de90eb2d2d9aecc69d1e4640) | `` octodns-providers.bind: 0.0.6 -> 0.0.7 ``                                                                   |
| [`d39e75bb`](https://github.com/NixOS/nixpkgs/commit/d39e75bb8b8c6905ee0752bba627ad96b67ad87d) | `` octodns: 1.10.0 -> 1.11.0 ``                                                                                |
| [`e2afb5b2`](https://github.com/NixOS/nixpkgs/commit/e2afb5b2eb6046ea6e8e9265d1a606fc4e34c432) | `` kin-openapi: 0.131.0 -> 0.132.0 ``                                                                          |
| [`399325e3`](https://github.com/NixOS/nixpkgs/commit/399325e30a4cbfab4f318082da510030b1bcaa18) | `` _1password-gui: 8.10.72 -> 8.10.75 ``                                                                       |
| [`1cfacd77`](https://github.com/NixOS/nixpkgs/commit/1cfacd777b1ee1e77cd392b989d00980f2e0384b) | `` orbiton: 2.68.9 -> 2.69.0 ``                                                                                |
| [`4f86f5ae`](https://github.com/NixOS/nixpkgs/commit/4f86f5aef450336e15a0e53e0012ac70b75c2862) | `` electron_32-bin, electron-chromedriver_32: remove (#402556) ``                                              |
| [`ad8675b2`](https://github.com/NixOS/nixpkgs/commit/ad8675b238575bb8dcf4ab2f6cc31fe9ead58d9b) | `` typstyle: 0.13.3 -> 0.13.4 ``                                                                               |
| [`b33937b0`](https://github.com/NixOS/nixpkgs/commit/b33937b00f85e88d081efbd914c49ab121b5240a) | `` python3Packages.whisperx: init at 3.3.2 ``                                                                  |
| [`0a636861`](https://github.com/NixOS/nixpkgs/commit/0a6368616cdeca7525b3ea64b086b188c416ee60) | `` python312Packages.torchrl: 0.7.2 -> 0.8.0 ``                                                                |
| [`1b1047da`](https://github.com/NixOS/nixpkgs/commit/1b1047da21c1d7f76b5a5f9cc871396c7f1ded73) | `` python312Packages.namex: 0.0.8 -> 0.0.9 ``                                                                  |
| [`548fb1af`](https://github.com/NixOS/nixpkgs/commit/548fb1afe01859d1b58a1e19329ee5353cf57a2e) | `` python312Packages.pysmartthings: 3.0.5 -> 3.2.0 ``                                                          |
| [`cb61bfdb`](https://github.com/NixOS/nixpkgs/commit/cb61bfdbe1bbc1d9cffaa0c7752a8c6cea180b58) | `` python312Packages.thinqconnect: 1.0.5 -> 1.0.6 ``                                                           |
| [`ba551e40`](https://github.com/NixOS/nixpkgs/commit/ba551e403c83cfd75f33972507079a6ccf7780d8) | `` nh: 4.0.0 -> 4.0.3; add changelog ``                                                                        |
| [`048ae19d`](https://github.com/NixOS/nixpkgs/commit/048ae19dfee189a59459555824e6b0feabe6fc8a) | `` python3Packages.fireworks-ai: init at 0.15.12 ``                                                            |
| [`ee2126ca`](https://github.com/NixOS/nixpkgs/commit/ee2126ca56592aaa4b3249c8956abd8a9fd38799) | `` python3Packages.langchain: 0.3.21 -> 0.3.24 ``                                                              |
| [`8bbd1a2b`](https://github.com/NixOS/nixpkgs/commit/8bbd1a2ba8a07f1e500b639e032f87694d5a24d3) | `` python3Packages.langchain-community: 0.3.20 -> 0.3.22 ``                                                    |
| [`9ecfef08`](https://github.com/NixOS/nixpkgs/commit/9ecfef08c81d256b7c1bde2d46f7bb03105f5285) | `` python312Packages.pyiceberg: 0.9.0 -> 0.9.1 ``                                                              |
| [`0401e33f`](https://github.com/NixOS/nixpkgs/commit/0401e33f9d8c6bf4258462051f34a043c825e5f3) | `` python312Packages.dm-control: 1.0.28 -> 1.0.30 ``                                                           |
| [`921ee2ac`](https://github.com/NixOS/nixpkgs/commit/921ee2aca2dbdf417a21ab8156e6a8210655303a) | `` google-chrome: 135.0.7049.114 -> 136.0.7103.59 ``                                                           |
| [`0debc521`](https://github.com/NixOS/nixpkgs/commit/0debc521784e8f860c65e4362031b92a408a0a9a) | `` homepage-dashboard: 1.1.1 -> 1.2.0 ``                                                                       |
| [`334faf28`](https://github.com/NixOS/nixpkgs/commit/334faf28c5b9cbf6d393ca78878cd787f701d8ba) | `` homepage-dashboard: fix update script ``                                                                    |
| [`52d385c3`](https://github.com/NixOS/nixpkgs/commit/52d385c37a6792aa5a91184dad896225e927df74) | `` bluesnooze: init at 1.2 ``                                                                                  |
| [`548048e7`](https://github.com/NixOS/nixpkgs/commit/548048e7f1155ee7975d281f2c6b9a005b9f9c6d) | `` python312Packages.tensordict: 0.8.0 -> 0.8.1 ``                                                             |
| [`135b7895`](https://github.com/NixOS/nixpkgs/commit/135b7895da4007c708d4b3b3a6d1c8c80e34d306) | `` wakapi: 2.13.3 -> 2.13.4 ``                                                                                 |
| [`f5d30316`](https://github.com/NixOS/nixpkgs/commit/f5d30316a7be7796fb3509f4942f69026b1e1cd0) | `` alan_2: move to by-name ``                                                                                  |
| [`9656f3ca`](https://github.com/NixOS/nixpkgs/commit/9656f3ca923aa1c5123c3a12b303f66c0ad80e14) | `` alan: move to by-name ``                                                                                    |
| [`c65dd72f`](https://github.com/NixOS/nixpkgs/commit/c65dd72f0010b5d4f04b1389301ef0226981ac2f) | `` alan_2: modernize ``                                                                                        |
| [`1a3bd1ba`](https://github.com/NixOS/nixpkgs/commit/1a3bd1ba740b883999a00c484e225a185e8f160c) | `` alan_2: unbreak on gcc 14 ``                                                                                |
| [`1b3e9d96`](https://github.com/NixOS/nixpkgs/commit/1b3e9d962903ce14aab822349cc122f47df51046) | `` alan: modernize ``                                                                                          |
| [`04a0ec04`](https://github.com/NixOS/nixpkgs/commit/04a0ec047a0eb25d2aa14710bc0dfc7f5b19cda0) | `` vimPlugins.tinted-vim: init at 2025-04-27 ``                                                                |
| [`b79f0613`](https://github.com/NixOS/nixpkgs/commit/b79f0613a754538b5a9e5a4576a97b33b95b36ef) | `` pcloud: 1.14.11 -> 1.14.12 ``                                                                               |
| [`0a4b3ab0`](https://github.com/NixOS/nixpkgs/commit/0a4b3ab0420ff8561fecce151bd0721b4840445d) | `` copilot-language-server: 1.304.0 -> 1.311.0 ``                                                              |
| [`ca43f154`](https://github.com/NixOS/nixpkgs/commit/ca43f154298a0782fd63ab04933d8fbeb1371344) | `` bililiverecorder: 2.16.0 -> 2.17.0 ``                                                                       |
| [`244118c1`](https://github.com/NixOS/nixpkgs/commit/244118c1b41fb9f274cf0d60b0c7cf7ec00285df) | `` cariddi: 1.4.0 -> 1.4.1 ``                                                                                  |
| [`10bb9e25`](https://github.com/NixOS/nixpkgs/commit/10bb9e25e084a9bd5faeea0caf91304e6839417d) | `` elan: 4.0.1 -> 4.1.1 ``                                                                                     |
| [`788d4a7a`](https://github.com/NixOS/nixpkgs/commit/788d4a7a5cdad1be224933f75949877e68e69574) | `` python312Packages.pylnk3: 0.4.2 -> 0.4.3 ``                                                                 |
| [`58072cb5`](https://github.com/NixOS/nixpkgs/commit/58072cb5f4d7991df7c609898bd3d951573c87a4) | `` electron_33-bin: 33.4.10 -> 33.4.11 ``                                                                      |
| [`a30bf0fc`](https://github.com/NixOS/nixpkgs/commit/a30bf0fc8017cc1715a8afa8e5e80010a8ddd663) | `` electron-chromedriver_33: 33.4.10 -> 33.4.11 ``                                                             |
| [`a3e248ad`](https://github.com/NixOS/nixpkgs/commit/a3e248ad6ba1645e2dcca511506619639f2ef643) | `` electron-chromedriver_35: 35.2.0 -> 35.2.1 ``                                                               |
| [`d3a043f3`](https://github.com/NixOS/nixpkgs/commit/d3a043f379dd51cd981bda2c8f28c83408863121) | `` electron_35-bin: 35.2.0 -> 35.2.1 ``                                                                        |
| [`81a53fd8`](https://github.com/NixOS/nixpkgs/commit/81a53fd87bc3bb52a4d284c50f23a07ad4556e9a) | `` electron-chromedriver_34: 34.5.2 -> 34.5.3 ``                                                               |
| [`b3b5bb7a`](https://github.com/NixOS/nixpkgs/commit/b3b5bb7aa1473e5384a8c89e0903e7e51e8fe086) | `` electron_34-bin: 34.5.2 -> 34.5.3 ``                                                                        |
| [`4e746680`](https://github.com/NixOS/nixpkgs/commit/4e7466802afcedb02c3e17b722f71a6125c4c2c0) | `` electron-source.electron_35: 35.2.0 -> 35.2.1 ``                                                            |
| [`3fd9664e`](https://github.com/NixOS/nixpkgs/commit/3fd9664e952d80dadedd1c62fe2bf2e34ab15d73) | `` electron-source.electron_34: 34.5.2 -> 34.5.3 ``                                                            |
| [`d9c296b4`](https://github.com/NixOS/nixpkgs/commit/d9c296b4e596cb3f6ed6433fecd742763d4b101c) | `` jreleaser-cli: 1.17.0 -> 1.18.0 ``                                                                          |
| [`8bc0fcaf`](https://github.com/NixOS/nixpkgs/commit/8bc0fcaf7dbe9ca643f797e5ea0c13c3d9d2fe62) | `` loksh: 7.6 -> 7.7 ``                                                                                        |
| [`2695c8d3`](https://github.com/NixOS/nixpkgs/commit/2695c8d3363fd3417ed6ba7da5e833c21ac8482a) | `` obs-studio-plugins.obs-source-record: 0.4.5 -> 0.4.6 ``                                                     |
| [`568c49b8`](https://github.com/NixOS/nixpkgs/commit/568c49b8e6299630c165ac084c5fe21c562cde78) | `` ncps: 0.1.1 -> 0.2.0 ``                                                                                     |
| [`10e6b845`](https://github.com/NixOS/nixpkgs/commit/10e6b845e8c1b0a45fed569688a2323426003fda) | `` pmtiles: 1.27.2 -> 1.28.0 ``                                                                                |
| [`de2767ab`](https://github.com/NixOS/nixpkgs/commit/de2767ab06caba76cdccee2c17dddebd8880c3d9) | `` reflection-cpp: 0.2.0 -> 0.3.0 ``                                                                           |
| [`623472e4`](https://github.com/NixOS/nixpkgs/commit/623472e4cbdf967ecf6771e8c846c5e1e8c64cd1) | `` maintainers: add agvantibo ``                                                                               |
| [`61dee033`](https://github.com/NixOS/nixpkgs/commit/61dee0330f46127f8f8a63c21d640703a7a76eea) | `` sherlock-launcher: init at 0.1.10 ``                                                                        |
| [`a53f7247`](https://github.com/NixOS/nixpkgs/commit/a53f7247ac9fa20030bac582c65e319cb8504fca) | `` stackit-cli: 0.30.0 -> 0.31.0 ``                                                                            |
| [`796bda51`](https://github.com/NixOS/nixpkgs/commit/796bda512398473ca60f5383fcc9bdf959adabc1) | `` ttdl: 4.10.0 -> 4.11.0 ``                                                                                   |
| [`034802a5`](https://github.com/NixOS/nixpkgs/commit/034802a5fef24f05b3db24325af3ea93592e0583) | `` qdocumentview: 0.3.0 -> 0.3.0.1 ``                                                                          |
| [`a0fd301f`](https://github.com/NixOS/nixpkgs/commit/a0fd301faade022c5ac2f57dda50e63a6554484e) | `` python312Packages.llama-cloud: 0.1.18 -> 0.1.19 ``                                                          |
| [`2c512920`](https://github.com/NixOS/nixpkgs/commit/2c51292032a374759eb5b52426426f9819ab4032) | `` netbird: 0.43.0 -> 0.43.1 ``                                                                                |
| [`1d2fe24f`](https://github.com/NixOS/nixpkgs/commit/1d2fe24fa4b39fee2aa9c9fd42bdf88589fb0f1a) | `` python3Packages.{pylance,pytorch-metric-learning,skorch}: torch.distributed is now enabled on darwin too `` |
| [`f0df3d4d`](https://github.com/NixOS/nixpkgs/commit/f0df3d4d277136a94a60dfdc59f3774ca79bee29) | `` python312Packages.openstackdocstheme: 3.4.1 -> 3.5.0 ``                                                     |
| [`83e510fe`](https://github.com/NixOS/nixpkgs/commit/83e510fe7bbfdaabd0b12f7da6823b435eb76610) | `` nodeinfo: 0.3.2 -> 1.0.0 ``                                                                                 |
| [`3dbece71`](https://github.com/NixOS/nixpkgs/commit/3dbece71219c0ed09d0247567abd273562ce7a54) | `` uv: 0.7.0 -> 0.7.1 ``                                                                                       |
| [`339d1d1c`](https://github.com/NixOS/nixpkgs/commit/339d1d1cb1f669d534acdae9641185ea97b5970d) | `` importNpmLock: handle "resolved" is null ``                                                                 |
| [`497ff532`](https://github.com/NixOS/nixpkgs/commit/497ff532d2ba9a5ebbcbf850b342f06245ff2dc4) | `` python312Packages.django-markdownx: 4.0.7 -> 4.0.9 ``                                                       |
| [`d6bbfcdf`](https://github.com/NixOS/nixpkgs/commit/d6bbfcdfc89abdb15439b4dbbf3874d13c64e847) | `` kew: linux audio fix ``                                                                                     |
| [`cecb5a0d`](https://github.com/NixOS/nixpkgs/commit/cecb5a0dcb24b07bc111a04ca6e97e82893fce85) | `` python312Packages.tenant-schemas-celery: 4.0.0 -> 4.0.1 ``                                                  |
| [`a9f57280`](https://github.com/NixOS/nixpkgs/commit/a9f57280edf0e6fb527a876d7e8317b4aa57de75) | `` odp-dpdk: fixes for dpdk 25.03 ``                                                                           |
| [`40a218f9`](https://github.com/NixOS/nixpkgs/commit/40a218f9f80cd4a0ef7dbe3d11ab5fe3ad455dda) | `` pktgen: 23.10.0 -> 24.10.3 ``                                                                               |
| [`fbb2875f`](https://github.com/NixOS/nixpkgs/commit/fbb2875fe1acb8b9b5afa7679de1b79c3598612c) | `` vpp: 24.10 -> 25.02 ``                                                                                      |
| [`7cc6471a`](https://github.com/NixOS/nixpkgs/commit/7cc6471a87b2d5feb1d95d7034bec98c80e4c37f) | `` python312Packages.fastexcel: 0.13.0 -> 0.14.0 ``                                                            |
| [`97c362cb`](https://github.com/NixOS/nixpkgs/commit/97c362cbfb004289d4848ae7953ca1bad30bdabe) | `` spdk: fix build with dpdk 25.03 ``                                                                          |
| [`7a443c22`](https://github.com/NixOS/nixpkgs/commit/7a443c2232b666a1e7d979bf15cf5acf56b09d39) | `` inputplumber: 0.53.0 -> 0.56.0 ``                                                                           |
| [`4cb77542`](https://github.com/NixOS/nixpkgs/commit/4cb775429d0a6cb2470218a370e0b18cab206bd2) | `` csharp-ls: 0.16.0 -> 0.17.0 ``                                                                              |
| [`821a22f5`](https://github.com/NixOS/nixpkgs/commit/821a22f550545ff50b3d36934f8c0952382b2837) | `` tinymist: 0.13.10 -> 0.13.12 ``                                                                             |
| [`bc2b4e77`](https://github.com/NixOS/nixpkgs/commit/bc2b4e77d888ff13effd7b244c37dc135bbc9b7c) | `` llvmPackages: add comments for all patches in LLVM and CLang ``                                             |
| [`0c929e9b`](https://github.com/NixOS/nixpkgs/commit/0c929e9b0e7e5967da9126f965226fedfe40e148) | `` mongoc: 1.30.2 -> 1.30.3 ``                                                                                 |
| [`f9398d6d`](https://github.com/NixOS/nixpkgs/commit/f9398d6d3257345ed991051eaa20dc0b33c36e91) | `` kubedb-cli: 0.53.0 -> 0.54.0 ``                                                                             |
| [`f026e745`](https://github.com/NixOS/nixpkgs/commit/f026e745297aadf8c77978e6cd2ec92ef2249217) | `` honeyvent: 1.1.0 -> 1.1.3 ``                                                                                |
| [`75568b94`](https://github.com/NixOS/nixpkgs/commit/75568b94f6a3a10d30e5b3ca0a67c1a95a8ec32f) | `` goreleaser: 2.8.2 -> 2.9.0 ``                                                                               |
| [`5cfc3262`](https://github.com/NixOS/nixpkgs/commit/5cfc32620958e566d59b1ef3892039691c33e64a) | `` nushell: 0.103.0 -> 0.104.0 ``                                                                              |
| [`6b7ce071`](https://github.com/NixOS/nixpkgs/commit/6b7ce071158e902907fbcf31962736c931d01359) | `` faketty: 1.0.18 -> 1.0.19 ``                                                                                |
| [`a7a65d53`](https://github.com/NixOS/nixpkgs/commit/a7a65d53a2e2a0825fb12477f6c4e82b065755fa) | `` python312Packages.unsloth: init at 2025.4.1 ``                                                              |
| [`81b8490b`](https://github.com/NixOS/nixpkgs/commit/81b8490b10cbb7afe3d219bac85571aa2a76f619) | `` python312Packages.unsloth-zoo: init at 2025.4.1 ``                                                          |
| [`4dfea7e0`](https://github.com/NixOS/nixpkgs/commit/4dfea7e0c0a40a0b7e891ea148968ea01e145599) | `` python312Packages.tyro: init at 0.9.19 ``                                                                   |
| [`b457279b`](https://github.com/NixOS/nixpkgs/commit/b457279ba3e79cafe8b07a644493a2b37f50fde1) | `` python312Packages.trl: init at 0.15.2 ``                                                                    |
| [`ac344136`](https://github.com/NixOS/nixpkgs/commit/ac3441361a9d2de4b68f54c48dc1978960a3a37b) | `` python312Packages.cut-cross-entropy: init at 25.3.1 ``                                                      |
| [`ec6d0a37`](https://github.com/NixOS/nixpkgs/commit/ec6d0a3753234ebd1127d01ee943b2daf16f696b) | `` maintainers: add hoh ``                                                                                     |
| [`e31e0aee`](https://github.com/NixOS/nixpkgs/commit/e31e0aee18fe4d60aa682249867c9cc0d5183d67) | `` coc-basedpyright: init at 0-unstable-2025-04-30 ``                                                          |
| [`7fd4e730`](https://github.com/NixOS/nixpkgs/commit/7fd4e73000eb673fcca138f6c794e719a6016628) | `` nix: update nix-fallback-paths to 2.28.3 ``                                                                 |
| [`50a572e1`](https://github.com/NixOS/nixpkgs/commit/50a572e12ba0dd4147d9b096cc44e7e62e8ec3a6) | `` nixVersions.nix_2_28: 2.28.2 -> 2.28.3 ``                                                                   |
| [`9971cc7a`](https://github.com/NixOS/nixpkgs/commit/9971cc7a0e633f060747e27d72b2f8570c1e9ea9) | `` ghmap: init at 1.0.2 ``                                                                                     |
| [`b4d31d66`](https://github.com/NixOS/nixpkgs/commit/b4d31d66efecdc166edeb59208a5619e13ff68f5) | `` cc-wrapper: autofix code style ``                                                                           |
| [`43ad6690`](https://github.com/NixOS/nixpkgs/commit/43ad669079e027588b993333851e5e1c631479de) | `` krillinai: 1.1.3 -> 1.1.4 ``                                                                                |
| [`920a79ee`](https://github.com/NixOS/nixpkgs/commit/920a79ee9b49febd7a8b7251e210aeee9c06b644) | `` ocamlPackages.core_unix: 0.17.0 → 0.17.1 ``                                                                 |
| [`b094fc9f`](https://github.com/NixOS/nixpkgs/commit/b094fc9f31c9e70deec7408320ca682b58f435e5) | `` hydralauncher: 3.4.4 -> 3.4.5 ``                                                                            |
| [`7aa182d8`](https://github.com/NixOS/nixpkgs/commit/7aa182d823e54f814acae25f11e1f4bb6c15e020) | `` python312Packages.nexia: 2.7.0 -> 2.8.0 ``                                                                  |