### PR TITLE
chore(flake/nixvim): `46fd0b18` -> `b37d4294`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1747945641,
-        "narHash": "sha256-Ts16c+kptbC3YDwPcB/NqXFVMHPNYKeFD7LkiawbWCU=",
+        "lastModified": 1748197130,
+        "narHash": "sha256-WkUknPbMYFeusz3GKkhnklGF0r9bz4Z4bpU8h0t1Ddc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "46fd0b184cbc5f1bdc5a8325cb973fc54e49ab68",
+        "rev": "b37d429468c1f5133743e967caf97d92dc35ef5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`b37d4294`](https://github.com/nix-community/nixvim/commit/b37d429468c1f5133743e967caf97d92dc35ef5b) | `` flake/wrappers: Deprecate homeManagerModules output ``     |
| [`e4a27ae8`](https://github.com/nix-community/nixvim/commit/e4a27ae810e7efdc2a0d626cf46f027b53daa34f) | `` flake/wrappers: Make homeModules the canonical name ``     |
| [`c10f60d0`](https://github.com/nix-community/nixvim/commit/c10f60d007ead7909d3ceb98b3a9aaa88ea9491b) | `` Migrate homeManagerModules uses to homeModules ``          |
| [`c1a14f8f`](https://github.com/nix-community/nixvim/commit/c1a14f8f5cbeaf14773c5ca148e5851776c111d7) | `` flake/wrappers: Add homeModules flake output ``            |
| [`1c5c991f`](https://github.com/nix-community/nixvim/commit/1c5c991fda4519db56c30c9d75ba29ba7097af83) | `` modules/lsp/servers: Fix lua_ls example ``                 |
| [`f54941e3`](https://github.com/nix-community/nixvim/commit/f54941e333ea2afd0b03ba09f5cb90bb1c6f8130) | `` flake/dev/flake.lock: Update ``                            |
| [`2c0a9ff1`](https://github.com/nix-community/nixvim/commit/2c0a9ff1e2bcc6aab15caa504a7c9670f6e0a929) | `` flake/dev/flake.lock: Update ``                            |
| [`5a07d9e5`](https://github.com/nix-community/nixvim/commit/5a07d9e5fdc7bff03166ad6f5f1ba3302b7870a2) | `` flake.lock: Update ``                                      |
| [`764a9b8d`](https://github.com/nix-community/nixvim/commit/764a9b8ddafcff877be16908447b7bd84204cca6) | `` treewide: replace mentions of 24.11 with 25.05 ``          |
| [`f80d8d59`](https://github.com/nix-community/nixvim/commit/f80d8d5907f9b22dc5e35fb8e44c772a35e81a19) | `` ci/docs: build documentation for the nixos-25.05 branch `` |
| [`2f610f97`](https://github.com/nix-community/nixvim/commit/2f610f97541a9cdebcdb485fe8f41e09bd46420d) | `` maintaining: initial "Releasing" section ``                |
| [`1350e87f`](https://github.com/nix-community/nixvim/commit/1350e87fa4d8801183fed2f2c3e9f001fc320fe7) | `` maintaining: add sub "Deprecation" section ``              |
| [`f39dd428`](https://github.com/nix-community/nixvim/commit/f39dd428240174bc1d2cbdd07eceebff7c652c03) | `` maintaining: init ``                                       |
| [`e3f4a57f`](https://github.com/nix-community/nixvim/commit/e3f4a57fb81644cdf71d334760b5713db168145a) | `` docs/mdbook: install directly to `$out` ``                 |
| [`4dc8d1e9`](https://github.com/nix-community/nixvim/commit/4dc8d1e9186d7608545b39e49d64b7ccfaba60dc) | `` plugins/vim-test: init ``                                  |
| [`c457fe94`](https://github.com/nix-community/nixvim/commit/c457fe942474c6888639c432a05f7cf200454d15) | `` plugins/dbee: init ``                                      |
| [`d88fde18`](https://github.com/nix-community/nixvim/commit/d88fde1899c3bc2a254797e3e373ce23e93705e6) | `` ci/update-other: trigger updates for 25.05 ``              |
| [`ad7e489a`](https://github.com/nix-community/nixvim/commit/ad7e489aa103e8b16ed63eb5318b9914e5ae3bdb) | `` ci/update: use nix-community GitHub App ``                 |
| [`fb2d007f`](https://github.com/nix-community/nixvim/commit/fb2d007f95efd9b73bd14458b08bf4afcfc9681a) | `` ci/update-other: don't run on forks ``                     |
| [`73c1a755`](https://github.com/nix-community/nixvim/commit/73c1a755f0ac6d09d312daffd13c1ce6572d6fe5) | `` flake/dev/new-plugin: add missing ';' ``                   |
| [`380aabb9`](https://github.com/nix-community/nixvim/commit/380aabb981a9307c3236cf43442e0ae3b2950698) | `` flake/dev/flake.lock: Update ``                            |
| [`d061f33d`](https://github.com/nix-community/nixvim/commit/d061f33d328c707fa628915c6c988c3b5a0c54da) | `` flake.lock: Update ``                                      |