### PR TITLE
chore(flake/nixvim): `00524c79` -> `2b6f694b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1749200997,
-        "narHash": "sha256-In+NjXI8kfJpamTmtytt+rnBzQ213Y9KW55IXvAAK/4=",
+        "lastModified": 1749420898,
+        "narHash": "sha256-QiB3xDyHuj2VzS6AaALTeikLt6EsZyMjDRmzb4y2vFM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "00524c7935f05606fd1b09e8700e9abcc4af7be8",
+        "rev": "2b6f694b48f43bbd89dcc21e8aa7aa676eb18eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`2b6f694b`](https://github.com/nix-community/nixvim/commit/2b6f694b48f43bbd89dcc21e8aa7aa676eb18eb8) | `` output: add extraPackagesAfter option ``                      |
| [`dce571fa`](https://github.com/nix-community/nixvim/commit/dce571fae5ce603d3e22221d64b118dea45811cd) | `` plugins/neotest: allow raw lua for `quickfix.open` setting `` |