### PR TITLE
chore(flake/nix-fast-build): `9b271cb4` -> `a803b722`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746470700,
-        "narHash": "sha256-azv9tuIs1tkkdvgNr/2m4i2ZbkeXHdbVNZCam6QT/uA=",
+        "lastModified": 1746887075,
+        "narHash": "sha256-44GrKkww1p4XOANN2WpXonMsnP8+SPi4wrvERWCSb7g=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "9b271cb42c591a5e031f64d5869fb0212a075bed",
+        "rev": "a803b722190a857768b06b4a804aee53c26ee49b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`a803b722`](https://github.com/Mic92/nix-fast-build/commit/a803b722190a857768b06b4a804aee53c26ee49b) | `` chore(deps): update nixpkgs digest to 5f833dd (#148) `` |
| [`1e462e81`](https://github.com/Mic92/nix-fast-build/commit/1e462e81133f0d9137079f89845485ada5b15f3e) | `` chore(deps): update nixpkgs digest to 0f1c18b (#147) `` |
| [`30b0e648`](https://github.com/Mic92/nix-fast-build/commit/30b0e64851dbb8e0d94ea1a93080a613dac8630b) | `` chore(deps): update nixpkgs digest to d06b53b (#146) `` |
| [`97af644c`](https://github.com/Mic92/nix-fast-build/commit/97af644c6941b8013fddddd719429beb8aac7c5e) | `` chore(deps): update nixpkgs digest to 2cd2dec (#145) `` |
| [`38eecfc4`](https://github.com/Mic92/nix-fast-build/commit/38eecfc45d91aa1e00a740ab39bbd9d33ba5835a) | `` chore(deps): update nixpkgs digest to 1676224 (#144) `` |
| [`88139228`](https://github.com/Mic92/nix-fast-build/commit/8813922864147f81f1b0d3644f8df6cf24d0d651) | `` chore(deps): update nixpkgs digest to c254c79 (#143) `` |
| [`011c7684`](https://github.com/Mic92/nix-fast-build/commit/011c7684932e9fc89b4251039ec2ed31ab57e518) | `` chore(deps): update nixpkgs digest to 40a6f04 (#142) `` |
| [`3806eebc`](https://github.com/Mic92/nix-fast-build/commit/3806eebcc7c7c9329577ebead0880f287ebfc405) | `` chore(deps): update nixpkgs digest to e7072d1 (#141) `` |
| [`b64c5b0c`](https://github.com/Mic92/nix-fast-build/commit/b64c5b0c5416f5d7824119326a22ada9d565d068) | `` chore(deps): update nixpkgs digest to 5a837cb (#140) `` |