### PR TITLE
chore(flake/nixvim): `e114d442` -> `95957f30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1749924512,
-        "narHash": "sha256-IYv0yEFh86c+UnkcjrUAV0UeIE+9vMEeXDIF+YRlooc=",
+        "lastModified": 1750032703,
+        "narHash": "sha256-l9gJbl99b23xhTSKNdG5lk0LZiECOt1kqa7qw7FY1XI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e114d442b14f3a299307ca9b0f0eab20e821f419",
+        "rev": "95957f306bf6d8e40f62fd0062cf326436bf011d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`95957f30`](https://github.com/nix-community/nixvim/commit/95957f306bf6d8e40f62fd0062cf326436bf011d) | `` ci/docs: fix build ref ``                      |
| [`7176d51a`](https://github.com/nix-community/nixvim/commit/7176d51a343c642d4cc6c4ac3f547b54850b0e82) | `` ci/docs: run non-build jobs on ARM ``          |
| [`40bf948e`](https://github.com/nix-community/nixvim/commit/40bf948e0e6893fb28933329881271659fa012bb) | `` ci/docs: extract action & refactor workflow `` |
| [`91ecff36`](https://github.com/nix-community/nixvim/commit/91ecff36b66353d2c764fdb4b3d71e6b1dab32d0) | `` ci/docs: rename workflow ``                    |
| [`2b2b1e6d`](https://github.com/nix-community/nixvim/commit/2b2b1e6d8fa21a7f780ad960374777f91ee51d04) | `` ci: rename `update-scripts` → `ci` ``          |
| [`7388c85c`](https://github.com/nix-community/nixvim/commit/7388c85c54cf03d7fa7d3230c8e9cc91fe56ea37) | `` escape backslash ``                            |
| [`d4e73694`](https://github.com/nix-community/nixvim/commit/d4e736941f7e4ae85e9c70ac60919577135d004d) | `` flake/dev/flake.lock: Update ``                |
| [`f54f383f`](https://github.com/nix-community/nixvim/commit/f54f383f1ff1dbf14a84be998113435e7dfe1c7c) | `` flake.lock: Update ``                          |