### PR TITLE
chore(flake/nixvim): `ceb52aec` -> `239d331b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751144320,
-        "narHash": "sha256-KJsKiGfkfXFB23V26NQ1p+UPsexI6NKtivnrwSlWWdQ=",
+        "lastModified": 1751492444,
+        "narHash": "sha256-26NgRXwhNM2x4hrok0C3CqSf2v0vi9byONNON5PzbHQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ceb52aece5d571b37096945c2815604195a04eb4",
+        "rev": "239d331bb48673dfd00d7187654892471cd60d44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`239d331b`](https://github.com/nix-community/nixvim/commit/239d331bb48673dfd00d7187654892471cd60d44) | `` ci/update: don't set NIX_PATH ``                           |
| [`5c3236c0`](https://github.com/nix-community/nixvim/commit/5c3236c091b6739bd962ba117bff1d29610c5d3f) | `` ci/pr-merged: use locked nixpkgs ``                        |
| [`54c44c09`](https://github.com/nix-community/nixvim/commit/54c44c09fa9326f609358a419e51a19dfdbba6af) | `` flake/dev: prefix nixvim's nixpkgs to devshell NIX_PATH `` |
| [`30d8be86`](https://github.com/nix-community/nixvim/commit/30d8be8628330bc5baa064e0dac904a574558b17) | `` plugins/linediff: init ``                                  |
| [`86dae358`](https://github.com/nix-community/nixvim/commit/86dae3585bd58a8bec1d69ffec8fc5d931d07787) | `` plugins/neogit: Add 'kitty' to graph_style. ``             |