### PR TITLE
chore(flake/nixvim): `ab0a3682` -> `aef7b539`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1750105753,
-        "narHash": "sha256-reWddMyGkxjackE4VSZ2NjOQlAdfiofhCEWFHapblNI=",
+        "lastModified": 1750204267,
+        "narHash": "sha256-d1Sf8RdT9DmaoF03GAFFSHX8jRu2MciFdAi8Ki26nX8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ab0a3682cc40da89029dcb3f467b46ae3b8c0fd1",
+        "rev": "aef7b53979b89cea9f5eaebf96c16d3bdae150e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`aef7b539`](https://github.com/nix-community/nixvim/commit/aef7b53979b89cea9f5eaebf96c16d3bdae150e2) | `` docs: add status to beta/deprecated version links ``            |
| [`ada9f560`](https://github.com/nix-community/nixvim/commit/ada9f560c3e4f4a4b9d69fee10b91ea497443f0b) | `` tests/lsp: disable vectorcode_server as vectorcode is broken `` |
| [`0577885b`](https://github.com/nix-community/nixvim/commit/0577885be63d384468091202a11ce466355b5712) | `` flake/dev/flake.lock: Update ``                                 |
| [`2897f1b8`](https://github.com/nix-community/nixvim/commit/2897f1b8c901ef6c85ad1a52322ea480c3e581dc) | `` flake.lock: Update ``                                           |
| [`b4750c46`](https://github.com/nix-community/nixvim/commit/b4750c46961be18d6cd61c121fa3f43082a64a3c) | `` ci/docs: fix `base-href` in matrix ``                           |
| [`7ff88452`](https://github.com/nix-community/nixvim/commit/7ff884527ecbb722e3b6b9f89025d1ee2065792b) | `` flake/dev/flake.lock: Update ``                                 |
| [`be49587a`](https://github.com/nix-community/nixvim/commit/be49587a2478a2d49e643160cfe13b4a0b40816e) | `` colorschemes/solarized-osaka: init ``                           |