### PR TITLE
chore(flake/nixvim): `aef7b539` -> `c6051305`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1750204267,
-        "narHash": "sha256-d1Sf8RdT9DmaoF03GAFFSHX8jRu2MciFdAi8Ki26nX8=",
+        "lastModified": 1750289168,
+        "narHash": "sha256-MepgWJlHm88sFbu0GLlNqMl8NHlEVDOtrwqHWAZIQVU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "aef7b53979b89cea9f5eaebf96c16d3bdae150e2",
+        "rev": "c6051305e5ab01474f4c4cc9f90721e08fd2be83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`c6051305`](https://github.com/nix-community/nixvim/commit/c6051305e5ab01474f4c4cc9f90721e08fd2be83) | `` colorschemes/moonfly: init ``   |
| [`2fabda24`](https://github.com/nix-community/nixvim/commit/2fabda24ccf14bfd14ee0f570479efd86776652f) | `` maintainers: add AidanWelch ``  |
| [`fef045cb`](https://github.com/nix-community/nixvim/commit/fef045cb912e51185d0d5d67e035eca7fea7eda4) | `` flake/dev/flake.lock: Update `` |
| [`a5be424c`](https://github.com/nix-community/nixvim/commit/a5be424c48f7d1485978436ca6e2a5f050d444f7) | `` flake.lock: Update ``           |