### PR TITLE
chore(flake/nixvim): `563fdaee` -> `14c7f5f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1747607161,
-        "narHash": "sha256-73mz+f6XlVsRxLbjQeCrgW7mZnUihoPoHDa+GIg2j/o=",
+        "lastModified": 1747683610,
+        "narHash": "sha256-Jis9/4lnr3pn1AIRgCnoeiReKs2MGy6COWc6JtAEESo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "563fdaeef95599e584fcff2e8f8d6f72011ffb99",
+        "rev": "14c7f5f8968940d1730b5e935dd1d9f3e461a2d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`14c7f5f8`](https://github.com/nix-community/nixvim/commit/14c7f5f8968940d1730b5e935dd1d9f3e461a2d3) | `` dev/tests: add `--attr` option to print full attrpath of tests `` |
| [`f4a7447d`](https://github.com/nix-community/nixvim/commit/f4a7447d27d3c43c59555c053c203f1abb45e899) | `` lib/util: move docs from `lib/index` to doc-comments ``           |
| [`4a272ca5`](https://github.com/nix-community/nixvim/commit/4a272ca5d723f56a320051b11058bc3d96bd4453) | `` docs/lib: enable `lib.nixvim.lua` docs ``                         |
| [`bda4be03`](https://github.com/nix-community/nixvim/commit/bda4be03fcfee0a64f6473e7577d31536d99818b) | `` docs/lib: enable `lib.nixvim.utils` docs ``                       |
| [`5cf8cb5e`](https://github.com/nix-community/nixvim/commit/5cf8cb5ee6d4310acda11af8e902b6ba52438861) | `` lib/utils: split into public and internal files ``                |
| [`2ee5d71d`](https://github.com/nix-community/nixvim/commit/2ee5d71d52bb66c9e407783a7df1b8f6c648ebd2) | `` doc/lib/index.md: update heading title ``                         |
| [`0f8dc108`](https://github.com/nix-community/nixvim/commit/0f8dc108de5de279955cd6e6f8c91bb0a9ded19d) | `` docs/man: move FAQ and examples before functions ``               |
| [`83d35350`](https://github.com/nix-community/nixvim/commit/83d3535097b03fbecd26d33c10bc60d1f20c2b7d) | `` docs/man: include all sections from `lib-doc` ``                  |
| [`0c7e2aa9`](https://github.com/nix-community/nixvim/commit/0c7e2aa96b3ba00b90cd499e8242a1846c12aa01) | `` docs: `user-guide/helpers.md` → `lib/index.md` ``                 |
| [`1c6dd657`](https://github.com/nix-community/nixvim/commit/1c6dd6579a9325aa7b438c271c1a264c0836a7dd) | `` docs: include function docs ``                                    |
| [`dfaea598`](https://github.com/nix-community/nixvim/commit/dfaea5982e4298567ee83e3cedb73964be46663e) | `` docs/lib: init ``                                                 |