### PR TITLE
chore(flake/nixvim): `95957f30` -> `ab0a3682`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1750032703,
-        "narHash": "sha256-l9gJbl99b23xhTSKNdG5lk0LZiECOt1kqa7qw7FY1XI=",
+        "lastModified": 1750105753,
+        "narHash": "sha256-reWddMyGkxjackE4VSZ2NjOQlAdfiofhCEWFHapblNI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "95957f306bf6d8e40f62fd0062cf326436bf011d",
+        "rev": "ab0a3682cc40da89029dcb3f467b46ae3b8c0fd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`ab0a3682`](https://github.com/nix-community/nixvim/commit/ab0a3682cc40da89029dcb3f467b46ae3b8c0fd1) | `` ci/docs: use `version-info.toml` ``         |
| [`6a054de0`](https://github.com/nix-community/nixvim/commit/6a054de04dd2b0a3cc5fed1adab8e9f76c050b45) | `` plugins/lsp: add packageFallback option ``  |
| [`ee715541`](https://github.com/nix-community/nixvim/commit/ee715541ab343046a0ebc6ed88b7166bf6888d9c) | `` plugins/actions-preview: add description `` |
| [`831b503f`](https://github.com/nix-community/nixvim/commit/831b503f114c12b55197547ce1c379f67d0768b6) | `` flake/dev/flake.lock: Update ``             |