### PR TITLE
chore(flake/nixvim): `0ec7ea3d` -> `4b276785`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1746138649,
-        "narHash": "sha256-mLtPx5Zb6b3iMmypaYsxzA8vjiI6DQObpbmGcn5QDjo=",
+        "lastModified": 1746221140,
+        "narHash": "sha256-lXFXddrfTY47kF3IGmUQHgJssvGnYY5T4luL+1UmCkc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0ec7ea3d6242de84c8a18b228b963064751cb56d",
+        "rev": "4b27678512c4b8a3c16676fd6d5d885f2fb84cb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`4b276785`](https://github.com/nix-community/nixvim/commit/4b27678512c4b8a3c16676fd6d5d885f2fb84cb3) | `` plugins/iron: init ``                   |
| [`a681f744`](https://github.com/nix-community/nixvim/commit/a681f7441da1e7d787e38922fcb04f6e47a28231) | `` flake/dev/flake.lock: Update ``         |
| [`da3e7374`](https://github.com/nix-community/nixvim/commit/da3e7374a9ee7bbc96968479e79c6c9ac580b01f) | `` flake.lock: Update ``                   |
| [`98644a34`](https://github.com/nix-community/nixvim/commit/98644a34abcda94b8bed8ecaeec8be6edc657a09) | `` plugins/origami: init ``                |
| [`cd30817b`](https://github.com/nix-community/nixvim/commit/cd30817b21f325ac0076c68c08f05875df94f03c) | `` plugins/tiny-inline-diagnostic: init `` |