### PR TITLE
chore(flake/nix-fast-build): `7dce68d3` -> `145221c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747332914,
-        "narHash": "sha256-EEPt1S1y0skS5VSlivTyNEEBo9X7DiPpHdjbmA2K7kI=",
+        "lastModified": 1747423988,
+        "narHash": "sha256-2VJDAbxbVKTK5ghX6pFn9Pei9kQyIGWMrwv+qAuOnAQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "7dce68d3adc8821db75018ff96acc876fd07c697",
+        "rev": "145221c7d655a46c0d772a5050d16021fe9d7576",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747299117,
-        "narHash": "sha256-JGjCVbxS+9t3tZ2IlPQ7sdqSM4c+KmIJOXVJPfWmVOU=",
+        "lastModified": 1747417995,
+        "narHash": "sha256-3WY1yVTcS9Vi6vmBjWsNTG6IYDs/ybu2xAQykdeE22k=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e758f27436367c23bcd63cd973fa5e39254b530e",
+        "rev": "42dd9289571ae3c6884af9885b1a7432e3278f92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`145221c7`](https://github.com/Mic92/nix-fast-build/commit/145221c7d655a46c0d772a5050d16021fe9d7576) | `` chore(deps): update nixpkgs digest to b965e4c (#163) ``     |
| [`529e4e49`](https://github.com/Mic92/nix-fast-build/commit/529e4e494621ef5efc440d615aa2145a58e51800) | `` chore(deps): update treefmt-nix digest to 42dd928 (#162) `` |
| [`2aba5540`](https://github.com/Mic92/nix-fast-build/commit/2aba5540a17e424a321505770b44f0c3fcb6eb37) | `` chore(deps): update nixpkgs digest to adfa8b0 (#160) ``     |