### PR TITLE
chore(flake/nixvim): `c6051305` -> `6a1a348a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1750289168,
-        "narHash": "sha256-MepgWJlHm88sFbu0GLlNqMl8NHlEVDOtrwqHWAZIQVU=",
+        "lastModified": 1750345447,
+        "narHash": "sha256-yOuSSfI4xovXQpSkZUK02CBcY1f0Nvm0RhnUN8xn2rY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c6051305e5ab01474f4c4cc9f90721e08fd2be83",
+        "rev": "6a1a348ab1f00bd32d2392b5c2fc72489c699af3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6a1a348a`](https://github.com/nix-community/nixvim/commit/6a1a348ab1f00bd32d2392b5c2fc72489c699af3) | `` generated: Updated lspconfig-servers.json `` |
| [`3b6448a3`](https://github.com/nix-community/nixvim/commit/3b6448a3d4809a4bceb4e02c7312950aa429306b) | `` flake/dev/flake.lock: Update ``              |
| [`41d6159c`](https://github.com/nix-community/nixvim/commit/41d6159cd35168f728e4568bd21c61b3f4186f70) | `` flake.lock: Update ``                        |