### PR TITLE
chore(flake/nixvim): `bc997a24` -> `a610befe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751904655,
-        "narHash": "sha256-lHAj9Xh/vBf3cXns1wN5HPw/zwGTO/Uv/ttloBok1n4=",
+        "lastModified": 1751994757,
+        "narHash": "sha256-F8t/OiOUAc+zmZ8pSHkppWW8fM8l2JJ2TRvsbeMUgF4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "bc997a240953bda9fa526e8a3d6f798a6072308a",
+        "rev": "a610befe67223933730872c2a47c9d8b880638ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`a610befe`](https://github.com/nix-community/nixvim/commit/a610befe67223933730872c2a47c9d8b880638ae) | `` plugins/otter: add HeitorAugustoLN as a maintainer ``        |
| [`e5824658`](https://github.com/nix-community/nixvim/commit/e58246583eea27bfead0d53bc5594b224bd212e7) | `` plugins/otter: migrate autoActivate to the new lsp module `` |
| [`67785f95`](https://github.com/nix-community/nixvim/commit/67785f957724771c7e6ce5a1654366580678c885) | `` flake/ci: fix lazy eval of dev partition ``                  |
| [`87e81a65`](https://github.com/nix-community/nixvim/commit/87e81a657267affdd119ba6efa75017d1721c215) | `` plugins/codecompanion: correct option description ``         |
| [`8c525708`](https://github.com/nix-community/nixvim/commit/8c5257088b04a1432cf2d4e06e0c271934d018be) | `` modules/files: improve `extraFiles` example ``               |
| [`6b56adb7`](https://github.com/nix-community/nixvim/commit/6b56adb71af4326e0136b64bbc2eaf8f498c887b) | `` ci: add update-maintainers workflow ``                       |
| [`f812a689`](https://github.com/nix-community/nixvim/commit/f812a689b861b84f3dd55ab16a804c8b98157118) | `` generated/all-maintainers.nix: init ``                       |
| [`056cd86c`](https://github.com/nix-community/nixvim/commit/056cd86cc0b1b67cdc8e8f60a4e9e63f802d7d4e) | `` flake/dev/generate-all-maintainers: init ``                  |
| [`95f129ca`](https://github.com/nix-community/nixvim/commit/95f129ca6569af251d9665bfe914d3d295b65745) | `` plugins/codecompanion: update defaults and examples ``       |