### PR TITLE
chore(flake/nix-fast-build): `477f87d0` -> `e9476294`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1745931313,
-        "narHash": "sha256-JFbvSvTNWCVtUyjzWyGVlMN/ZhLYrWUCEiJZDddnAoQ=",
+        "lastModified": 1746390439,
+        "narHash": "sha256-b9kKckpMGXAWwwRcD4Y9PRQH2GPCEmJ6M4FK9S28ykI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "477f87d03723596693cc15afc89a098d089a9efa",
+        "rev": "e947629455fa6f36701f5c39669d0e5a634324dd",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745929750,
-        "narHash": "sha256-k5ELLpTwRP/OElcLpNaFWLNf8GRDq4/eHBmFy06gGko=",
+        "lastModified": 1746216483,
+        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "82bf32e541b30080d94e46af13d46da0708609ea",
+        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`e9476294`](https://github.com/Mic92/nix-fast-build/commit/e947629455fa6f36701f5c39669d0e5a634324dd) | `` chore(deps): update nixpkgs digest to 0ab7cd9 (#137) ``     |
| [`ce7847bf`](https://github.com/Mic92/nix-fast-build/commit/ce7847bf427a5fea76b941fa73e24b7514d7bf90) | `` chore(deps): lock file maintenance (#125) ``                |
| [`e42dc94a`](https://github.com/Mic92/nix-fast-build/commit/e42dc94ac629ee5e1d8b7ea521e3713827a1743a) | `` bump line-length limit to 10MB for nix-eval-jobs ``         |
| [`cc574559`](https://github.com/Mic92/nix-fast-build/commit/cc57455901b52c3f50f61775b131919683147b0a) | `` chore(deps): update nixpkgs digest to a4b6cee ``            |
| [`612ce2f2`](https://github.com/Mic92/nix-fast-build/commit/612ce2f20de14d83af8c12c0034c3607eaf1786d) | `` chore(deps): update nixpkgs digest to a4b6cee (#124) ``     |
| [`6bbdca21`](https://github.com/Mic92/nix-fast-build/commit/6bbdca2161834b917fe58b64c97156e99b39a839) | `` chore(deps): update treefmt-nix digest to 29ec502 (#134) `` |