### PR TITLE
chore(flake/nix-fast-build): `e9476294` -> `9b271cb4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746390439,
-        "narHash": "sha256-b9kKckpMGXAWwwRcD4Y9PRQH2GPCEmJ6M4FK9S28ykI=",
+        "lastModified": 1746470700,
+        "narHash": "sha256-azv9tuIs1tkkdvgNr/2m4i2ZbkeXHdbVNZCam6QT/uA=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "e947629455fa6f36701f5c39669d0e5a634324dd",
+        "rev": "9b271cb42c591a5e031f64d5869fb0212a075bed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`9b271cb4`](https://github.com/Mic92/nix-fast-build/commit/9b271cb42c591a5e031f64d5869fb0212a075bed) | `` chore(deps): update nixpkgs digest to 83c45b9 (#139) `` |
| [`3f859bb9`](https://github.com/Mic92/nix-fast-build/commit/3f859bb966fe65ac15412aaf39387d5e4d10e41b) | `` chore(deps): update nixpkgs digest to 8cf2a06 (#138) `` |