### PR TITLE
chore(flake/nixvim): `f0764db7` -> `c39f5f39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1750879244,
-        "narHash": "sha256-ClV6rZbPnd5wIcBYNiCdrbhtSzY6dwPRA4Z/z1cFcyo=",
+        "lastModified": 1751053139,
+        "narHash": "sha256-FMcWdec8fAXs7kiOQBsD+vA/RzjqoDz3zoYgPDQpZlA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "f0764db7212003520341ac10ddcee50e9c458a6f",
+        "rev": "c39f5f39c32e0a8fe91bff1cda847de7a0269411",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`c39f5f39`](https://github.com/nix-community/nixvim/commit/c39f5f39c32e0a8fe91bff1cda847de7a0269411) | `` plugins/telescope-zf-native-nvim: init `` |
| [`a473ef65`](https://github.com/nix-community/nixvim/commit/a473ef658a8611cfbb48bb9bd7d0f2eed2fe038a) | `` flake: add diff-plugins command ``        |