### PR TITLE
chore(flake/nixvim): `7d18194a` -> `6597afe2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1746387720,
-        "narHash": "sha256-x8k0DKiQYRNaf9Hg+di+WCKxb76zJVWSjKOlPiuc22o=",
+        "lastModified": 1746650585,
+        "narHash": "sha256-9WZtcSn1/UkYK4UNXkcLCnVR7aIVI83VweqVlCf06OA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7d18194a22325f212e17eb876d9c00afcc434113",
+        "rev": "6597afe2097ba07fdf515a541a2a02a7e06768cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`6597afe2`](https://github.com/nix-community/nixvim/commit/6597afe2097ba07fdf515a541a2a02a7e06768cd) | `` tests/lsp: disable ols test because odin is broken ``                                       |
| [`60f9ddf3`](https://github.com/nix-community/nixvim/commit/60f9ddf36981e8e43e6eb071caba47193d2da010) | `` generated: Updated lspconfig-servers.json ``                                                |
| [`dfca942d`](https://github.com/nix-community/nixvim/commit/dfca942dbbb600bc18827502dcc7ed6bd716fea1) | `` flake/dev/flake.lock: Update ``                                                             |
| [`9b5e955b`](https://github.com/nix-community/nixvim/commit/9b5e955b51c3532a4b27945bec6ba3a3fc006240) | `` flake.lock: Update ``                                                                       |
| [`5c52e8f9`](https://github.com/nix-community/nixvim/commit/5c52e8f9e438b6850f2c7a6e4bf3f967a3a699fd) | `` plugins.lsp: alias `onAttach` to new `lsp.onAttach` ``                                      |
| [`c26f5c2e`](https://github.com/nix-community/nixvim/commit/c26f5c2e31c1da895bf9289783ff8e2fe3637ca0) | `` plugins/lsp-format: use `lsp.onAttach` instead of an autoCmd ``                             |
| [`a45b5f37`](https://github.com/nix-community/nixvim/commit/a45b5f372f510d8a97e4d325b7907453c66efd8e) | `` modules/lsp: add `onAttach` option ``                                                       |
| [`391e4fd0`](https://github.com/nix-community/nixvim/commit/391e4fd093eaa993089525da2648cc2b4ec380ce) | `` flake/dev/flake.lock: Update ``                                                             |
| [`1d0e4a0b`](https://github.com/nix-community/nixvim/commit/1d0e4a0bb506a3fd38265a5961cf0b04bf010f23) | `` flake.lock: Update ``                                                                       |
| [`53084257`](https://github.com/nix-community/nixvim/commit/53084257189483605182aaf388696ace02f5d208) | `` modules/lsp/servers: move to dedicated file/dir ``                                          |
| [`64cd675e`](https://github.com/nix-community/nixvim/commit/64cd675ece86352c8540da765aef72eeba045cf5) | `` Port lsp-format to use non-deprecated setup instructions ``                                 |
| [`4016854b`](https://github.com/nix-community/nixvim/commit/4016854bccf192d6a5d7fdd5860571dfa1ece55c) | `` flake/dev/flake.lock: Update ``                                                             |
| [`9cad0ea6`](https://github.com/nix-community/nixvim/commit/9cad0ea6948de0a90801e570b937ac82a710e5ac) | `` flake.lock: Update ``                                                                       |
| [`ce5d7080`](https://github.com/nix-community/nixvim/commit/ce5d708018e11865e5079514319429081e4e194b) | `` plugins/blink-copilot: Mention in the description that copilot-lua is enabled by default `` |