### PR TITLE
chore(flake/nixvim): `4f584b5b` -> `e1aa35fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1753655972,
-        "narHash": "sha256-x1gsih/gAiUo6qw/ZjcFm3KqKLL/P1f9HgPGoi8bXQI=",
+        "lastModified": 1753706533,
+        "narHash": "sha256-ZNyVwyj+4qvaOT/gQWfNypP8qtHmXtt02D9WDZH4IPU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4f584b5b366303510702b10c496ab27a44e90426",
+        "rev": "e1aa35fb04047df11a9c1ab539a0bac35ddad509",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`e1aa35fb`](https://github.com/nix-community/nixvim/commit/e1aa35fb04047df11a9c1ab539a0bac35ddad509) | `` flake/dev/flake.lock: Update `` |