### PR TITLE
chore(flake/nixvim): `29edaafd` -> `4f584b5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1753533009,
-        "narHash": "sha256-4KlfDVsYL9c3ogEehJcQOBZ+pUBH7Lwvlu2J6FCtSJc=",
+        "lastModified": 1753655972,
+        "narHash": "sha256-x1gsih/gAiUo6qw/ZjcFm3KqKLL/P1f9HgPGoi8bXQI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "29edaafdb088cee3d8c616a4a5bb48b5eecc647c",
+        "rev": "4f584b5b366303510702b10c496ab27a44e90426",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`4f584b5b`](https://github.com/nix-community/nixvim/commit/4f584b5b366303510702b10c496ab27a44e90426) | `` flake/dev/flake.lock: Update ``         |
| [`00cada56`](https://github.com/nix-community/nixvim/commit/00cada56ce420ac6fbf13135d67b54c05b3bfc28) | `` flake.lock: Update ``                   |
| [`35e4b616`](https://github.com/nix-community/nixvim/commit/35e4b6167ff2bc4fc774d28372abdeb31d506580) | `` plugins/notify: allow raw for stages `` |