### PR TITLE
chore(flake/nix-fast-build): `a803b722` -> `2b94af42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746887075,
-        "narHash": "sha256-44GrKkww1p4XOANN2WpXonMsnP8+SPi4wrvERWCSb7g=",
+        "lastModified": 1746990252,
+        "narHash": "sha256-w+px507d1d2xqDoH6KSYBb6WXAZL5LsBHTSCxw+nKFw=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "a803b722190a857768b06b4a804aee53c26ee49b",
+        "rev": "2b94af42cb355865c8bfc4b7068681a4dbb171ef",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746216483,
-        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
+        "lastModified": 1746989248,
+        "narHash": "sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
+        "rev": "708ec80ca82e2bbafa93402ccb66a35ff87900c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`2b94af42`](https://github.com/Mic92/nix-fast-build/commit/2b94af42cb355865c8bfc4b7068681a4dbb171ef) | `` chore(deps): update treefmt-nix digest to 708ec80 (#151) `` |
| [`285f2b83`](https://github.com/Mic92/nix-fast-build/commit/285f2b83cceb85b163f185bf36394f3baef3f44e) | `` chore(deps): update treefmt-nix digest to 4819332 (#150) `` |
| [`c9c3cd5e`](https://github.com/Mic92/nix-fast-build/commit/c9c3cd5e340b53a6e4489297e4430ea5e1496e0b) | `` chore(deps): update nixpkgs digest to 7fb53a7 (#149) ``     |