### PR TITLE
chore(flake/nixvim): `1c53ad9b` -> `ffdeb40a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1747173002,
-        "narHash": "sha256-06aYCSKtw1nlDn7PEAXwAYncSn8Fky4rtYrALep7f6I=",
+        "lastModified": 1747436826,
+        "narHash": "sha256-uLyPKU5V9hRO6lsHkrMg2f+N6o7cIG+XiO7PXNOJyFk=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1c53ad9b2f5fd4a3c1f644d03895cda7756c92a3",
+        "rev": "ffdeb40a505c6f7d2dfd9bcae6358e4e97bb0d2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`ffdeb40a`](https://github.com/nix-community/nixvim/commit/ffdeb40a505c6f7d2dfd9bcae6358e4e97bb0d2e) | `` flake/dev: sort flake inputs ``                             |
| [`0ccc452a`](https://github.com/nix-community/nixvim/commit/0ccc452af218dc1eb948d65b03a46af3271aa07b) | `` maintainers: enforce sorting ``                             |
| [`0a6bd171`](https://github.com/nix-community/nixvim/commit/0a6bd171cf4e5f11f5233dd7419aa36d695ad00b) | `` flake: add `keep-sorted` to treefmt ``                      |
| [`2628efee`](https://github.com/nix-community/nixvim/commit/2628efee7111398e3ba1e7ba3cff00f580fe554b) | `` flake/devshell: add treefmt to shell ``                     |
| [`4c989abc`](https://github.com/nix-community/nixvim/commit/4c989abc8cb53c94986bca6fc5f058d53a1d55cc) | `` flake/devshell: run treefmt directly in `format` command `` |
| [`46e13593`](https://github.com/nix-community/nixvim/commit/46e1359338d0f86acf80c61cbcb4d7a4c1198e58) | `` flake: use pre-configured treefmt package in git-hooks ``   |
| [`95ca65c8`](https://github.com/nix-community/nixvim/commit/95ca65c8d1adee5594bd14f527c68d564fb68879) | `` flake/dev/flake.lock: Update ``                             |