### PR TITLE
chore(flake/nix-fast-build): `c4fa0a45` -> `5f5ff111`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747987523,
-        "narHash": "sha256-uafqPb9rNdk8VWXucW/wABKHs/Zvn8j7Te67bhpNe78=",
+        "lastModified": 1748081099,
+        "narHash": "sha256-yk2H78SmFgSSxEHzBWFtIgwZrE57wQODUMUvTou6scQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "c4fa0a456ff799b66bbd50993fe1259993a3c7aa",
+        "rev": "5f5ff111255393c6ff3bca40fbd627f039aa8eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`5f5ff111`](https://github.com/Mic92/nix-fast-build/commit/5f5ff111255393c6ff3bca40fbd627f039aa8eb8) | `` chore(deps): update nixpkgs digest to c3ee76c (#175) `` |
| [`82293603`](https://github.com/Mic92/nix-fast-build/commit/82293603648a1ecb7c3ceb1b57ec8736444e7ad6) | `` chore(deps): update nixpkgs digest to 4501014 (#174) `` |