### PR TITLE
chore(flake/nixvim): `ef0fa015` -> `bc997a24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751746175,
-        "narHash": "sha256-6JABU+UMkaL4c+ZJRQYyFyIkm9ry1fOkhNQgSSjK5OM=",
+        "lastModified": 1751904655,
+        "narHash": "sha256-lHAj9Xh/vBf3cXns1wN5HPw/zwGTO/Uv/ttloBok1n4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ef0fa015a8236241bdcc27f32e6a4aa537d96cf8",
+        "rev": "bc997a240953bda9fa526e8a3d6f798a6072308a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`bc997a24`](https://github.com/nix-community/nixvim/commit/bc997a240953bda9fa526e8a3d6f798a6072308a) | `` ci/version-info: create temp files in a temp directory ``                    |
| [`2369b7fc`](https://github.com/nix-community/nixvim/commit/2369b7fc4fc6bab6c85a3f2feb36d68d63926406) | `` ci/version-info: correctly set NIX_PATH instead of flake registries ``       |
| [`981c917a`](https://github.com/nix-community/nixvim/commit/981c917a430cebe5e9d8d2be7b286fedec02d46e) | `` tests/none-ls: disable tests that depend on open-policy-agent on darwin ``   |
| [`0ce4ebf1`](https://github.com/nix-community/nixvim/commit/0ce4ebf139a4f9f11c2f22507a55fc9a73aa533d) | `` plugins/origami: update module to v2.0 ``                                    |
| [`65725e83`](https://github.com/nix-community/nixvim/commit/65725e83f85d7b6a68026705483742145fd6075c) | `` tests/kulala: disable runNvim as the plugin tries to install a TS grammar `` |
| [`daae37a9`](https://github.com/nix-community/nixvim/commit/daae37a908879b77f3d172f9636eec467dd6f617) | `` plugins/efmls-configs: add package mapping for ZLint ``                      |
| [`76c2e816`](https://github.com/nix-community/nixvim/commit/76c2e816e13cb8989696cab752cc0efcbed7bd21) | `` generated: Update ``                                                         |
| [`a364039e`](https://github.com/nix-community/nixvim/commit/a364039e8b56bd25c2bcde63fcb031c1fca79312) | `` flake/dev/flake.lock: Update ``                                              |
| [`8c80c0ae`](https://github.com/nix-community/nixvim/commit/8c80c0ae375968035231a1df5623dc9b5fd19295) | `` flake.lock: Update ``                                                        |
| [`28f818b5`](https://github.com/nix-community/nixvim/commit/28f818b57bb68d91891d23952490b1e19055d63c) | `` user-configs: add @r17x's config ``                                          |
| [`19aab2f9`](https://github.com/nix-community/nixvim/commit/19aab2f935171faa6efd10282138706775543bad) | `` colorschemes/gruvbox-material: update default config due to lib changes ``   |