### PR TITLE
chore(flake/nixpkgs): `3016b4b1` -> `9807714d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751271578,
-        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`9807714d`](https://github.com/NixOS/nixpkgs/commit/9807714d6944a957c2e036f84b0ff8caf9930bc0) | `` libdjinterop: 0.24.3 -> 0.26.1; fix aarch64-linux build (#422754) ``      |
| [`2cf46883`](https://github.com/NixOS/nixpkgs/commit/2cf468838369ca367c7414a81b95bad81bb0f9e5) | `` ptyxis: 48.4 -> 48.5 ``                                                   |
| [`ca352e30`](https://github.com/NixOS/nixpkgs/commit/ca352e30df795bcfe6a03bd45a44cb2e54b09a74) | `` ty: 0.0.1-alpha.13 -> 0.0.1-alpha.14 ``                                   |
| [`d8c58b7a`](https://github.com/NixOS/nixpkgs/commit/d8c58b7af0a627f5885bc58ed5a8394e0673226a) | `` texlive: 2025.20250603 -> 2025.20250703 ``                                |
| [`8302e1cd`](https://github.com/NixOS/nixpkgs/commit/8302e1cd19561b2b35536b5255b2d4578adf1f57) | `` linux_xanmod_latest: 6.15.4 -> 6.15.5 ``                                  |
| [`aa2e1fff`](https://github.com/NixOS/nixpkgs/commit/aa2e1fff170a8d60f06a194b011409c3432f1797) | `` linux_xanmod: 6.12.35 -> 6.12.36 ``                                       |
| [`9e18de41`](https://github.com/NixOS/nixpkgs/commit/9e18de41f2eb7c39039ee5edf8ea1a8a0890fb7e) | `` libretro.beetle-saturn: 0-unstable-2025-06-22 -> 0-unstable-2025-07-01 `` |
| [`23232fdd`](https://github.com/NixOS/nixpkgs/commit/23232fdda84ee2afaf616542ba220f3bfbb09d81) | `` wyoming-openwakeword: fix build-system typo ``                            |
| [`30c1ef05`](https://github.com/NixOS/nixpkgs/commit/30c1ef051b5aaf33bf362dc9730628ac5cc26cd8) | `` nixos/ec2-data: fix eval ``                                               |
| [`6d35689a`](https://github.com/NixOS/nixpkgs/commit/6d35689a8da46f308efed2460950f00a5e04c981) | `` nixos/peertube: support auto transcription ``                             |
| [`2fcfe280`](https://github.com/NixOS/nixpkgs/commit/2fcfe280b51a589f81541b12d32da046bf69bbe6) | `` rocq-core_9_1: init at 9.1+rc1 ``                                         |
| [`431f160d`](https://github.com/NixOS/nixpkgs/commit/431f160d392533db0dbdd958e903ac8a7b2d8104) | `` androidStudioPackages.canary: 2025.1.2.7 -> 2025.1.2.8 ``                 |
| [`e801d589`](https://github.com/NixOS/nixpkgs/commit/e801d5894f0f6133629872e1c71e95a22f5a74ec) | `` nixos/network-interfaces-systemd: fix WoL policy handling ``              |
| [`76c4ca93`](https://github.com/NixOS/nixpkgs/commit/76c4ca93f42236f3e386416e92f70a02072bdca7) | `` rustc: Add support for bootstrapping ppc64-elfv1 ``                       |
| [`b1990e8a`](https://github.com/NixOS/nixpkgs/commit/b1990e8ac0e856d001c3bd54fa2f25922053330e) | `` icestudio: Fix passthru.updateScript ``                                   |
| [`1681ac72`](https://github.com/NixOS/nixpkgs/commit/1681ac72dd5e1f0f7c06d0df6edc646a628fbee0) | `` go-errorlint: 1.5.1 -> 1.8.0 ``                                           |
| [`12b315a7`](https://github.com/NixOS/nixpkgs/commit/12b315a76574e4a7ddb38b6cf0549d7f0c255ef7) | `` coqPackages.fcsl-pcm: init at 2.2.0 ``                                    |
| [`98394f79`](https://github.com/NixOS/nixpkgs/commit/98394f79335e1522ee2a723a4e1ca98e68030483) | `` python3Packages.pycollada: 0.9 -> 0.9.2 ``                                |
| [`143dfa1a`](https://github.com/NixOS/nixpkgs/commit/143dfa1ac9d6d641a8283848c8ffc36280ff6e80) | `` coqPackages.mathcomp-analysis: 1.11.0 -> 1.12.0 ``                        |
| [`e5977889`](https://github.com/NixOS/nixpkgs/commit/e59778897eebb2cc1404340eba241b006a578622) | `` libretro.ppsspp: 0-unstable-2025-06-28 -> 0-unstable-2025-07-06 ``        |
| [`f9422626`](https://github.com/NixOS/nixpkgs/commit/f94226260f56bbe25eaa57e416cbdbef630fa859) | `` fcitx5-mcbopomofo: 2.9.1 -> 2.9.2 ``                                      |
| [`109f57d5`](https://github.com/NixOS/nixpkgs/commit/109f57d5b77afbf45ce466a26c19071da860f11e) | `` home-assistant: update component packages ``                              |
| [`fbfb46ec`](https://github.com/NixOS/nixpkgs/commit/fbfb46ec369ac2f083fd5694b0c2faf658662967) | `` python313Packages.pyforked-daapd: init at 0.1.14 ``                       |
| [`b070eacf`](https://github.com/NixOS/nixpkgs/commit/b070eacfa2fc9885fcb7d9e6a8f7128038812e45) | `` chatmcp: 0.0.69 -> 0.0.70 ``                                              |
| [`6def0235`](https://github.com/NixOS/nixpkgs/commit/6def02350901d6033b74b4b6f796a28757c5ed8a) | `` python3Packages.pytubefix: 9.2.0 -> 9.2.2 (#421345) ``                    |
| [`fef56ae5`](https://github.com/NixOS/nixpkgs/commit/fef56ae55dcf5b5cd256f9192040a1934702ace3) | `` telepresence2: 2.23.2 -> 2.23.3 ``                                        |
| [`756720b2`](https://github.com/NixOS/nixpkgs/commit/756720b2664cd2d68298a345233604b550b24991) | `` copygen: init at 0.4.1 (#421359) ``                                       |
| [`c35913b6`](https://github.com/NixOS/nixpkgs/commit/c35913b63beb962ebd3c765e8756f7b78f2bbc06) | `` datafusion-cli: 48.0.0 -> 48.0.1 ``                                       |
| [`585d6757`](https://github.com/NixOS/nixpkgs/commit/585d6757bce1a9899513a09f79ed96bdaaca1ef5) | `` python3Packages.allantools: init at 2024.06 ``                            |
| [`2afbb7c1`](https://github.com/NixOS/nixpkgs/commit/2afbb7c1146e3d8632c492b6f8d55a14c9c2fe1b) | `` aaaaxy: 1.6.241 -> 1.6.252 ``                                             |
| [`ecfa2edf`](https://github.com/NixOS/nixpkgs/commit/ecfa2edf0291d9332ca0264a2745acc3071c276f) | `` tdlib: 1.8.49 -> 1.8.51 ``                                                |
| [`537207e0`](https://github.com/NixOS/nixpkgs/commit/537207e05353d6486aabff059f47ed97191f38f9) | `` exercism: 3.5.5 -> 3.5.6 ``                                               |
| [`12d25c49`](https://github.com/NixOS/nixpkgs/commit/12d25c49bda8ad646304934c0a9029cf4fbb6780) | `` chrony: remove myself as maintainer ``                                    |
| [`b1c964b5`](https://github.com/NixOS/nixpkgs/commit/b1c964b55750ca8b86947e26226f05f1203f9e58) | `` nixos/tests/chrony: graphene-hardened works without mlock ``              |
| [`64b826d3`](https://github.com/NixOS/nixpkgs/commit/64b826d3aa1333245613bc1a6503fe6ccec775fc) | `` python313Packages.publicsuffixlist: 1.0.2.20250627 -> 1.0.2.20250707 ``   |
| [`543a5b42`](https://github.com/NixOS/nixpkgs/commit/543a5b42313d0a36483b8f960b85692a0bdbe75c) | `` python313Packages.tencentcloud-sdk-python: 3.0.1417 -> 3.0.1418 ``        |
| [`aab4b8a8`](https://github.com/NixOS/nixpkgs/commit/aab4b8a85e3d2a776ed661e9a66e5ddbe8462b81) | `` pphack: add versionCheckHook ``                                           |
| [`c18fdfa1`](https://github.com/NixOS/nixpkgs/commit/c18fdfa1f04abec54202b3960025fc3679ff808c) | `` pphack: migrate to finalAttrs ``                                          |
| [`9f2f45a9`](https://github.com/NixOS/nixpkgs/commit/9f2f45a95f6a6ac9b7daaaf341f939e1410d6b9a) | `` python3Packages.bokeh-sampledata: 2024.2 -> 2025.0 ``                     |
| [`4a004775`](https://github.com/NixOS/nixpkgs/commit/4a004775e636ea0742846bc47b27fce3b6ef3608) | `` redis: 8.0.2 -> 8.0.3 ``                                                  |
| [`90d14631`](https://github.com/NixOS/nixpkgs/commit/90d1463182d77a8379658da8dcfe4da75a7545c9) | `` ocamlPackages.jsont: init at 0.1.1 ``                                     |
| [`43c98b9e`](https://github.com/NixOS/nixpkgs/commit/43c98b9e4bb46a09aa2122c136500fda2cfcbe99) | `` ocamlPackages.bytesrw: init at 0.1.0 ``                                   |
| [`09b7782d`](https://github.com/NixOS/nixpkgs/commit/09b7782d3290d197ef84fe8b5cae8f167a12e81e) | `` nixVersions.nix_2_24: Fix FOD hash for 2.24.15 ``                         |
| [`3700b96e`](https://github.com/NixOS/nixpkgs/commit/3700b96eecf9ba0ebf5417d83e04bf16a1455c80) | `` jaq: add ngi team ``                                                      |
| [`0e326612`](https://github.com/NixOS/nixpkgs/commit/0e326612020a266215f96b1aaf8d5a5d97f39b2f) | `` nixos/testing: Add test attribute to please discoverTests ``              |
| [`9f4ab5de`](https://github.com/NixOS/nixpkgs/commit/9f4ab5def9b82b945b433ad0120b8fb9a600e755) | `` eclib: 20250616 -> 20250627 ``                                            |
| [`150e9dbb`](https://github.com/NixOS/nixpkgs/commit/150e9dbb079ef222742440562200e5a638b8a563) | `` gdu: migrate to finalAttrs ``                                             |
| [`c4ac7eb9`](https://github.com/NixOS/nixpkgs/commit/c4ac7eb951f562376409f66f07fe4a5117b12c69) | `` adu: migrate to versionCheckHook ``                                       |
| [`c2f705ce`](https://github.com/NixOS/nixpkgs/commit/c2f705ce80854eb8c399a4d934ff15b011e2c536) | `` buildRustCrate: also replace hyphens in CRATEVERSION ``                   |
| [`1b71bea7`](https://github.com/NixOS/nixpkgs/commit/1b71bea7be5a4af39efefebe674f8656ae00fff6) | `` icloudpd: 1.28.1 -> 1.28.2 ``                                             |
| [`e72ab6d4`](https://github.com/NixOS/nixpkgs/commit/e72ab6d47f4a3f1111aa4023fe51b9b6109c8061) | `` mediamtx: 1.12.3 -> 1.13.0 ``                                             |
| [`92b2f6be`](https://github.com/NixOS/nixpkgs/commit/92b2f6bee1c1a26eb1585e0d9e5709e88c1c5ad5) | `` codex: remove openssl from nativeBuildInputs ``                           |
| [`0295ad19`](https://github.com/NixOS/nixpkgs/commit/0295ad1904fb12ae0406cbc46b8a023d128c0b23) | `` nixos/all-tests: Use ? in discoverTests ``                                |
| [`6766db42`](https://github.com/NixOS/nixpkgs/commit/6766db42847c4fee897f5bad384cac700edd86b3) | `` apko: 0.29.1 -> 0.29.2 ``                                                 |
| [`7c1c76a2`](https://github.com/NixOS/nixpkgs/commit/7c1c76a2918219d4db375f04253d3b74ed2bcf4a) | `` apko: update changelog attr ``                                            |
| [`1d903c2e`](https://github.com/NixOS/nixpkgs/commit/1d903c2ec50dfbb790e0d517f00da6e50a22c57c) | `` f3d: fix build after assimp update ``                                     |
| [`626f52e7`](https://github.com/NixOS/nixpkgs/commit/626f52e72b7d917a5b7667fdb4b98eff8178e5dd) | `` lux-cli: use finalAttrs pattern ``                                        |
| [`b99175e0`](https://github.com/NixOS/nixpkgs/commit/b99175e09a75e2cafcaf14d2ff5676041033c32c) | `` python3Packages.paddleocr: 3.0.3 -> 3.1.0 ``                              |
| [`304cd354`](https://github.com/NixOS/nixpkgs/commit/304cd3549509da7ccc6f66b9783af5e4ed9b9976) | `` mtr: 0.95 -> 0.96 ``                                                      |
| [`17b2a0ed`](https://github.com/NixOS/nixpkgs/commit/17b2a0ed5a69d52f37fbd3bea552ecf42954fee3) | `` python3Packages.pynng: init at 0.8.1-unstable-2025-05-14 ``               |
| [`93d0e63a`](https://github.com/NixOS/nixpkgs/commit/93d0e63a62bf5e870b4ec015535cdcda57ba7c5e) | `` ocamlPackages.js_of_ocaml: 6.1.0 -> 6.1.1 ``                              |
| [`47741dad`](https://github.com/NixOS/nixpkgs/commit/47741dad8d8d4bc02c67705024ae105c52bcde3d) | `` jaq: 2.2.0 -> 2.3.0 ``                                                    |
| [`73ad097b`](https://github.com/NixOS/nixpkgs/commit/73ad097b9eb7f1f7692d2f3339eb3e4d8384018b) | `` flyctl: 0.3.145 -> 0.3.149 ``                                             |
| [`72da41d4`](https://github.com/NixOS/nixpkgs/commit/72da41d4a862d5b60c5ffde51bb4288a921dfd43) | `` espflash: 4.0.0 -> 4.0.1 ``                                               |
| [`817ddba5`](https://github.com/NixOS/nixpkgs/commit/817ddba540963c781f24bf5d0b7ef47ade8dd9a2) | `` mautrix-whatsapp: add SchweGELBin as maintainer ``                        |
| [`a94b4d0c`](https://github.com/NixOS/nixpkgs/commit/a94b4d0cdce39115ebe37ffe164c32f572a6e8f5) | `` portunus: 2.1.2 -> 2.1.4 ``                                               |
| [`be261b8f`](https://github.com/NixOS/nixpkgs/commit/be261b8fb393c2617ec4140d7d11d65a8f546a94) | `` kubectl-gadget: 0.41.0 -> 0.42.0 ``                                       |
| [`bea380e8`](https://github.com/NixOS/nixpkgs/commit/bea380e8341d66fed40ea5e4593c6283cd40cdff) | `` gleam: move js runtimes and git to nativeCheckInputs ``                   |
| [`a119ffa4`](https://github.com/NixOS/nixpkgs/commit/a119ffa449dee537e75366e9d33d1d5e841db6d0) | `` iw4x-launcher: 1.0.1 -> 1.0.2 ``                                          |
| [`5c849993`](https://github.com/NixOS/nixpkgs/commit/5c8499934295dd5b0ad89472f9f6b91a773d8643) | `` ocamlPackages.gen_js_api: 1.1.4 -> 1.1.5 ``                               |
| [`a5c02729`](https://github.com/NixOS/nixpkgs/commit/a5c0272928b61a2d9b9b58b1818c38e4656173b2) | `` nominatim-ui: revert back to mkDerivation ``                              |
| [`30b6164d`](https://github.com/NixOS/nixpkgs/commit/30b6164dab852c430426ab206fb44add667cf287) | `` nominatim-ui: add possibility to customize config.theme.js file ``        |
| [`a160bd4b`](https://github.com/NixOS/nixpkgs/commit/a160bd4bfb1ca62eed6264990b86fd871012a901) | `` postgresql13Packages.pgaudit: 1.5.2 -> 1.5.3 ``                           |
| [`f2d2e1a1`](https://github.com/NixOS/nixpkgs/commit/f2d2e1a1bf077f21cb6580c032074e4bc2fbe284) | `` postgresql14Packages.pgaudit: 1.6.2 -> 1.6.3 ``                           |
| [`13bb575a`](https://github.com/NixOS/nixpkgs/commit/13bb575a82eb9d6e61c22d828a66eaa5b2b23cf4) | `` postgresql15Packages.pgaudit: 1.7.0 -> 1.7.1 ``                           |
| [`8e9aa811`](https://github.com/NixOS/nixpkgs/commit/8e9aa8119ef990a3ccf97e3010f398d630add64d) | `` postgresql16Packages.pgaudit: 16.0 -> 16.1 ``                             |
| [`77a84b41`](https://github.com/NixOS/nixpkgs/commit/77a84b41094b3773193ac9c8b6b47b66fe03ca90) | `` postgresql17Packages.pgaudit: 17.0 -> 17.1 ``                             |
| [`3ee9701f`](https://github.com/NixOS/nixpkgs/commit/3ee9701f36529b763e611b4c1271dc912df69580) | `` postgresql18Packages.pgaudit: add note about v18 support ``               |
| [`53c381fd`](https://github.com/NixOS/nixpkgs/commit/53c381fdf368991575005a4cb39dcc17ae918454) | `` postgresql18Packages.pg_hint_plan: add note about upstream ticket ``      |
| [`59e77beb`](https://github.com/NixOS/nixpkgs/commit/59e77beb3b833acc3d8d5bc194dcfcb06ecfa4a1) | `` postgresql18Packages.pg_safeupdate: unbreak ``                            |
| [`1a78867a`](https://github.com/NixOS/nixpkgs/commit/1a78867a15791b8b4df9f42b0991693f826cf507) | `` postgresql18Packages.{pg_hint_plan,pg_safeupdate,pgaudit}: mark broken `` |