### PR TITLE
chore(flake/nix-fast-build): `36eb141b` -> `9ee30c01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1752451847,
-        "narHash": "sha256-61GFLI0ikyjh1sbIru5VgmaZHKAHBeo6ZNrlaWDmG4I=",
+        "lastModified": 1753007040,
+        "narHash": "sha256-fTDnQ2lvX2sLIq8Kego6YP93R3P5tctcuGJ+wj2rzoQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "36eb141bd4b6d799be07db7450a78e885523ff68",
+        "rev": "9ee30c01cf8fee2379c80d189d8ec2e96a48b74a",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752055615,
-        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "lastModified": 1753006367,
+        "narHash": "sha256-tzbhc4XttkyEhswByk5R38l+ztN9UDbnj0cTcP6Hp9A=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "rev": "421b56313c65a0815a52b424777f55acf0b56ddf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`9ee30c01`](https://github.com/Mic92/nix-fast-build/commit/9ee30c01cf8fee2379c80d189d8ec2e96a48b74a) | `` chore(deps): update treefmt-nix digest to 421b563 (#195) `` |
| [`663f68f1`](https://github.com/Mic92/nix-fast-build/commit/663f68f1f5a283e8a6d5b929104f7b4b084c47bd) | `` chore(deps): update treefmt-nix digest to 0043b95 (#194) `` |