### PR TITLE
chore(flake/nixpkgs): `910796ca` -> `c2a03962`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`a9cdbd80`](https://github.com/NixOS/nixpkgs/commit/a9cdbd802358583dc8b66cf102a6824144e221d4) | `` vscode-extensions.julialang.language-julia: 1.140.2 -> 1.141.2 ``                              |
| [`8e876759`](https://github.com/NixOS/nixpkgs/commit/8e876759944795a410b39455d5c79b19b697d0e9) | `` doc/rust: pass cargoRoot to fetcher in example ``                                              |
| [`501b8f1c`](https://github.com/NixOS/nixpkgs/commit/501b8f1c698bc10902b70b2f36f9c6ebd24d55d9) | `` wealthfolio: directly pass cargoRoot to fetcher ``                                             |
| [`071c2273`](https://github.com/NixOS/nixpkgs/commit/071c2273ef0d1a8ac96fee095a3eb7e28fd37c2a) | `` surrealist: directly pass cargoRoot to fetcher ``                                              |
| [`6d70a4ac`](https://github.com/NixOS/nixpkgs/commit/6d70a4ac0eb912ddaecba2b89eab560ae09b2834) | `` ruby: directly pass cargoRoot to fetcher ``                                                    |
| [`8aa2633d`](https://github.com/NixOS/nixpkgs/commit/8aa2633d5600daab737e1e626daa18c489d85fbe) | `` python313Packages.temporalio: directly pass cargoRoot to fetcher ``                            |
| [`7c6f50ae`](https://github.com/NixOS/nixpkgs/commit/7c6f50aedd536bd9aa03ed3a51a141db212a2200) | `` python313Packages.libcst: directly pass cargoRoot to fetcher ``                                |
| [`0726017b`](https://github.com/NixOS/nixpkgs/commit/0726017b4fcf2bece2d8702a6300092589ef57ab) | `` animdl: move to pkgs/by-name ``                                                                |
| [`6d8de291`](https://github.com/NixOS/nixpkgs/commit/6d8de291b422f67abb2a85dc01dcb6f229df209a) | `` python313Packages.biliass: directly pass cargoRoot to fetcher ``                               |
| [`c158832c`](https://github.com/NixOS/nixpkgs/commit/c158832c51e5af38dd5e37291a1c49cbcb52af1a) | `` python313Packages.bcrypt: directly pass cargoRoot to fetcher ``                                |
| [`b67755bc`](https://github.com/NixOS/nixpkgs/commit/b67755bccd5d0e0db2ea6ac35f58f484884871c2) | `` opengamepadui: directly pass cargoRoot to fetcher ``                                           |
| [`6c1bc14c`](https://github.com/NixOS/nixpkgs/commit/6c1bc14c30bf404c45e64537a1e1a1a8c216e392) | `` librepcb: directly pass cargoRoot to fetcher ``                                                |
| [`9e275132`](https://github.com/NixOS/nixpkgs/commit/9e2751327b434d49aff907ae2b811c0675dc654e) | `` kdePackages.kdepim-addons: directly pass cargoRoot to fetcher ``                               |
| [`9a40ac05`](https://github.com/NixOS/nixpkgs/commit/9a40ac05c18987b0508fe6273ac39414a7d380f5) | `` kdePackages.akonadi-search: directly pass cargoRoot to fetcher ``                              |
| [`3a6328f7`](https://github.com/NixOS/nixpkgs/commit/3a6328f75aa7a31166b3401992a1e6a2d5996a11) | `` ibus-engines.openbangla-keyboard: directly pass cargoRoot to fetcher ``                        |
| [`e99c97f2`](https://github.com/NixOS/nixpkgs/commit/e99c97f254c2f71d586287b773904eaf2d911eff) | `` ceph: directly pass cargoRoot to fetcher ``                                                    |
| [`c1d2184a`](https://github.com/NixOS/nixpkgs/commit/c1d2184a49c7e590536020fc8121531dc96a5527) | `` ccextractor: directly pass cargoRoot to fetcher ``                                             |
| [`9441c5dc`](https://github.com/NixOS/nixpkgs/commit/9441c5dc561fb8c06d7910141a6dea8737848828) | `` animdl: unpin cssselect ``                                                                     |
| [`f9738506`](https://github.com/NixOS/nixpkgs/commit/f9738506f7a028249800a1c22e023102a64151ef) | `` distroshelf: 1.0.7 -> 1.0.8 ``                                                                 |
| [`17423823`](https://github.com/NixOS/nixpkgs/commit/17423823a78628824f494c73025e0e8385a69a88) | `` chromium,chromedriver: 137.0.7151.55 -> 137.0.7151.68 ``                                       |
| [`4dc4df6a`](https://github.com/NixOS/nixpkgs/commit/4dc4df6ab3261963d148c3579886a08f8963e584) | `` python3Packages.gphoto2: modernize ``                                                          |
| [`026b7627`](https://github.com/NixOS/nixpkgs/commit/026b7627e6438390c8dbcb1563d8219917fb8376) | `` python3Packages.gphoto2: 2.5.1 -> 2.6.0 ``                                                     |
| [`8c565143`](https://github.com/NixOS/nixpkgs/commit/8c565143029f9cfdbd8dc08d408f941c3165b931) | `` python312Packages.python-debian: 0.1.52 -> 1.0.1 ``                                            |
| [`3bdb5fff`](https://github.com/NixOS/nixpkgs/commit/3bdb5fff3a2c79293145f61e7ca87811e8724aad) | `` python312Packages.mautrix: 0.20.7 -> 0.20.8 ``                                                 |
| [`a24e9579`](https://github.com/NixOS/nixpkgs/commit/a24e9579d6dd1f70b261dcebb9a47d873efd19f2) | `` olivetin: 2025.5.26 -> 2025.6.1 ``                                                             |
| [`b833b497`](https://github.com/NixOS/nixpkgs/commit/b833b49732d8d57c2833295219109f993f42753c) | `` synapse-admin-etkecc: 0.11.0-etke42 -> 0.11.1-etke43 ``                                        |
| [`b3168f37`](https://github.com/NixOS/nixpkgs/commit/b3168f37d27d0d16b8acfc9fa55cb882d7e4be6a) | `` clorinde: 0.15.1 -> 0.15.2 ``                                                                  |
| [`6e49a562`](https://github.com/NixOS/nixpkgs/commit/6e49a56258a976d8ff645d15a00104533639fe82) | `` alertmanager-ntfy: 0-unstable-2025-05-04 -> 0-unstable-2025-05-31 ``                           |
| [`e0fd47c0`](https://github.com/NixOS/nixpkgs/commit/e0fd47c071e504a04010875a90b79e143007de76) | `` snort: 3.7.4.0 -> 3.8.1.0 ``                                                                   |
| [`21ec0dd7`](https://github.com/NixOS/nixpkgs/commit/21ec0dd7a84bc925a3613b97f553c1ba0f20f0f7) | `` yaziPlugins.ouch: 0-unstable-2025-04-12 -> 0-unstable-2025-06-01 ``                            |
| [`c28211ba`](https://github.com/NixOS/nixpkgs/commit/c28211bac84a2fdcd0e8e14d0d018fd91c504fbe) | `` vscode-extensions.tabnine.tabnine-vscode: 3.283.0 -> 3.287.0 ``                                |
| [`bc95f85d`](https://github.com/NixOS/nixpkgs/commit/bc95f85dbfe1e198d2a50da5d402494319c6e448) | `` krillinai: 1.1.5 -> 1.2.1-hotfix-2 ``                                                          |
| [`6041ea02`](https://github.com/NixOS/nixpkgs/commit/6041ea02f4280e63753c792da9ff533b7ce2193e) | `` gopher: 3.0.18 -> 3.0.19 ``                                                                    |
| [`574dd889`](https://github.com/NixOS/nixpkgs/commit/574dd889896ee3802a10be61b8e35c5112fc9b8c) | `` home-assistant-custom-components.oref_alert: 2.20.1 -> 2.21.1 (#413259) ``                     |
| [`eac3b2f7`](https://github.com/NixOS/nixpkgs/commit/eac3b2f74f5acd25cbb332c06db79431fe928798) | `` terraform-providers.mongodbatlas: 1.34.0 -> 1.35.1 ``                                          |
| [`943ed0a2`](https://github.com/NixOS/nixpkgs/commit/943ed0a2201735e5687fc602302467774202d43e) | `` python3Packages.simsimd: 6.4.4 -> 6.4.7 ``                                                     |
| [`cf11813e`](https://github.com/NixOS/nixpkgs/commit/cf11813ecb4de3f2c2464d592000d2845df73777) | `` gildas: 20250501_a -> 20250601_a ``                                                            |
| [`5680270f`](https://github.com/NixOS/nixpkgs/commit/5680270f6e4e790706ddf9546ec795878e8a47c9) | `` python313Packages.yara-python: 4.5.2 -> 4.5.4 ``                                               |
| [`90c03df8`](https://github.com/NixOS/nixpkgs/commit/90c03df84e12b15c82293be13be3a6e6d5a737e4) | `` podman-desktop: Remove usage of finalAttrs.pname ``                                            |
| [`8f79c78d`](https://github.com/NixOS/nixpkgs/commit/8f79c78d1d9073c81d109d0ef46bf6a1bd05877d) | `` libfaketime: use --replace-fail ``                                                             |
| [`abeb33f6`](https://github.com/NixOS/nixpkgs/commit/abeb33f662ae92b2d9a2d3080c480aef3bff3b0d) | `` libfaketime: 0.9.10 -> 0.9.11 ``                                                               |
| [`571c42f9`](https://github.com/NixOS/nixpkgs/commit/571c42f927de966d438304db07aa2244c8174aff) | `` treesheets: 0-unstable-2025-05-19 -> 0-unstable-2025-06-02 ``                                  |
| [`96064417`](https://github.com/NixOS/nixpkgs/commit/9606441731caf8c5990ad766d35feb37da859b93) | `` geoclock: remove finalAttrs.pname and hardcode ``                                              |
| [`c793c51b`](https://github.com/NixOS/nixpkgs/commit/c793c51b88374446e08937fa7b6eec78c0b0af01) | `` nixos/minio: replace deprecated mc config host command ``                                      |
| [`dcd99fdf`](https://github.com/NixOS/nixpkgs/commit/dcd99fdf96a7216f3eebbd291a09a7f1dec6e539) | `` minio-client: 2025-04-16T18-13-26Z -> 2025-05-21T01-59-54Z ``                                  |
| [`16ca5175`](https://github.com/NixOS/nixpkgs/commit/16ca5175592f852e0ebdc4c8fe439d1e4b6f2cf0) | `` minio: 2025-03-12T18-04-18Z -> 2025-04-22T22-12-26Z ``                                         |
| [`d40276e4`](https://github.com/NixOS/nixpkgs/commit/d40276e4ff0f941b2ca288ec5843b907c3981d26) | `` python313Packages.ha-mqtt-discoverable: 0.19.1 -> 0.19.2 ``                                    |
| [`6541cd28`](https://github.com/NixOS/nixpkgs/commit/6541cd28f1d22ecfc1553ce61d6dffad47c4bd3e) | `` cdncheck: 1.1.20 -> 1.1.21 ``                                                                  |
| [`eb01e02b`](https://github.com/NixOS/nixpkgs/commit/eb01e02bd5c96acf9e95044012452b7a1b56be70) | `` dsnet: init at 0.8.1 and init module ``                                                        |
| [`e1e5af4e`](https://github.com/NixOS/nixpkgs/commit/e1e5af4e71767ed003178be3513fd0600d63b679) | `` python3Packages.pyyaml-ft: fix pname ``                                                        |
| [`bbeb76d1`](https://github.com/NixOS/nixpkgs/commit/bbeb76d12a4478e596e187b36e53f546b58dad64) | `` gitleaks: 8.26.0 -> 8.27.0 ``                                                                  |
| [`bc2cc094`](https://github.com/NixOS/nixpkgs/commit/bc2cc0946c8a2023377508d68da2bea06b69738f) | `` python313Packages.aiohomekit: 3.2.14 -> 3.2.15 ``                                              |
| [`4f1cae5e`](https://github.com/NixOS/nixpkgs/commit/4f1cae5e3aeb2e470a8e83dff6cf633524a36bf5) | `` python313Packages.garth: 0.5.10 -> 0.5.12 ``                                                   |
| [`715f24da`](https://github.com/NixOS/nixpkgs/commit/715f24da1f96eda872e1764bdfe8760977a214db) | `` protoc-gen-es: 2.5.0 -> 2.5.1 ``                                                               |
| [`cd63aeda`](https://github.com/NixOS/nixpkgs/commit/cd63aeda59e78c22045be783ddfa3d83d46e958c) | `` build(deps): bump cachix/install-nix-action from 31.3.0 to 31.4.0 ``                           |
| [`c1edd733`](https://github.com/NixOS/nixpkgs/commit/c1edd73399c277f852948b04c43301995cf6d560) | `` protols: 0.12.0 -> 0.12.5 ``                                                                   |
| [`5eea0fb5`](https://github.com/NixOS/nixpkgs/commit/5eea0fb5df744e2d32d935a947fe3885bad44e01) | `` terramate: 0.13.1 -> 0.13.2 ``                                                                 |
| [`d9424d11`](https://github.com/NixOS/nixpkgs/commit/d9424d1120cce69c41ad865b8e6715c6c5153e24) | `` gleam: 1.10.0 -> 1.11.0 ``                                                                     |
| [`58b55767`](https://github.com/NixOS/nixpkgs/commit/58b557670474aa5d1eafeb4e83218fef0fd760a5) | `` workflows/eval: fix pull_request condition ``                                                  |
| [`50f6d8d9`](https://github.com/NixOS/nixpkgs/commit/50f6d8d90946f9e6248de473795b768902240ab0) | `` workflows: condition steps with secrets on pull_request_target event ``                        |
| [`48baebba`](https://github.com/NixOS/nixpkgs/commit/48baebba5090892683f2bdd6095e907d674e7106) | `` workflows/codeowners: improve test-ability in forks ``                                         |
| [`f8ce8eb6`](https://github.com/NixOS/nixpkgs/commit/f8ce8eb61e388566a439519ff7c2f159f01cbdbe) | `` dprint-plugins.dprint-plugin-typescript: 0.95.4 -> 0.95.5 ``                                   |
| [`cdbc334d`](https://github.com/NixOS/nixpkgs/commit/cdbc334d2548359d681a363802abcba140972989) | `` python3Packages.sse-starlette: 2.3.5 -> 2.3.6 ``                                               |
| [`0b360e93`](https://github.com/NixOS/nixpkgs/commit/0b360e932837087c70b869670abbb9eaaf0e3178) | `` nixos/lasuite-docs: use systemd bind mount instead of stateful symlink for static directory `` |
| [`7ee611b0`](https://github.com/NixOS/nixpkgs/commit/7ee611b07f8cd0dcb68c2aa32374c82d7199f44a) | `` tests.fetchgit.fetchTags: fix flaky test by removing .git directory after getting tags ``      |
| [`cf0d1123`](https://github.com/NixOS/nixpkgs/commit/cf0d11234ee4f9ce5e449d8224f2ac1535f39e5b) | `` hyprls: 0.6.0 -> 0.7.0 ``                                                                      |
| [`96999641`](https://github.com/NixOS/nixpkgs/commit/96999641fbc332279c8b510992055fb60d985ff2) | `` python3Packages.duckduckgo-search: 8.0.0 -> 8.0.2 ``                                           |
| [`b44e4bd9`](https://github.com/NixOS/nixpkgs/commit/b44e4bd99a5911de9e82aceae7f93acd9bb535c0) | `` python3Packages.primp: 14.0.0 -> 15.0.0 ``                                                     |
| [`978f295e`](https://github.com/NixOS/nixpkgs/commit/978f295e3614ae19b32d45e465dd1f20e014ca12) | `` flaresolverr: remove discouraged anti-pattern ``                                               |
| [`ab654f18`](https://github.com/NixOS/nixpkgs/commit/ab654f18fbf6f31882562a53cf6832be2affe167) | `` ktailctl: 0.20.1 -> 0.20.2 ``                                                                  |
| [`82c6ea2d`](https://github.com/NixOS/nixpkgs/commit/82c6ea2ddc9a2d59c8c765f76bee8141d051f71c) | `` workflows/check-cherry-picks: minimize more than one old review ``                             |
| [`25265908`](https://github.com/NixOS/nixpkgs/commit/252659081e250858a40bd96b27d0f13b6cce136f) | `` labels: automatically add labels for 24.11 on CI PRs ``                                        |
| [`d85e9635`](https://github.com/NixOS/nixpkgs/commit/d85e9635e368f60c0fa353652149b3834b823cbd) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.5.2 -> 4.5.3 ``                |
| [`01ab1fc0`](https://github.com/NixOS/nixpkgs/commit/01ab1fc0cb3cc2781cabd0d9d404edcef91e298b) | `` yaziPlugins.bypass: 25.3.2-unstable-2025-05-30 -> 25.3.2-unstable-2025-06-01 ``                |
| [`6d53dfcd`](https://github.com/NixOS/nixpkgs/commit/6d53dfcd455d9f359d38785be6d024fae2999128) | `` OVMFFull: debian-edk-src: 2024.05-1 -> 2025.02-8 ``                                            |
| [`7bcf9ade`](https://github.com/NixOS/nixpkgs/commit/7bcf9ade60603921f46e267461e0e157bd89adfb) | `` workflows/dismissed-review: drop ``                                                            |
| [`e9688cd9`](https://github.com/NixOS/nixpkgs/commit/e9688cd9d3eb9549cea0d6362833bd457f81651e) | `` chart-testing: 3.12.0 -> 3.13.0 ``                                                             |
| [`72e24453`](https://github.com/NixOS/nixpkgs/commit/72e244538d7456c4a3ee6cb9358a9c4184bde773) | `` ty: 0.0.1-alpha.7 -> 0.0.1-alpha.8 ``                                                          |
| [`c77ac9df`](https://github.com/NixOS/nixpkgs/commit/c77ac9dfc3e022dfeb2788dbf533d0d6b853f8c7) | `` treewide: fix typos ``                                                                         |
| [`c106a5bc`](https://github.com/NixOS/nixpkgs/commit/c106a5bc279406a70b74c064549e785ca51c13b1) | `` ci/codeowners-validator: fix typo in comment ``                                                |
| [`ba3f75ca`](https://github.com/NixOS/nixpkgs/commit/ba3f75ca014ceac3183766f60fe33e431647f102) | `` beam26Packages.rebar3: 3.24.0 -> 3.25.0 ``                                                     |
| [`dd7435fe`](https://github.com/NixOS/nixpkgs/commit/dd7435fe61e26e4b8f64557ba5902cc9192b1bb6) | `` gimp3: 3.0.2 -> 3.0.4 ``                                                                       |
| [`3dd14d8a`](https://github.com/NixOS/nixpkgs/commit/3dd14d8a5176e7a790e6eeeab7bfebd49c4b8eab) | `` ci/nixpkgs-vet: fix random errors ``                                                           |
| [`1149cb0a`](https://github.com/NixOS/nixpkgs/commit/1149cb0a2f379e112e206ea115eec0e717f629d9) | `` vimPlugins.avante-nvim: 0.0.23-unstable-2025-05-30 -> 0.0.23-unstable-2025-06-02 ``            |
| [`8a411150`](https://github.com/NixOS/nixpkgs/commit/8a411150909570819828cff5d0501cd3c3500418) | `` fly: 7.13.0 -> 7.13.2 (#412942) ``                                                             |
| [`dbab73fb`](https://github.com/NixOS/nixpkgs/commit/dbab73fb8f65254ef7dfd237d0cea30fff65dcb4) | `` krapslog: 0.6.0 -> 0.6.1 ``                                                                    |
| [`4c3d1ae0`](https://github.com/NixOS/nixpkgs/commit/4c3d1ae0b535357a40ca1809f7ea8042ea2578a9) | `` ogen: 1.13.0 -> 1.14.0 ``                                                                      |
| [`cbf54c37`](https://github.com/NixOS/nixpkgs/commit/cbf54c37a34b302da2b3d3caad2a983a6ffb04b0) | `` watchexec: add passthru.updateScript ``                                                        |
| [`9a5165bf`](https://github.com/NixOS/nixpkgs/commit/9a5165bf547cd6d2361f4ce106b1baabcea48a9a) | `` watchexec: install bash and fish completions ``                                                |
| [`7719f944`](https://github.com/NixOS/nixpkgs/commit/7719f944cf0b0902130003fdb3b12caeac6f9077) | `` watchexec: add prince213 to maintainers ``                                                     |
| [`548afb3c`](https://github.com/NixOS/nixpkgs/commit/548afb3c372a67114a8b1bcd6ff18db07652b823) | `` watchexec: avoid with lib; ``                                                                  |
| [`5320ab9f`](https://github.com/NixOS/nixpkgs/commit/5320ab9f9e6c0dcafd7eba984c1154b5bbc8b502) | `` watchexec: use finalAttrs ``                                                                   |
| [`826f4980`](https://github.com/NixOS/nixpkgs/commit/826f4980861734ac84f89485072927e4874f3ef0) | `` watchexec: 2.3.1 -> 2.3.2 ``                                                                   |
| [`3111745a`](https://github.com/NixOS/nixpkgs/commit/3111745abcf9d4f8986648312030dee8432f0009) | `` phrase-cli: 2.40.0 -> 2.42.0 ``                                                                |
| [`6dea73eb`](https://github.com/NixOS/nixpkgs/commit/6dea73ebdc42d9f87068a3944d3d5033e4313867) | `` ike-scan: 1.9.5 -> 1.9.5-unstable-2024-09-15 ``                                                |
| [`e2e0c2ea`](https://github.com/NixOS/nixpkgs/commit/e2e0c2ea9d2d73a8c8e4505f09d3dd24a7389c22) | `` slirp4netns: 1.3.2 -> 1.3.3 ``                                                                 |
| [`1053faba`](https://github.com/NixOS/nixpkgs/commit/1053fabad58dfa22caef2e1f9d234d64c9b54d30) | `` burpsuite: 2025.4.2 -> 2025.5.1 ``                                                             |
| [`60691ced`](https://github.com/NixOS/nixpkgs/commit/60691cedcbc5857c12959af1439c43804d905c68) | `` python3Packages.pynitrokey: 0.8.4 -> 0.8.5 ``                                                  |
| [`f2f7b44c`](https://github.com/NixOS/nixpkgs/commit/f2f7b44cb20cf93acc962a75aae7086a6c2f4be7) | `` amp-cli: update 0.0.1748404992-ga3f78f -> 0.0.1748865683-g71e54e ``                            |