### PR TITLE
chore(flake/nixvim): `1b1e43a3` -> `02a85bd2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -228,11 +228,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1746822201,
-        "narHash": "sha256-XAt4FgViCT9kcSkODQUcbQ8JejjjbTGcMVGIP+7o7YE=",
+        "lastModified": 1746965641,
+        "narHash": "sha256-6+Cn5aMDSWvsk4nOXmea3whAI4v+PjYaEpcDkTEAlXc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1b1e43a36e4f701fb2fc870c322373579936f739",
+        "rev": "02a85bd29333ce9fbde0d2c57a2378f47205bb21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`02a85bd2`](https://github.com/nix-community/nixvim/commit/02a85bd29333ce9fbde0d2c57a2378f47205bb21) | `` flake/dev/flake.lock: Update `` |
| [`e527939f`](https://github.com/nix-community/nixvim/commit/e527939f79caa0636c7d5331e4e6c70857a1fbe0) | `` flake/dev/flake.lock: Update `` |