### PR TITLE
chore(flake/nix-fast-build): `64b4f816` -> `54a7a75e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1751414949,
-        "narHash": "sha256-vLGqlaHsvgvA1ozdcMtCGentlDru5UkvPt6f8uJ1gYI=",
+        "lastModified": 1751851538,
+        "narHash": "sha256-mfqGoKVtq7/vt0onTh68R8OuFBtvt4FQr6+Ves3xzSI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "64b4f81619f1691dba8d886458911d553632b8bb",
+        "rev": "54a7a75eb1e69b3971f236710213a8894adde0ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`54a7a75e`](https://github.com/Mic92/nix-fast-build/commit/54a7a75eb1e69b3971f236710213a8894adde0ee) | `` chore(deps): lock file maintenance (#191) `` |
| [`148c3836`](https://github.com/Mic92/nix-fast-build/commit/148c3836eab55ba69c10e5d7e85d643dabd88b5b) | `` chore(deps): lock file maintenance (#190) `` |