### PR TITLE
chore(flake/nixvim): `1f3e5741` -> `f0764db7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1750691276,
-        "narHash": "sha256-F507hXG4ORVpvuFeuoyDo/bmO/rR2PJRB7XhtDuBnBE=",
+        "lastModified": 1750879244,
+        "narHash": "sha256-ClV6rZbPnd5wIcBYNiCdrbhtSzY6dwPRA4Z/z1cFcyo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1f3e5741a927b5b0a983f08ab9d3bcf313bc141e",
+        "rev": "f0764db7212003520341ac10ddcee50e9c458a6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f0764db7`](https://github.com/nix-community/nixvim/commit/f0764db7212003520341ac10ddcee50e9c458a6f) | `` plugins/efmls: add renames for HTML & JSON setup options ``   |
| [`bc210635`](https://github.com/nix-community/nixvim/commit/bc210635f4e37d3c70584e9f4b370cb47413e3b4) | `` generated/efmls-configs: generate with merged html/json ``    |
| [`7594bac2`](https://github.com/nix-community/nixvim/commit/7594bac24e0e4a17814a3c337ea44cb9fecefc94) | `` ci/efmls-configs: merge language sets with different cases `` |
| [`b74cec16`](https://github.com/nix-community/nixvim/commit/b74cec1698b8fcbc3784e47e5dceb8833c3c8ce0) | `` tests/claude-code: enable on darwin again ``                  |
| [`3d65f2d0`](https://github.com/nix-community/nixvim/commit/3d65f2d04477ba289cb9f6b46d69eb8e6c51951c) | `` tests/vimtex: update disable reason ``                        |
| [`563b0d9b`](https://github.com/nix-community/nixvim/commit/563b0d9bdd34a5f0583e3b96eb04142f84c73f02) | `` tests/none-ls: enable on darwin ``                            |
| [`708c601e`](https://github.com/nix-community/nixvim/commit/708c601e0dc6e863321e73992645f172903c371b) | `` docs: enable on darwin ``                                     |
| [`175b7a47`](https://github.com/nix-community/nixvim/commit/175b7a47dea539ec42355f6fa211b39d476a7229) | `` plugins/lzn-auto-require: init ``                             |
| [`e7e6cfd3`](https://github.com/nix-community/nixvim/commit/e7e6cfd32b09b7218f8759e349824b7aecd7dec5) | `` flake/dev/flake.lock: Update ``                               |
| [`fc38b2f9`](https://github.com/nix-community/nixvim/commit/fc38b2f92be497ca7772e2b8881c754d56b9cab1) | `` flake.lock: Update ``                                         |
| [`6a15c2ff`](https://github.com/nix-community/nixvim/commit/6a15c2ffc50ca7998df2fd6b86c3c9f298e9137a) | `` colorschemes/gruvbox-material: init ``                        |
| [`4cbb93da`](https://github.com/nix-community/nixvim/commit/4cbb93da8f0cfc2e3e80fa9aca05ee56c9da162d) | `` flake/dev/flake.lock: Update ``                               |
| [`094537b6`](https://github.com/nix-community/nixvim/commit/094537b6bb3bb587bc22c6fa069cebd6f0bda911) | `` flake.lock: Update ``                                         |
| [`3843b622`](https://github.com/nix-community/nixvim/commit/3843b6226193bd2c40de0aea1343065b1bf9d3e4) | `` maintaining: update to reflect version-info ``                |
| [`a41559f0`](https://github.com/nix-community/nixvim/commit/a41559f0931eab14e3186059bd57591843e5cbe0) | `` treewide: add plugin descriptions ``                          |