### PR TITLE
chore(flake/nixvim): `8b3a69cf` -> `d063d0dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1748564405,
-        "narHash": "sha256-uCmQLJmdg0gKWBs+vhNmS9RIPJW8/ddo6TvQ/a4gupc=",
+        "lastModified": 1748884506,
+        "narHash": "sha256-P/ldKE0SCGKH6pEVJoW2MJJo2dZCZe10d/h1ree66c0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8b3a69cfea5ba2fa008c6c57ab79c99c513a349b",
+        "rev": "d063d0dd5e0b82d8be4dd4bc00b887ac1f92e4b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| [`d063d0dd`](https://github.com/nix-community/nixvim/commit/d063d0dd5e0b82d8be4dd4bc00b887ac1f92e4b2) | `` plugins/treesitter: don't exclude nvim-treesitter from combining by default ``                                   |
| [`65d35db5`](https://github.com/nix-community/nixvim/commit/65d35db5cac209cf5acd3dfd40aee98840cfc127) | `` modules/performance: fix specifying combinePlugin.standalonePlugins as packages when byte compilation enabled `` |
| [`6c456efc`](https://github.com/nix-community/nixvim/commit/6c456efc96f60213019460046d07f5691e0fafa3) | `` flake/ci: re-enable package tests on buildbot ``                                                                 |
| [`7d0ac005`](https://github.com/nix-community/nixvim/commit/7d0ac00557dd97d4353cfcad8ffb65163ac1d782) | `` flake/ci: re-enable most tests on buildbot ``                                                                    |
| [`74e6ada9`](https://github.com/nix-community/nixvim/commit/74e6ada9d1545d3a3c515ea3d85ad6766dc00df5) | `` buildbot: init config ``                                                                                         |
| [`e18d3fb2`](https://github.com/nix-community/nixvim/commit/e18d3fb2804908fc00629e9139059d26a3ff4dcb) | `` flake/ci: add `ci.buildbot` output ``                                                                            |