### PR TITLE
chore(flake/nixvim): `1fb1bf8a` -> `bc0555c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1752546848,
-        "narHash": "sha256-WzHqmJ1wEZoUGAedomwcVLCuNsiB9bZzZXk7K9ZDBwk=",
+        "lastModified": 1752762787,
+        "narHash": "sha256-WZLSOR2Pei7C4nH/ntKUqOZOAa5rgvc2fVZl4RoEXmw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1fb1bf8a73ccf207dbe967cdb7f2f4e0122c8bd5",
+        "rev": "bc0555c8694d43fb63ae2c7afec08b6987431a04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`bc0555c8`](https://github.com/nix-community/nixvim/commit/bc0555c8694d43fb63ae2c7afec08b6987431a04) | `` plugins/img-clip: init ``           |
| [`7ad0cadd`](https://github.com/nix-community/nixvim/commit/7ad0cadd8b0e7025f4c4d6cb073d79a0b75e4446) | `` plugins/lualine: fix description `` |