### PR TITLE
chore(flake/nixvim): `0c50ed93` -> `3d09c8ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1753121425,
+        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1752976861,
-        "narHash": "sha256-59HcrqHfbSJUdmpzrAa9x8fW1PoS+ZGhCjL5k5HbyV8=",
+        "lastModified": 1753487377,
+        "narHash": "sha256-dEr3pYtC4/1PhP5ADIV8Fjjmxv6WC6UisQAUqtwdews=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0c50ed9349199219583cb1ed1a972d71e06039ec",
+        "rev": "3d09c8eaceb7a78ef9f5568024da1616f00c33e3",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749730855,
-        "narHash": "sha256-L3x2nSlFkXkM6tQPLJP3oCBMIsRifhIDPMQQdHO5xWo=",
+        "lastModified": 1753385846,
+        "narHash": "sha256-XDu9T2o6Rxe0acpchwQ2aXaRfE/uEYALpVbf+9QDEO4=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "8dfe5879dd009ff4742b668d9c699bc4b9761742",
+        "rev": "5c7e4eff303cba8447ffb443522b3c72bc47a9ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
| [`3d09c8ea`](https://github.com/nix-community/nixvim/commit/3d09c8eaceb7a78ef9f5568024da1616f00c33e3) | `` plugins/lsp: use new lsp module to implement plugins.lsp.inlayHints (two-way alias) ``    |
| [`dff79d34`](https://github.com/nix-community/nixvim/commit/dff79d34f8021d721461f63286537efc28a41451) | `` tests/plugins/none-ls: disable puppet_lint and prisma_format on darwin (prisma broken) `` |
| [`7988de00`](https://github.com/nix-community/nixvim/commit/7988de00d63a6d6713beb3dca64bd01f2e721283) | `` tests/plugins/obsidian: suppress deprecation warning ``                                   |
| [`0e2af088`](https://github.com/nix-community/nixvim/commit/0e2af088f1b954f198c013f2b125498c026c8b5e) | `` plugins/wtf: adapt to upstream changes ``                                                 |
| [`2dbe5199`](https://github.com/nix-community/nixvim/commit/2dbe5199ede60600826ca8690324aad426b028ba) | `` tests/plugins/efmls: disable ZLint tool on aarch64-darwin (zig-zlint failing to build) `` |
| [`8a7d5f54`](https://github.com/nix-community/nixvim/commit/8a7d5f548b50432a3c9c9925681a30c311447129) | `` tests/plugins/dbee: disable test on aarch64-linux (duckdb broken) ``                      |
| [`16e3c175`](https://github.com/nix-community/nixvim/commit/16e3c175ec2505050b1a5a9c418a7b8ba844d0c3) | `` tests/performance: disable test ``                                                        |
| [`2dd3e4c8`](https://github.com/nix-community/nixvim/commit/2dd3e4c8fcead91d4425f61e4cff1ffa7ed6a631) | `` tests/lsp: disable broken servers ``                                                      |
| [`8529f1c8`](https://github.com/nix-community/nixvim/commit/8529f1c86b1d7e0f9e739cc28816504653e3d006) | `` treewide: format with new treefmt ``                                                      |
| [`c61851af`](https://github.com/nix-community/nixvim/commit/c61851aff7d5e24f1b5ae5323b3c2993913bb774) | `` flake/dev/flake.lock: Update ``                                                           |
| [`e4663d7a`](https://github.com/nix-community/nixvim/commit/e4663d7ac06e92dea7fb6b0df3d2040d5d569e1f) | `` flake.lock: Update ``                                                                     |