### PR TITLE
chore(flake/nixvim): `a6eda590` -> `1b1e43a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1746749676,
-        "narHash": "sha256-782lJpCRuehoNvvyj5OJLuM3g01T1zXWEBEdZcvuiZc=",
+        "lastModified": 1746822201,
+        "narHash": "sha256-XAt4FgViCT9kcSkODQUcbQ8JejjjbTGcMVGIP+7o7YE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a6eda59091bfb984dde882ae7faad0f48ee8e216",
+        "rev": "1b1e43a36e4f701fb2fc870c322373579936f739",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`1b1e43a3`](https://github.com/nix-community/nixvim/commit/1b1e43a36e4f701fb2fc870c322373579936f739) | `` plugins/oil-git-status: set `signcolumn` sane default ``    |
| [`17e13d47`](https://github.com/nix-community/nixvim/commit/17e13d478de2c088476058a8272b8b6f3e24ddfe) | `` plugins/oil-git-status: improve `signcolumn` warning ``     |
| [`2797fd8b`](https://github.com/nix-community/nixvim/commit/2797fd8b64038bb43e16bf76f1c12af9a8db3e19) | `` plugins/oil-git-status: update `signcolumn` instructions `` |
| [`3556951d`](https://github.com/nix-community/nixvim/commit/3556951d361d5732cd261079b0543ccbee6035dd) | `` plugins/oil-git-status: fix whitespace in desc ``           |
| [`52db53ce`](https://github.com/nix-community/nixvim/commit/52db53cea2ea3e845526087061f0ca20b9e6e63a) | `` flake/dev/flake.lock: Update ``                             |
| [`cacdb973`](https://github.com/nix-community/nixvim/commit/cacdb973655a5b48d032c9053abf39bfdd20348f) | `` config-examples: add cirius-nix (#3307) ``                  |
| [`2d485ca1`](https://github.com/nix-community/nixvim/commit/2d485ca1a25244e518ec67e908fef668e05e8fad) | `` colorschemes/bamboo: init ``                                |