### PR TITLE
chore(flake/nixvim): `b728cf43` -> `4b068551`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1752158208,
-        "narHash": "sha256-XbXYLUtaB/wHvZYefvaDPbo4eYj27kbtowHfww9bqLw=",
+        "lastModified": 1752358818,
+        "narHash": "sha256-Txnm5vJqZgaHpEM/9OANg1Ux4e9xHQ7iXfQ8EqtqM9s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b728cf43d97814df43f5d9bd9dafac9072ccd9e8",
+        "rev": "4b068551d85cb4984fc60268a95097cf7af1ae48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4b068551`](https://github.com/nix-community/nixvim/commit/4b068551d85cb4984fc60268a95097cf7af1ae48) | `` ci/tag-maintainers: refactor managing reviewers ``       |
| [`c4353d05`](https://github.com/nix-community/nixvim/commit/c4353d057a785a8263d99885414ec494101e2d83) | `` flake/dev: pin flake-compat to PR fixing shallow repo `` |
| [`4f9e8551`](https://github.com/nix-community/nixvim/commit/4f9e8551726e7a96198f74673ba54c009c1e4bcf) | `` ci/tag-maintainers: exit if nix fails ``                 |
| [`3708f788`](https://github.com/nix-community/nixvim/commit/3708f788e25d8602dde5b63bf66f9579357fef2f) | `` docs: fix typo ``                                        |
| [`4aad22c3`](https://github.com/nix-community/nixvim/commit/4aad22c30c5eb090c3f4ea8dac5b69ab11c04d98) | `` user-configs: update GaetanLepage's config url ``        |
| [`658980fb`](https://github.com/nix-community/nixvim/commit/658980fb247e2f10fa692bae372ac21389a67c6c) | `` user-configs: add @c4patino's config" ``                 |