### PR TITLE
chore(flake/nix-fast-build): `51d2cb88` -> `214d9223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747509878,
-        "narHash": "sha256-e32LtD8AZepEWUunTv7IpVoNaMWq1tcNoM3SLTM8Nlg=",
+        "lastModified": 1747648711,
+        "narHash": "sha256-I1l/Mjry4wspuUBqIScXVg2Iy9ZdVKgGavV5FDCJ694=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "51d2cb882dde63b270f37579479afb69b5e64391",
+        "rev": "214d92233e3b125efaaa2c2931448ab6f5bccd61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`214d9223`](https://github.com/Mic92/nix-fast-build/commit/214d92233e3b125efaaa2c2931448ab6f5bccd61) | `` chore(deps): update nixpkgs digest to 949fb7f (#169) `` |
| [`330397c7`](https://github.com/Mic92/nix-fast-build/commit/330397c7e005ef1fbd420d89877ed34e12d4988a) | `` chore(deps): update nixpkgs digest to b7d438b (#168) `` |
| [`4ade860f`](https://github.com/Mic92/nix-fast-build/commit/4ade860f015131c12ab0317289ad9336c5e882c7) | `` chore(deps): update nixpkgs digest to d0afebf (#167) `` |