### PR TITLE
chore(flake/nixpkgs): `96ec055e` -> `910796ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748460289,
-        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
+        "lastModified": 1748693115,
+        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
+        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`ef02b1a1`](https://github.com/NixOS/nixpkgs/commit/ef02b1a19fc9347181d052a10c2fe462a0a6fbb2) | `` python3Packages.weblate-language-data: 2025.5 -> 2025.6 ``                              |
| [`1c320d5b`](https://github.com/NixOS/nixpkgs/commit/1c320d5bd44adbc9fef8a23dd971166434df55fb) | `` avr-sim: drop ``                                                                        |
| [`80d5523a`](https://github.com/NixOS/nixpkgs/commit/80d5523ade614fe80f5fb84e19205cb18e25f0c6) | `` adobe-reader: drop ``                                                                   |
| [`44606564`](https://github.com/NixOS/nixpkgs/commit/4460656436381d1f00f43b7e3b26e3fb6b4acef0) | `` fx: 36.0.0 -> 36.0.3 ``                                                                 |
| [`8c05d9a8`](https://github.com/NixOS/nixpkgs/commit/8c05d9a8657a5f68796909ffcf95019ef5b3edbd) | `` open-webui: 0.6.12 -> 0.6.13 ``                                                         |
| [`6d0f5382`](https://github.com/NixOS/nixpkgs/commit/6d0f53825ae32e70ece63e80e69795c9d385ffdd) | `` skim: 0.17.3 -> 0.18.0 ``                                                               |
| [`c8955ea9`](https://github.com/NixOS/nixpkgs/commit/c8955ea96eb127374bd4e0e3d9073c03b46f8f49) | `` geph -> geph5 : 4.99.16 -> 0.2.61 ``                                                    |
| [`bcef3fb1`](https://github.com/NixOS/nixpkgs/commit/bcef3fb133c427aa5448fa8528052cb5fa6a20bb) | `` lug-helper: 3.9 -> 3.10 ``                                                              |
| [`bd92ec72`](https://github.com/NixOS/nixpkgs/commit/bd92ec72e35dc21b6bfd33a052f897a8629ff83f) | `` trivy: 0.62.1 -> 0.63.0 ``                                                              |
| [`34553fdf`](https://github.com/NixOS/nixpkgs/commit/34553fdf8863607c7becec5aad9698258d1275f6) | `` trufflehog: 3.88.34 -> 3.88.35 ``                                                       |
| [`d2e89756`](https://github.com/NixOS/nixpkgs/commit/d2e89756838f480070570b90d3647ebb277cd63b) | `` trufflehog: 3.88.33 -> 3.88.34 ``                                                       |
| [`fbdb19c3`](https://github.com/NixOS/nixpkgs/commit/fbdb19c32ffd8b7294860a7e51631e9c3482d94d) | `` python313Packages.yolink-api: 0.5.2 -> 0.5.4 ``                                         |
| [`40480ced`](https://github.com/NixOS/nixpkgs/commit/40480ced71d5f6da0a053fed2ca2ad93b326a5a5) | `` python313Packages.sendgrid: 6.12.2 -> 6.12.3 ``                                         |
| [`f4ca7a61`](https://github.com/NixOS/nixpkgs/commit/f4ca7a6141413c8e3d923235893e8d4c5dedba9a) | `` haskellPackages: regenerate package set based on current config (#412513) ``            |
| [`19cd7d82`](https://github.com/NixOS/nixpkgs/commit/19cd7d82a3bf7758b02c40b5bf6afb7d9afd8f6a) | `` python313Packages.twilio: 9.6.1 -> 9.6.2 ``                                             |
| [`e98d4dfc`](https://github.com/NixOS/nixpkgs/commit/e98d4dfc22e51fd3d431ec49cb6dcff4c368558c) | `` python313Packages.mechanicalsoup: 1.3.0 -> 1.4.0 ``                                     |
| [`ff2aee9c`](https://github.com/NixOS/nixpkgs/commit/ff2aee9c6716befac4391b27d67d75dbace92e22) | `` python313Packages.mitogen: 0.3.23 -> 0.3.24 ``                                          |
| [`fc499b56`](https://github.com/NixOS/nixpkgs/commit/fc499b56572b5cdb31c43f792e50470ef2703f4a) | `` python313Packages.opower: 0.12.2 -> 0.12.3 ``                                           |
| [`c4fa6af2`](https://github.com/NixOS/nixpkgs/commit/c4fa6af24bb5317c1a486abfe0fdc27701fae973) | `` checkov: 3.2.435 -> 3.2.436 ``                                                          |
| [`f64577bf`](https://github.com/NixOS/nixpkgs/commit/f64577bfd03b153efe59b0ee69e92ef1240bedf8) | `` python313Packages.tencentcloud-sdk-python: 3.0.1389 -> 3.0.1390 ``                      |
| [`aaf02983`](https://github.com/NixOS/nixpkgs/commit/aaf029837f89a843154d3fd633705f076c197e0a) | `` python313Packages.boto3-stubs: 1.38.25 -> 1.38.27 ``                                    |
| [`f8f49463`](https://github.com/NixOS/nixpkgs/commit/f8f49463dea22b35ebe85186153d08c568edbb6b) | `` python313Packages.botocore-stubs: 1.38.25 -> 1.38.27 ``                                 |
| [`5da1eb90`](https://github.com/NixOS/nixpkgs/commit/5da1eb90479dc758d090c32c5b884f2927d4f9fb) | `` python312Packages.mypy-boto3-sagemaker: 1.38.14 -> 1.38.27 ``                           |
| [`15cdca0b`](https://github.com/NixOS/nixpkgs/commit/15cdca0be8f54692d4f9e14c9e1b486780ff11e4) | `` python312Packages.mypy-boto3-s3: 1.38.0 -> 1.38.26 ``                                   |
| [`037e54c3`](https://github.com/NixOS/nixpkgs/commit/037e54c3bf04aa062c9521a940bd46d3f376f801) | `` python312Packages.mypy-boto3-mwaa: 1.38.0 -> 1.38.26 ``                                 |
| [`847ca51a`](https://github.com/NixOS/nixpkgs/commit/847ca51a1999063f6aee6cda9bc9708fb712a497) | `` python312Packages.mypy-boto3-ivs-realtime: 1.38.0 -> 1.38.26 ``                         |
| [`6da7b870`](https://github.com/NixOS/nixpkgs/commit/6da7b87097196d6f2aa01a63f68ab9d29e8a625b) | `` python312Packages.mypy-boto3-fsx: 1.38.0 -> 1.38.26 ``                                  |
| [`26443df1`](https://github.com/NixOS/nixpkgs/commit/26443df1e89cbd9100107938cfd27662dabc3efe) | `` python312Packages.mypy-boto3-emr-serverless: 1.38.0 -> 1.38.27 ``                       |
| [`50e2d349`](https://github.com/NixOS/nixpkgs/commit/50e2d3491279006aab3b3b5ae58b9b96090250f1) | `` python312Packages.mypy-boto3-datasync: 1.38.20 -> 1.38.26 ``                            |
| [`c27cc120`](https://github.com/NixOS/nixpkgs/commit/c27cc120af863b97e64cdf9e9167c4202fb5fe48) | `` python312Packages.mypy-boto3-dataexchange: 1.38.0 -> 1.38.26 ``                         |
| [`b91a42c0`](https://github.com/NixOS/nixpkgs/commit/b91a42c055f3b03805fd1bcc8259993b603179aa) | `` python312Packages.mypy-boto3-connect: 1.38.7 -> 1.38.26 ``                              |
| [`951b458d`](https://github.com/NixOS/nixpkgs/commit/951b458dd1b96a07ccdb3618723a5e6caeab9c86) | `` python312Packages.mypy-boto3-cloudtrail: 1.38.0 -> 1.38.26 ``                           |
| [`feeed214`](https://github.com/NixOS/nixpkgs/commit/feeed21476aeaf5b2ebeaddaa11cc0b38c0a4821) | `` python312Packages.mypy-boto3-autoscaling: 1.38.0 -> 1.38.26 ``                          |
| [`2d031f94`](https://github.com/NixOS/nixpkgs/commit/2d031f9457062759ad8f70fae01f4b6187f73a20) | `` google-chrome: fix update script ``                                                     |
| [`9a4c2b22`](https://github.com/NixOS/nixpkgs/commit/9a4c2b226612eff706ab880e8188e94e90190353) | `` python312Packages.mypy-boto3-amplify: 1.38.0 -> 1.38.26 ``                              |
| [`5c4d3ddc`](https://github.com/NixOS/nixpkgs/commit/5c4d3ddc342554ec360d934126ecf664a6554720) | `` python313Packages.boto3-stubs: 1.38.24 -> 1.38.25 ``                                    |
| [`616b1032`](https://github.com/NixOS/nixpkgs/commit/616b1032295eea23032a2bb0ff9b1560971d4c41) | `` python313Packages.botocore-stubs: 1.38.24 -> 1.38.25 ``                                 |
| [`fca286b2`](https://github.com/NixOS/nixpkgs/commit/fca286b2d1e36ed14ebc31eb1f23b7f3ed4de15f) | `` python312Packages.mypy-boto3-synthetics: 1.38.13 -> 1.38.25 ``                          |
| [`295210b4`](https://github.com/NixOS/nixpkgs/commit/295210b484f72983ee8ddb611dd4a9a5f301020a) | `` python312Packages.mypy-boto3-network-firewall: 1.38.0 -> 1.38.25 ``                     |
| [`9735b95e`](https://github.com/NixOS/nixpkgs/commit/9735b95efca6b7350b68b5e13a4f7f62b132abf4) | `` python312Packages.mypy-boto3-events: 1.38.0 -> 1.38.25 ``                               |
| [`32f6a99f`](https://github.com/NixOS/nixpkgs/commit/32f6a99f8856867d0106e56216766f317ca8c6cf) | `` python312Packages.mypy-boto3-ec2: 1.38.24 -> 1.38.25 ``                                 |
| [`45a71508`](https://github.com/NixOS/nixpkgs/commit/45a715089c831075e4736a394764a9b790552b40) | `` postgres-lsp: add myypo to maintainers ``                                               |
| [`554c9703`](https://github.com/NixOS/nixpkgs/commit/554c97036d282e37138dc0bc42b8636fe843e5dc) | `` python314: add zstd dependency (#409307) ``                                             |
| [`d2226511`](https://github.com/NixOS/nixpkgs/commit/d222651152c6eab8be7ed3bbb5719a32f32ee7c2) | `` firebase-tools: 14.4.0 -> 14.5.1 ``                                                     |
| [`e96913f2`](https://github.com/NixOS/nixpkgs/commit/e96913f2a38b459026f78780063d446223233e7d) | `` codebook: 0.2.13 -> 0.3.0 ``                                                            |
| [`34190def`](https://github.com/NixOS/nixpkgs/commit/34190defeb0b45b12ba3587580e452b351f611f7) | `` bt-migrate: 0-unstable-2023-08-17 → 0-unstable-2025-05-31 ``                            |
| [`71a00577`](https://github.com/NixOS/nixpkgs/commit/71a005771bb60cf8b3266f8f9dfa98e16c0d6150) | `` pyradio: 0.9.3.11.11 -> 0.9.3.11.13 ``                                                  |
| [`82f78582`](https://github.com/NixOS/nixpkgs/commit/82f78582cda724132a9090271c303983c1e54aaa) | `` snipe-it: 8.1.3 -> 8.1.4 ``                                                             |
| [`aac0debe`](https://github.com/NixOS/nixpkgs/commit/aac0debe621f5e6116da84a7e18f871175e64c9c) | `` firefox-beta-unwrapped: 140.0b2 -> 140.0b3 ``                                           |
| [`b019dcab`](https://github.com/NixOS/nixpkgs/commit/b019dcab339cf0031956006208edd1757801e09f) | `` linux_6_12: 6.12.30 -> 6.12.31 ``                                                       |
| [`c40e658f`](https://github.com/NixOS/nixpkgs/commit/c40e658fdd821b0d985d469a665e26a67d256c1d) | `` linux_6_14: 6.14.8 -> 6.14.9 ``                                                         |
| [`b0c89d44`](https://github.com/NixOS/nixpkgs/commit/b0c89d44be27f59210a8e6c06dae9c271babc5b2) | `` python312Packages.transformers: 4.52.3 -> 4.52.4 ``                                     |
| [`83700242`](https://github.com/NixOS/nixpkgs/commit/83700242038485a49750f4a8f722389fa325b2c0) | `` workflows/eval: skip on ready_for_review ``                                             |
| [`4c2e2382`](https://github.com/NixOS/nixpkgs/commit/4c2e23826c98b3eb6fb2337642907b8d1c988ccf) | `` workflows/eval: split reviewers job into re-usable workflow ``                          |
| [`ecf95fa4`](https://github.com/NixOS/nixpkgs/commit/ecf95fa458a838357565c0d67e3c919e521ec668) | `` workflows/eval: split tag into compare and reviews jobs ``                              |
| [`0f6aae72`](https://github.com/NixOS/nixpkgs/commit/0f6aae72831cd7124f2245e4dc4b525d5f11b3a6) | `` azurehound: 2.4.1 -> 2.5.0 ``                                                           |
| [`6ae7d9b3`](https://github.com/NixOS/nixpkgs/commit/6ae7d9b3c525334edd34f7c7d6e81f5f881e23e5) | `` directx-headers: 1.615.0 -> 1.616.0 ``                                                  |
| [`9fee7e36`](https://github.com/NixOS/nixpkgs/commit/9fee7e36882d8b1b6202452890cbf53694c8b491) | `` eza: 0.21.3 -> 0.21.4 ``                                                                |
| [`676464e3`](https://github.com/NixOS/nixpkgs/commit/676464e3dc862333fc0f3594b3cf7b9a75f13767) | `` filterpath: 1.0.2 -> 1.0.3 ``                                                           |
| [`08767aee`](https://github.com/NixOS/nixpkgs/commit/08767aeedb4d0369c02412768e7c5864d6214ebe) | `` git-blame-ignore-revs: Add commit cleaning up Redmine module ``                         |
| [`d7850f03`](https://github.com/NixOS/nixpkgs/commit/d7850f03e94dd286ecbd90bb550cbee5a9c4db9b) | `` patch2pr: 0.34.0 -> 0.35.0 ``                                                           |
| [`cc5ca451`](https://github.com/NixOS/nixpkgs/commit/cc5ca4513f49379988d9b99d5c0f6934daf9262a) | `` python313: fix static for x86_64-linux ``                                               |
| [`e0051de9`](https://github.com/NixOS/nixpkgs/commit/e0051de9fee3e232eac1f4338c8291b55e3b68bb) | `` luau-lsp: 1.47.0 -> 1.48.0 ``                                                           |
| [`38d4b809`](https://github.com/NixOS/nixpkgs/commit/38d4b809a18900b138468aeef62b44535d672ba8) | `` nixos/redmine: Remove some spurious empty lines ``                                      |
| [`d7f1102f`](https://github.com/NixOS/nixpkgs/commit/d7f1102f04c58b2edfc74c9a1d577e3aebfca775) | `` nixos/redmine: Get rid of global lib expansions ``                                      |
| [`d97277f3`](https://github.com/NixOS/nixpkgs/commit/d97277f32132f367d58449902befdffe6d88eb1f) | `` nixos/redmine: Use lib.mkEnableOption where possible ``                                 |
| [`23c614c2`](https://github.com/NixOS/nixpkgs/commit/23c614c23fc7b11aec51ed715fbe096f3ba5afe5) | `` yazi-unwrapped: 25.5.28 -> 25.5.31 ``                                                   |
| [`51ecd580`](https://github.com/NixOS/nixpkgs/commit/51ecd580473bbd095f42438481cac69cf23a6120) | `` system.etc.overlay: build erofs also locally ``                                         |
| [`694a18cb`](https://github.com/NixOS/nixpkgs/commit/694a18cbf92688ce46d67027c91c3bb0aa757574) | `` librewolf-unwrapped: 139.0-1 -> 139.0.1-1 ``                                            |
| [`41dd9777`](https://github.com/NixOS/nixpkgs/commit/41dd9777d16936fd0269420e765d444bc3d069b2) | `` yaziPlugins.vcs-files: 25.4.8-unstable-2025-04-08 -> 25.5.28-unstable-2025-05-28 ``     |
| [`f0aac9a2`](https://github.com/NixOS/nixpkgs/commit/f0aac9a2d4a7a2e71ab4baf3e54ee0eb2b7b190d) | `` docker-language-server: 0.7.0 -> 0.9.0 ``                                               |
| [`5b8f14d7`](https://github.com/NixOS/nixpkgs/commit/5b8f14d7013d7bda6f7c1aa90c5c260c01009ee0) | `` yaziPlugins.toggle-pane: 25.2.26-unstable-2025-04-21 -> 25.5.28-unstable-2025-05-28 ``  |
| [`86512478`](https://github.com/NixOS/nixpkgs/commit/865124789acafc6d5d9f1a2f1b58a0aa68c69fb8) | `` yaziPlugins.starship: 25.4.8-unstable-2025-04-20 -> 25.4.8-unstable-2025-05-30 ``       |
| [`4da0ae41`](https://github.com/NixOS/nixpkgs/commit/4da0ae4100ad3a8f6fde1f6c34ff95e41b74f972) | `` yaziPlugins.smart-paste: 0-unstable-2025-04-27 -> 25.5.28-unstable-2025-05-28 ``        |
| [`bcced90c`](https://github.com/NixOS/nixpkgs/commit/bcced90c04aad4d3f92df060c7bb5a8ad6cd7de4) | `` yaziPlugins.smart-filter: 25.2.26-unstable-2025-03-02 -> 25.5.28-unstable-2025-05-28 `` |
| [`1e8307aa`](https://github.com/NixOS/nixpkgs/commit/1e8307aa5e63ba19aa0c5f7edfd321fc78b856a9) | `` yaziPlugins.smart-enter: 25.2.26-unstable-2025-03-02 -> 25.5.28-unstable-2025-05-28 ``  |
| [`9d465814`](https://github.com/NixOS/nixpkgs/commit/9d465814f5031b37f44d5c6d63ed337c6cfd2269) | `` yaziPlugins.rsync: 0-unstable-2025-04-12 -> 0-unstable-2025-04-24 ``                    |
| [`5736fd4d`](https://github.com/NixOS/nixpkgs/commit/5736fd4d56f14e46fdeebe1c65239e481db2eb23) | `` yaziPlugins.rich-preview: 0-unstable-2025-04-22 -> 0-unstable-2025-05-30 ``             |
| [`d237bf66`](https://github.com/NixOS/nixpkgs/commit/d237bf664f0c4f27721fc1d6c61c56ce3f583a86) | `` yaziPlugins.restore: 25.2.7-unstable-2025-04-24 -> 25.5.28-unstable-2025-05-30 ``       |
| [`5d86d170`](https://github.com/NixOS/nixpkgs/commit/5d86d170004bda855f780443edc51da5ad7da248) | `` yaziPlugins.projects: 0-unstable-2025-05-17 -> 0-unstable-2025-05-29 ``                 |
| [`995aec9e`](https://github.com/NixOS/nixpkgs/commit/995aec9ea5a0d9868fee73d9b0c830e9a531e051) | `` yaziPlugins.piper: 25.4.8-unstable-2025-04-21 -> 25.5.28-unstable-2025-05-28 ``         |
| [`95624aaf`](https://github.com/NixOS/nixpkgs/commit/95624aaf2b6633195ea26266d917648b1eb62a5e) | `` yaziPlugins.mount: 25.2.26-unstable-2025-03-02 -> 25.5.28-unstable-2025-05-28 ``        |
| [`1a0eb71c`](https://github.com/NixOS/nixpkgs/commit/1a0eb71c8a4c9b6d01aae1d7787eec913cde69bb) | `` yaziPlugins.mime-ext: 25.4.4-unstable-2025-04-04 -> 25.5.28-unstable-2025-05-28 ``      |
| [`bf4e7a44`](https://github.com/NixOS/nixpkgs/commit/bf4e7a44b9172ffc69a04fa9fef7d607ca8fe820) | `` yaziPlugins.miller: 0-unstable-2024-08-28 -> 0-unstable-2025-04-17 ``                   |
| [`f1f6cd69`](https://github.com/NixOS/nixpkgs/commit/f1f6cd69beb79a168b15b74a73ede8dc2284ee26) | `` yaziPlugins.mediainfo: 25.4.8-unstable-2025-05-19 -> 25.5.28-unstable-2025-05-30 ``     |
| [`5dcd5e87`](https://github.com/NixOS/nixpkgs/commit/5dcd5e87dffa50d6f9f4232940fbf42a382e92d9) | `` yaziPlugins.mactag: 25.4.4-unstable-2025-04-04 -> 25.5.28-unstable-2025-05-28 ``        |
| [`d58ae95e`](https://github.com/NixOS/nixpkgs/commit/d58ae95e4ec6e8affc4174d4dffd82f8224379e2) | `` yaziPlugins.lsar: 25.2.26-unstable-2025-03-02 -> 25.5.28-unstable-2025-05-28 ``         |
| [`01e5aecd`](https://github.com/NixOS/nixpkgs/commit/01e5aecdf5078eb30cb4ebfcbb5ba029f39315a7) | `` yaziPlugins.jump-to-char: 25.2.26-unstable-2025-03-02 -> 25.5.28-unstable-2025-05-28 `` |
| [`1c82ffe4`](https://github.com/NixOS/nixpkgs/commit/1c82ffe4d2660d15e9ab7917a7c5055fd98810f7) | `` yaziPlugins.git: 25.4.4-unstable-2025-04-04 -> 25.5.28-unstable-2025-05-28 ``           |
| [`9d1dea7d`](https://github.com/NixOS/nixpkgs/commit/9d1dea7de0e2ba5c713f8a9d5014faecd0430edb) | `` yaziPlugins.full-border: 25.2.26-unstable-2025-03-11 -> 25.2.26-unstable-2025-05-28 ``  |
| [`8d44a81a`](https://github.com/NixOS/nixpkgs/commit/8d44a81a02bdc44c603503af5390b8617fe27987) | `` yaziPlugins.duckdb: 25.4.8-unstable-2025-04-28 -> 25.4.8-unstable-2025-05-29 ``         |
| [`c3770951`](https://github.com/NixOS/nixpkgs/commit/c3770951798d845c6883476d9d8dcc6f317fe016) | `` yaziPlugins.chmod: 25.2.26-unstable-2025-03-02 -> 25.5.28-unstable-2025-05-28 ``        |
| [`8c6b6530`](https://github.com/NixOS/nixpkgs/commit/8c6b6530093cf026559076dd4088817a4d7db144) | `` yaziPlugins.bypass: 25.3.2-unstable-2025-05-11 -> 25.3.2-unstable-2025-05-30 ``         |
| [`f9d7d4bc`](https://github.com/NixOS/nixpkgs/commit/f9d7d4bcd30ee25405e40d8d576bcfb66347d390) | `` vimPlugins.hare-vim: unstable-2025-01-23 -> 0-unstable-2025-04-24 ``                    |
| [`504a92ad`](https://github.com/NixOS/nixpkgs/commit/504a92ad6468525af673f91b6021eef6d72261da) | `` python3Packages.particle: 0.25.3 -> 0.25.4 ``                                           |
| [`b59816ae`](https://github.com/NixOS/nixpkgs/commit/b59816ae56934b8d5df6d63c5b17d1330b249303) | `` vimPlugins.cord-nvim: 2.2.3 -> 2.2.7 ``                                                 |
| [`fca79977`](https://github.com/NixOS/nixpkgs/commit/fca799770554eb042c190747a592a603f9ef5229) | `` postgres-lsp: Use system jemalloc ``                                                    |