### PR TITLE
chore(flake/nixvim): `2e24f8e6` -> `b728cf43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1752099138,
-        "narHash": "sha256-riX+IkcFhurR1M1vMEp2cdzraxsZEZl+XbpFWcgz3lU=",
+        "lastModified": 1752158208,
+        "narHash": "sha256-XbXYLUtaB/wHvZYefvaDPbo4eYj27kbtowHfww9bqLw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2e24f8e62bc5da7e1ce81e2f2ff7d9e1f51350b7",
+        "rev": "b728cf43d97814df43f5d9bd9dafac9072ccd9e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`b728cf43`](https://github.com/nix-community/nixvim/commit/b728cf43d97814df43f5d9bd9dafac9072ccd9e8) | `` ci/tag-maintainers: don't remove review requests ``         |
| [`db7c5364`](https://github.com/nix-community/nixvim/commit/db7c5364a58e1d9519bb4e1e0e13abb0a368376f) | `` tests: use a nested attrset for buildbot ``                 |
| [`1463ec64`](https://github.com/nix-community/nixvim/commit/1463ec64d5ecc241aebb0ee373a792c8121b8ded) | `` tests: use a single link-farm for flake-checks ``           |
| [`278eb40f`](https://github.com/nix-community/nixvim/commit/278eb40fa7fa5775dd5384a09fee99bef09d2682) | `` tests: take responsibility for flakecheck/buildbot split `` |