### PR TITLE
chore(flake/nixpkgs): `d3d2d80a` -> `3e3afe51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749143949,
-        "narHash": "sha256-QuUtALJpVrPnPeozlUG/y+oIMSLdptHxb3GK6cpSVhA=",
+        "lastModified": 1749285348,
+        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d3d2d80a2191a73d1e86456a751b83aa13085d7d",
+        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`1d2afc0e`](https://github.com/NixOS/nixpkgs/commit/1d2afc0e998abe2a1bb2c6b803ae9154717c3e24) | `` ocamlPackages.wasm: 2.0.1 -> 2.0.2 ``                                                 |
| [`72caf3ac`](https://github.com/NixOS/nixpkgs/commit/72caf3acb7785b0ef5ec48152ccdd2288d44bf29) | `` uudeview: 0.5.20 -> 0.5.20-unstable-2025-03-20, update repo, fixes build (#411084) `` |
| [`fe9d231a`](https://github.com/NixOS/nixpkgs/commit/fe9d231ab6c4c2c2443c166f94d6c1a9884c4fdd) | `` libfaketime: clean ``                                                                 |
| [`3c4d0acf`](https://github.com/NixOS/nixpkgs/commit/3c4d0acfe2b9ac5ff59d12372975601c9e14ee2e) | `` libfaketime: clean ``                                                                 |
| [`665e4c13`](https://github.com/NixOS/nixpkgs/commit/665e4c13be2141ab053d71cb3b40b1ad636eb68f) | `` libfaketime: keep 0.9.11 on linux ``                                                  |
| [`bd23e609`](https://github.com/NixOS/nixpkgs/commit/bd23e60931e4cbe85f8fbefe350b92de277791ea) | `` Revert "libfaketime: 0.9.10 -> 0.9.11" ``                                             |
| [`3f1dc43d`](https://github.com/NixOS/nixpkgs/commit/3f1dc43dde5cfbb09b5d20ee4e8340aefad3a9e2) | `` logcheck: 1.4.4 -> 1.4.5 ``                                                           |
| [`e5693625`](https://github.com/NixOS/nixpkgs/commit/e5693625983e3c1d7381983ee66433e7f5bdab27) | `` particle-cli: 3.35.11 -> 3.36.1 ``                                                    |
| [`10606ff1`](https://github.com/NixOS/nixpkgs/commit/10606ff13f72772a40767c9046f2b8e0242a8ffe) | `` xed: 2024.02.22 -> 2025.03.02 ``                                                      |
| [`b943bef6`](https://github.com/NixOS/nixpkgs/commit/b943bef6150169cc64fbf3db341ac5330476a90a) | `` lazygit: 0.51.1 -> 0.52.0 ``                                                          |
| [`2772bd1e`](https://github.com/NixOS/nixpkgs/commit/2772bd1e38178d52ec612d85d66c99e2bef7d031) | `` mmsd: drop ``                                                                         |
| [`ba4aba08`](https://github.com/NixOS/nixpkgs/commit/ba4aba08b3631a74a0fa09415837560fa3d87c92) | `` n2048: drop ``                                                                        |
| [`f29a5f15`](https://github.com/NixOS/nixpkgs/commit/f29a5f158bbc56a2f84ed13a352c8a2316d3f7b8) | `` ja2-stracciatella: mark as broken ``                                                  |
| [`640036c1`](https://github.com/NixOS/nixpkgs/commit/640036c10ee78ad7cff305c462cb6342a961b58f) | `` miniaudio: export miniaudio header ``                                                 |
| [`c6729488`](https://github.com/NixOS/nixpkgs/commit/c6729488de632cc9f8af5aa82edd7097ea506c36) | `` treewide: remove with lib Part 4 ``                                                   |
| [`668252d1`](https://github.com/NixOS/nixpkgs/commit/668252d1de48e989c79394ea20d44a3613165ab7) | `` claude-code: 1.0.11 -> 1.0.17 ``                                                      |
| [`9d0f4b82`](https://github.com/NixOS/nixpkgs/commit/9d0f4b82ff2c0472dc6929fc40cddc5a54c1e0b2) | `` soju: remove jtbx from meta.maintainers ``                                            |
| [`d8021655`](https://github.com/NixOS/nixpkgs/commit/d8021655aaa12fd0f86ce98dec939837a0414bf1) | `` chawan: orphan ``                                                                     |
| [`43a09535`](https://github.com/NixOS/nixpkgs/commit/43a09535285e06093d758e4da01c176660c70c79) | `` olivetin: 2025.6.1 -> 2025.6.6 ``                                                     |
| [`8eb2c07e`](https://github.com/NixOS/nixpkgs/commit/8eb2c07e2a9f1ae99e150eb73f378433b35b5115) | `` xurls: 2.5.0-unstable-2024-11-03 -> 2.6.0 ``                                          |
| [`03246eeb`](https://github.com/NixOS/nixpkgs/commit/03246eeb803ee7c92369b0a7aaabefd9a352742c) | `` meraki-cli: modernize, fix cross build ``                                             |
| [`ac337836`](https://github.com/NixOS/nixpkgs/commit/ac3378365628e229737c15ec03f84fc72a1037a7) | `` graphhopper: fix and enable strictDeps ``                                             |
| [`8e2aa7da`](https://github.com/NixOS/nixpkgs/commit/8e2aa7dae048ec6ffc5ae2bafdc6c6ff93cd1457) | `` rustic: simplify shell completion installation ``                                     |
| [`86394421`](https://github.com/NixOS/nixpkgs/commit/86394421cd328db8782ef50db3210f40aa28e217) | `` ocamlPackages.ffmpeg: add @momeemt to maintainers ``                                  |
| [`9019cc42`](https://github.com/NixOS/nixpkgs/commit/9019cc426ef42d9a3013ab8b6031bfbeaaaa5148) | `` ocamlPackages.ffmpeg: modernized derivation ``                                        |
| [`1da75063`](https://github.com/NixOS/nixpkgs/commit/1da7506394c1087504dda1d338c2523410188691) | `` ocamlPackages.ffmpeg: 1.2.1 -> 1.2.5 ``                                               |
| [`20058c63`](https://github.com/NixOS/nixpkgs/commit/20058c63c0a9c5021a3355b0c8a5e0e203728fa7) | `` python312Packages.nominal: init at 1.59.0 ``                                          |
| [`1c658645`](https://github.com/NixOS/nixpkgs/commit/1c6586455c5c21ad97cee4f38611959ea40f21bb) | `` treewide: Leverage new top-level `libc` in bootstrap, and simplify ``                 |
| [`264e9cb9`](https://github.com/NixOS/nixpkgs/commit/264e9cb92811dd0ac300090264089e7eeacf4707) | `` treewide: remove with lib Part 3 ``                                                   |
| [`ae8daeb5`](https://github.com/NixOS/nixpkgs/commit/ae8daeb5f0e1ea2d976c8a1467e107fb40e79cb2) | `` python3Packages.markitdown: add missing dependency ``                                 |
| [`1867adb2`](https://github.com/NixOS/nixpkgs/commit/1867adb2356a35aec34f6108b81eb6151e010bf9) | `` Revert "llvmPackages_20: 20.1.5 -> 20.1.6" ``                                         |
| [`1e5032d3`](https://github.com/NixOS/nixpkgs/commit/1e5032d31aa83eb4c03c7ee8e78ed92b32b065cb) | `` shadow: unbreak cross eval ``                                                         |
| [`1b951d5f`](https://github.com/NixOS/nixpkgs/commit/1b951d5f0ba020e9849053447a434b94d8b05115) | `` python312Packages.nominal-api-protos: init at 0.708.0 ``                              |
| [`d6f9c4d2`](https://github.com/NixOS/nixpkgs/commit/d6f9c4d2edb75ad2fbc767b4214aea19e64b7e47) | `` python312Packages.nominal-api: init at 0.708.0 ``                                     |
| [`4ad7d585`](https://github.com/NixOS/nixpkgs/commit/4ad7d58513de8108713245be7bef37e61da0b7d3) | `` python312Packages.conjure-python-client: init at 3.0.0 ``                             |
| [`3f8ae669`](https://github.com/NixOS/nixpkgs/commit/3f8ae669c9fb21c3e6841d97c2456d38a8c85645) | `` rocksndiamonds: modernize ``                                                          |
| [`1f8a0325`](https://github.com/NixOS/nixpkgs/commit/1f8a032588e2189d6ef47e31a89b3de85426db19) | `` rocksndiamonds: unreak cross ``                                                       |
| [`cb742cea`](https://github.com/NixOS/nixpkgs/commit/cb742cea3fc1de19ee8aed81b1083620d010e9f0) | `` detach: init at 0.2.3 ``                                                              |
| [`669dea47`](https://github.com/NixOS/nixpkgs/commit/669dea4759a3d74fdd877e5e359d32082d414818) | `` mullvad: 2025.3 -> 2025.6 (#413876) ``                                                |
| [`bab9d019`](https://github.com/NixOS/nixpkgs/commit/bab9d019285a938e356ef9e6f157a7644c4232f7) | `` zipline: 4.1.1 -> 4.1.2 ``                                                            |
| [`59527f51`](https://github.com/NixOS/nixpkgs/commit/59527f5170a5009246de3dbb1bd3df5acd2e0ee2) | `` headscale: 0.26.0 -> 0.26.1 ``                                                        |
| [`ba171fcc`](https://github.com/NixOS/nixpkgs/commit/ba171fcce275cc8179eaf22eb34c9a6e79fb02f3) | `` python3Packages.robotframework: 7.2.2 -> 7.3 ``                                       |
| [`364a4d0d`](https://github.com/NixOS/nixpkgs/commit/364a4d0d44b67261462dd162f31f7fb2b93bf271) | `` newelle: init at 0.9.7 ``                                                             |
| [`7b39a05e`](https://github.com/NixOS/nixpkgs/commit/7b39a05e07c11abde4e2521ae27c270209632644) | `` docs/language-frameworks/python: don't test coverage etc ``                           |
| [`308e77dd`](https://github.com/NixOS/nixpkgs/commit/308e77ddac6ade9b4771711c16f8e603bd3fbfb9) | `` electron-source.electron_36: 36.3.2 -> 36.4.0 ``                                      |
| [`84093de5`](https://github.com/NixOS/nixpkgs/commit/84093de5993565084a19f4bc1776b885ff71ed88) | `` electron-source.electron_35: 35.5.0 -> 35.5.1 ``                                      |
| [`e237be9a`](https://github.com/NixOS/nixpkgs/commit/e237be9a454d3ac772db3163d582faf582c1dc25) | `` electron-source.electron_34: 34.5.7 -> 34.5.8 ``                                      |
| [`6d9e078e`](https://github.com/NixOS/nixpkgs/commit/6d9e078ea6de978a7d8245e5ecf0c8ff4b715b5b) | `` electron-chromedriver_36: 36.3.2 -> 36.4.0 ``                                         |
| [`53cbc1a3`](https://github.com/NixOS/nixpkgs/commit/53cbc1a396c2bfaefa140b150a3492fd3c618c32) | `` electron_36-bin: 36.3.2 -> 36.4.0 ``                                                  |
| [`0e153293`](https://github.com/NixOS/nixpkgs/commit/0e153293e68b27add2f69228b9b4cc8dab615311) | `` electron-chromedriver_35: 35.5.0 -> 35.5.1 ``                                         |
| [`7d88bd44`](https://github.com/NixOS/nixpkgs/commit/7d88bd44155d663632aad535e32ad57156c994f3) | `` electron_35-bin: 35.5.0 -> 35.5.1 ``                                                  |
| [`6d5dbf6f`](https://github.com/NixOS/nixpkgs/commit/6d5dbf6fae055bd5f4d655c48c925d31ac8a01aa) | `` electron-chromedriver_34: 34.5.7 -> 34.5.8 ``                                         |
| [`07dd7435`](https://github.com/NixOS/nixpkgs/commit/07dd7435ee2a3fdef3f03227d121eb705d06bc7a) | `` electron_34-bin: 34.5.7 -> 34.5.8 ``                                                  |
| [`1e6cf3ce`](https://github.com/NixOS/nixpkgs/commit/1e6cf3ce4fb45a9d4ca422b45043e78189f66489) | `` pre-commit: unbreak darwin ``                                                         |
| [`34aefd5e`](https://github.com/NixOS/nixpkgs/commit/34aefd5ed345bf529a14c6d327c81d8aaa70de68) | `` nekoray: fix icon not shown ``                                                        |
| [`d5960b9e`](https://github.com/NixOS/nixpkgs/commit/d5960b9e0318c33ca2a4c44e7d2ff74587608011) | `` nixos-generate-config: Add test for Flake=1 option ``                                 |
| [`2a1290b2`](https://github.com/NixOS/nixpkgs/commit/2a1290b206bc2a2392ef030a63cb8c2f3d5ba8c7) | `` metals: 1.5.3 -> 1.6.0 ``                                                             |
| [`e8acefcc`](https://github.com/NixOS/nixpkgs/commit/e8acefccde2b5b8a20453c2ea6b060696e3ad057) | `` cnspec: 11.53.2 -> 11.57.2 ``                                                         |
| [`7e7cf1ce`](https://github.com/NixOS/nixpkgs/commit/7e7cf1ce2fe2e5742db5ebea58cada7f16cc3d7d) | `` nixos-generate-config: Add a flake default to the conf file ``                        |
| [`0fb2cd5d`](https://github.com/NixOS/nixpkgs/commit/0fb2cd5d830500c4cd0c01282b50be9536576b0e) | `` cnspec: move to pkgs/by-name ``                                                       |
| [`a969291a`](https://github.com/NixOS/nixpkgs/commit/a969291ab1d200012e9a5c0a4f32839a0bce7fad) | `` treewide: use https when meta.homepage redirects to https ``                          |
| [`d6413ba4`](https://github.com/NixOS/nixpkgs/commit/d6413ba43682273de9595d4193f64209ff8d770e) | `` nixosTests.draupnir: init ``                                                          |
| [`4b153aad`](https://github.com/NixOS/nixpkgs/commit/4b153aad5d363b9d88ca4b47b4628f8032d05863) | `` nixos/draupnir: init ``                                                               |
| [`afa1d3ca`](https://github.com/NixOS/nixpkgs/commit/afa1d3cadb2ab4cb0b9617dfbdb8f2d8f5fe1329) | `` better-control: 6.11.9 -> 6.12.1 ``                                                   |
| [`d75957a3`](https://github.com/NixOS/nixpkgs/commit/d75957a3bbc310475425c9042174225c837f9473) | `` treewide: remove rec when using finalAttrs ``                                         |
| [`48da8657`](https://github.com/NixOS/nixpkgs/commit/48da8657f71e2492e27b1799c7b7650bbabc4b0a) | `` python313Packages.boto3-stubs: 1.38.30 -> 1.38.31 ``                                  |
| [`406c3a34`](https://github.com/NixOS/nixpkgs/commit/406c3a34217aae131d7ea780dc54a73fcbdd2016) | `` python312Packages.mypy-boto3-wafv2: 1.38.0 -> 1.38.31 ``                              |
| [`fd187d1c`](https://github.com/NixOS/nixpkgs/commit/fd187d1c2fdc6c6a52d3f05fc8804ceb7098b92b) | `` python312Packages.mypy-boto3-kms: 1.38.0 -> 1.38.31 ``                                |
| [`144b4784`](https://github.com/NixOS/nixpkgs/commit/144b4784fa5762781ea74e5cc9d802e20c152f11) | `` python312Packages.mypy-boto3-cloudformation: 1.38.0 -> 1.38.31 ``                     |
| [`cf0749d1`](https://github.com/NixOS/nixpkgs/commit/cf0749d1a04a7759405d44a03f3d34411bb71bd8) | `` checkov: 3.2.436 -> 3.2.437 ``                                                        |
| [`24b3e369`](https://github.com/NixOS/nixpkgs/commit/24b3e369f8b405c326fa82fbff5506c97e5f84b9) | `` python313Packages.publicsuffixlist: 1.0.2.20250603 -> 1.0.2.20250606 ``               |
| [`56353fdb`](https://github.com/NixOS/nixpkgs/commit/56353fdbc53627ec6b6c74da8b236147992fa0b8) | `` python313Packages.tencentcloud-sdk-python: 3.0.1393 -> 3.0.1394 ``                    |
| [`c7a62d36`](https://github.com/NixOS/nixpkgs/commit/c7a62d368dd19fecb9321e2e1e5e884bf91d1443) | `` exploitdb: 2025-05-30 -> 2025-06-06 ``                                                |
| [`b0afabcc`](https://github.com/NixOS/nixpkgs/commit/b0afabcc289d6da392d76fbd19cf1673c9244337) | `` zipline: 4.1.0 -> 4.1.1 ``                                                            |
| [`cc43028a`](https://github.com/NixOS/nixpkgs/commit/cc43028aa6ec5585efb67d41c2f1c076fdfde306) | `` nushellPlugins.hcl: init at 0.104.1 ``                                                |
| [`69407aae`](https://github.com/NixOS/nixpkgs/commit/69407aaed768e51544be9a0d39212078330777dd) | `` maintainers: add yethal ``                                                            |
| [`585e6f6d`](https://github.com/NixOS/nixpkgs/commit/585e6f6de1759841a87f0f909a452896b9aaf1ce) | `` labelife-label-printer: 1.2.1 -> 2.0.0 ``                                             |
| [`d0a93ecb`](https://github.com/NixOS/nixpkgs/commit/d0a93ecbda813d2e80afa5b15d63dc3c74c14514) | `` radicle-{explorer,httpd}: 0.18.2 → 0.19.1 ``                                          |
| [`fffc35b2`](https://github.com/NixOS/nixpkgs/commit/fffc35b2bbba8b0a0bf215bf19daa5cabe7da698) | `` apacheHttpdPackages.php: 8.4.7 -> 8.4.8 ``                                            |
| [`4e238e4a`](https://github.com/NixOS/nixpkgs/commit/4e238e4aa894a139332b3d496a54f35a71180d5c) | `` elmPackages.elm: Fix runtime TLS connection to package.elm-lang.org ``                |
| [`1ec5ab7f`](https://github.com/NixOS/nixpkgs/commit/1ec5ab7f1a97d7d7681b3317067c05da4a5a14d0) | `` snapcraft: pin Python 3.12 ``                                                         |
| [`65c2df87`](https://github.com/NixOS/nixpkgs/commit/65c2df876015becf9190f9c49cef8057fec9904e) | `` python3Packages.craft-grammar: move pydantic to dependencies ``                       |
| [`2e501491`](https://github.com/NixOS/nixpkgs/commit/2e501491d67897b6b03cbe4189cba747208ea9cb) | `` mobilizon: 5.1.2 -> 5.1.4 ``                                                          |
| [`e2443f78`](https://github.com/NixOS/nixpkgs/commit/e2443f78016538195dc7f7a0a6e57fbf1fa2e599) | `` python3Packages.markitdown: 0.1.1 -> 0.1.2 ``                                         |
| [`10196518`](https://github.com/NixOS/nixpkgs/commit/101965187eb19218d061b1ab04da4d76ea8fa66f) | `` nixos/dnscrypt-proxy2: add `package` option ``                                        |
| [`78aa5d76`](https://github.com/NixOS/nixpkgs/commit/78aa5d766be4a1024f40fb105c769256c0bd84bc) | `` kew: 3.3.2 -> 3.3.3 ``                                                                |
| [`458b3d17`](https://github.com/NixOS/nixpkgs/commit/458b3d1709bbb02a1583f8a4e9a8e7982453ba1c) | `` python3Packages.replicate: 1.0.4 -> 1.0.7 ``                                          |
| [`72e9f573`](https://github.com/NixOS/nixpkgs/commit/72e9f573288d0c474403e3f20a6bbc081e215ae0) | `` mobilizon: use lib.getExe ``                                                          |
| [`27c294bd`](https://github.com/NixOS/nixpkgs/commit/27c294bd543bc9a0891d4b872c73f37b2ff297b7) | `` geteduroam: 0.11 -> 0.12 ``                                                           |
| [`e95626ec`](https://github.com/NixOS/nixpkgs/commit/e95626ec05157709c75c74f3d3a2c96999617966) | `` mastodon: allow specifying missingHashes when overriding src ``                       |
| [`6e25d988`](https://github.com/NixOS/nixpkgs/commit/6e25d9885ff38b782cd5c5b6418ddff202ffb6be) | `` nixos/filesystems: chore replace 'with' statements ``                                 |
| [`a1ea6c92`](https://github.com/NixOS/nixpkgs/commit/a1ea6c92fd6583300054949b76744028436d3a98) | `` python3Packages.ipyvuetify: 1.11.1 -> 1.11.2 ``                                       |
| [`1619e5a3`](https://github.com/NixOS/nixpkgs/commit/1619e5a32a1be662cfedd07337d6c231346ddc55) | `` framework-tool: add johnazoidberg as maintainer ``                                    |
| [`90f36a1e`](https://github.com/NixOS/nixpkgs/commit/90f36a1e98384ee3161b86db1bd1cafe49e8d1a1) | `` framework-tool: 0.4.2 -> 0.4.3 ``                                                     |
| [`97568674`](https://github.com/NixOS/nixpkgs/commit/97568674a30e7e3f10c5e7cc25b3d85cb7970316) | `` firefox-devedition-bin-unwrapped: 140.0b4 -> 140.0b5 ``                               |
| [`cf85d813`](https://github.com/NixOS/nixpkgs/commit/cf85d813d29ba16143fdf5a1eeb746e85c305a90) | `` shh: 2025.6.4 -> 2025.6.5 ``                                                          |
| [`d311c0ea`](https://github.com/NixOS/nixpkgs/commit/d311c0eaeb6e8ec527a9a58821693e500c0b4dc6) | `` doc: call out 'src' should ideally point to sources ``                                |