### PR TITLE
chore(flake/nixvim): `a610befe` -> `2e24f8e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751994757,
-        "narHash": "sha256-F8t/OiOUAc+zmZ8pSHkppWW8fM8l2JJ2TRvsbeMUgF4=",
+        "lastModified": 1752099138,
+        "narHash": "sha256-riX+IkcFhurR1M1vMEp2cdzraxsZEZl+XbpFWcgz3lU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a610befe67223933730872c2a47c9d8b880638ae",
+        "rev": "2e24f8e62bc5da7e1ce81e2f2ff7d9e1f51350b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`2e24f8e6`](https://github.com/nix-community/nixvim/commit/2e24f8e62bc5da7e1ce81e2f2ff7d9e1f51350b7) | `` ci/tag-maintainers: minor cleanup ``                            |
| [`8eaf9254`](https://github.com/nix-community/nixvim/commit/8eaf9254a132ec6c257995f5271e5db8f558238e) | `` ci/tag-maintainers: pass changed file to nix as json ``         |
| [`cd856a32`](https://github.com/nix-community/nixvim/commit/cd856a327cf13f7d19ad98e1503c2aaf2b3bbda3) | `` ci/tag-maintainers: split nix into separate file ``             |
| [`22b3c49a`](https://github.com/nix-community/nixvim/commit/22b3c49a0ebaab1d7cfa4b49fcf38900c115bf76) | `` ci: run treefmt ``                                              |
| [`405132ba`](https://github.com/nix-community/nixvim/commit/405132bab3f0e52c351ef0f5a73dfaddac0420ac) | `` ci: tag-maintainers extract maintainers in a separate script `` |
| [`86075435`](https://github.com/nix-community/nixvim/commit/860754350d6e65c55c478b507b0ab84b792f14e3) | `` ci: add tag-maintainers workflow ``                             |