### PR TITLE
chore(flake/git-hooks): `623c5628` -> `16ec914f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749636823,
-        "narHash": "sha256-WUaIlOlPLyPgz9be7fqWJA5iG6rHcGRtLERSCfUDne4=",
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`b8c7eb0c`](https://github.com/cachix/git-hooks.nix/commit/b8c7eb0c7e0817c78804947921b419ca50a509f0) | `` feat: add uv hooks ``                                 |
| [`8f917ec5`](https://github.com/cachix/git-hooks.nix/commit/8f917ec50b90d1c3221821e0def78d622a0e07a5) | `` fix(trufflehog): Remove redundant --no-update flag `` |