### PR TITLE
chore(flake/nix-fast-build): `2b94af42` -> `f59908e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746990252,
-        "narHash": "sha256-w+px507d1d2xqDoH6KSYBb6WXAZL5LsBHTSCxw+nKFw=",
+        "lastModified": 1747265771,
+        "narHash": "sha256-XCJuEIQ3gC3UZYNEZBh6q6fdpm+5AqusSGEPUdWZkwo=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "2b94af42cb355865c8bfc4b7068681a4dbb171ef",
+        "rev": "f59908e2b7a9e04579dace6b5728957f5dfbd058",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`f59908e2`](https://github.com/Mic92/nix-fast-build/commit/f59908e2b7a9e04579dace6b5728957f5dfbd058) | `` chore(deps): update nixpkgs digest to b112281 (#156) `` |
| [`689861d6`](https://github.com/Mic92/nix-fast-build/commit/689861d60a91614c1010bb6b5b006c18f115a9dd) | `` chore(deps): update nixpkgs digest to 3a00b4e (#155) `` |
| [`a132dbcf`](https://github.com/Mic92/nix-fast-build/commit/a132dbcf4d172216df12e971308a7e78b29f71f7) | `` chore(deps): update nixpkgs digest to fab95ba (#153) `` |
| [`6f12fbf0`](https://github.com/Mic92/nix-fast-build/commit/6f12fbf083586fce01b8bfdc9df747eb3672b43f) | `` chore(deps): update nixpkgs digest to e4f52f3 (#152) `` |