### PR TITLE
chore(flake/nixvim): `c39f5f39` -> `ceb52aec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751053139,
-        "narHash": "sha256-FMcWdec8fAXs7kiOQBsD+vA/RzjqoDz3zoYgPDQpZlA=",
+        "lastModified": 1751144320,
+        "narHash": "sha256-KJsKiGfkfXFB23V26NQ1p+UPsexI6NKtivnrwSlWWdQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c39f5f39c32e0a8fe91bff1cda847de7a0269411",
+        "rev": "ceb52aece5d571b37096945c2815604195a04eb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`ceb52aec`](https://github.com/nix-community/nixvim/commit/ceb52aece5d571b37096945c2815604195a04eb4) | `` ci/merge: add pr-merged workflow ``                 |
| [`ee0f56f4`](https://github.com/nix-community/nixvim/commit/ee0f56f4f854f551b78453ba15dbeb639144fe23) | `` flake/diff-plugins: allow specifying HEAD commit `` |
| [`01a861f6`](https://github.com/nix-community/nixvim/commit/01a861f66973e4e02b3ed0a4b2b78329cc70622c) | `` flake/dev/list-plugins: add zf-native exclusion ``  |
| [`590b9b13`](https://github.com/nix-community/nixvim/commit/590b9b13f776ce802f72061b0ee22c91900272e4) | `` flake/dev: remove redundant python interpreator ``  |
| [`9cc99629`](https://github.com/nix-community/nixvim/commit/9cc99629f3b7d13006889088ccdfcc0d78ee7fad) | `` flake/dev: use nix-shell shebangs for scripts ``    |