### PR TITLE
chore(flake/nixvim): `bc0555c8` -> `60556b5d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1752762787,
-        "narHash": "sha256-WZLSOR2Pei7C4nH/ntKUqOZOAa5rgvc2fVZl4RoEXmw=",
+        "lastModified": 1752944806,
+        "narHash": "sha256-7nBFB2r9E0SyrEbUmZYDVAPkghTpkbgiWywZHvUjGew=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "bc0555c8694d43fb63ae2c7afec08b6987431a04",
+        "rev": "60556b5df9b70b7be88de760e695892b9ce74b9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`60556b5d`](https://github.com/nix-community/nixvim/commit/60556b5df9b70b7be88de760e695892b9ce74b9e) | `` plugins/no-neck-pain: init ``        |
| [`cebc5458`](https://github.com/nix-community/nixvim/commit/cebc5458ce95c1fb7fdeaae96c357d04e5f3920c) | `` maintainers: add ChelseaWilkinson `` |