### PR TITLE
chore(flake/nixpkgs): `17f6bd17` -> `dc963787`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753549186,
-        "narHash": "sha256-Znl7rzuxKg/Mdm6AhimcKynM7V3YeNDIcLjBuoBcmNs=",
+        "lastModified": 1753694789,
+        "narHash": "sha256-cKgvtz6fKuK1Xr5LQW/zOUiAC0oSQoA9nOISB0pJZqM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "17f6bd177404d6d43017595c5264756764444ab8",
+        "rev": "dc9637876d0dcc8c9e5e22986b857632effeb727",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`6497d443`](https://github.com/NixOS/nixpkgs/commit/6497d443452cfba1405034e2f54cec5801f2bfdc) | `` release: don't block on bootstrap tools, temporarily ``                                          |
| [`2014a8b2`](https://github.com/NixOS/nixpkgs/commit/2014a8b27a90ef142462b5dfabc8e73bb95bec8b) | `` hyprprop: 0.1-unstable-2025-07-18 -> 0.1-unstable-2025-07-23 ``                                  |
| [`f532942d`](https://github.com/NixOS/nixpkgs/commit/f532942d6ec159b137919b48cda84800211f0ead) | `` claude-code: add markus1189 to maintainers ``                                                    |
| [`c95e58f4`](https://github.com/NixOS/nixpkgs/commit/c95e58f4525bdce551defb149ceb006b32d825f8) | `` vscode-extensions.marp-team.marp-vscode: 3.2.0 -> 3.2.1 ``                                       |
| [`a2da4cab`](https://github.com/NixOS/nixpkgs/commit/a2da4cab4b59677d82cb6ba9312e939f6c058c4f) | `` xmrig: patch modprobe path ``                                                                    |
| [`93260787`](https://github.com/NixOS/nixpkgs/commit/932607871a90c813c2e72d9eb29af6782f71d3eb) | `` github-mcp-server: 0.8.0 -> 0.9.0 ``                                                             |
| [`ac9f0ff3`](https://github.com/NixOS/nixpkgs/commit/ac9f0ff3818c906b657c7cc94c869f9ec677bd8c) | `` devenv: 1.8 -> 1.8.1 ``                                                                          |
| [`ad914f55`](https://github.com/NixOS/nixpkgs/commit/ad914f55dce51c7b8c982e9c0f3d98282595f823) | `` mattermost: disable another S3 test ``                                                           |
| [`ac031589`](https://github.com/NixOS/nixpkgs/commit/ac031589280bba177a0a1f51d47575be0bcc3eff) | `` quarkus: 3.24.4 -> 3.24.5 ``                                                                     |
| [`c27e74ac`](https://github.com/NixOS/nixpkgs/commit/c27e74acd403e3db7dfc00e9e7413d48e10e0806) | `` cargo-update: 16.4.0 -> 17.0.0 ``                                                                |
| [`0f3dd253`](https://github.com/NixOS/nixpkgs/commit/0f3dd2531ac52ebb4f1d25459623b216e76cc213) | `` hugo: 0.148.1 -> 0.148.2 ``                                                                      |
| [`726e8234`](https://github.com/NixOS/nixpkgs/commit/726e82341c45f28bbf84bc788daf51910b72d67c) | `` duckdb: fix 'with lib;' ``                                                                       |
| [`8f66a11c`](https://github.com/NixOS/nixpkgs/commit/8f66a11cc1d84d221e9d0f9d719352b05a35b1f3) | `` miniflux: 2.2.10 -> 2.2.11 ``                                                                    |
| [`6d4764d3`](https://github.com/NixOS/nixpkgs/commit/6d4764d3c053c7d4527d842a04ff12b7665add56) | `` maintainers: update guyonvarch ``                                                                |
| [`92808bae`](https://github.com/NixOS/nixpkgs/commit/92808bae636fb90a22cc448e83af0313f87d310c) | `` python3Packages.pymilvus: 2.5.13 -> 2.5.14 ``                                                    |
| [`9086fc17`](https://github.com/NixOS/nixpkgs/commit/9086fc179a63b8b3fefb3ddeb08b5397ee7b2bcf) | `` changie: 1.22.0 -> 1.22.1 ``                                                                     |
| [`dffe614d`](https://github.com/NixOS/nixpkgs/commit/dffe614d45adc71a788915c4944734995abd6e64) | `` vscode-extensions.github.vscode-pull-request-github: 0.114.2 -> 0.114.3 ``                       |
| [`0df4905d`](https://github.com/NixOS/nixpkgs/commit/0df4905d50197a97c699d318b8afd86aae44fde1) | `` warp-terminal: 0.2025.07.09.08.11.stable_01 -> 0.2025.07.23.08.12.stable_02 ``                   |
| [`52c4dd0a`](https://github.com/NixOS/nixpkgs/commit/52c4dd0a4a4f001dba91c2aa9672ef6355889fc2) | `` xdg-desktop-portal-hyprland: 1.3.9 -> 1.3.10 ``                                                  |
| [`ea5608d8`](https://github.com/NixOS/nixpkgs/commit/ea5608d8251637569ceeae1645e1c7ce7eb9f19e) | `` usbguard: cleanup ``                                                                             |
| [`edec20fa`](https://github.com/NixOS/nixpkgs/commit/edec20fa2638533e645161a5b07c632f8c5c63d5) | `` usbguard: unpin protobuf_29 ``                                                                   |
| [`9303e05a`](https://github.com/NixOS/nixpkgs/commit/9303e05a44fb60a6ac06437fd909f44b220aee1b) | `` jikken: add version-regex to updateScript ``                                                     |
| [`0fedde96`](https://github.com/NixOS/nixpkgs/commit/0fedde966c921527cea476c36962d6dab8847908) | `` xwin: init at 0.6.6 ``                                                                           |
| [`a8707a2a`](https://github.com/NixOS/nixpkgs/commit/a8707a2a8b4309213970d00ab9e71d577841e828) | `` lux-cli: 0.9.1 -> 0.11.1 ``                                                                      |
| [`afb0e9ea`](https://github.com/NixOS/nixpkgs/commit/afb0e9ea0e970ff032b816ad27aadabe6e7c36d9) | `` files-cli: 2.15.51 -> 2.15.61 ``                                                                 |
| [`201da458`](https://github.com/NixOS/nixpkgs/commit/201da4580bfbac40931dc51b41727c7a00fe82a9) | `` diffoscope: 301 -> 302 ``                                                                        |
| [`29ea9737`](https://github.com/NixOS/nixpkgs/commit/29ea9737f601eafbe9998a5976c7d33832c7cf2b) | `` amazon-q-cli: 1.12.6 -> 1.12.7 ``                                                                |
| [`6a11d2fb`](https://github.com/NixOS/nixpkgs/commit/6a11d2fbc4348c83304a79a7bb2d8ec0ef7105c3) | `` tootik: 0.17.1 -> 0.18.0 ``                                                                      |
| [`15ad2670`](https://github.com/NixOS/nixpkgs/commit/15ad26705be8bcb7a8b1af6078e71a1de399b83b) | `` nixos/hardware.fw-fanctrl: add package option and refactor using lib.attrsets.recursiveUpdate `` |
| [`42d7d8f5`](https://github.com/NixOS/nixpkgs/commit/42d7d8f51b443f4fd18ea2f4b33168a44047b1cb) | `` mmctl: 10.5.8 -> 10.5.9 ``                                                                       |
| [`4ace4850`](https://github.com/NixOS/nixpkgs/commit/4ace4850b3bcd933c5717d48d748f1db55d431f8) | `` python313Packages.boto3-stubs: 1.39.11 -> 1.39.14 ``                                             |
| [`781572b2`](https://github.com/NixOS/nixpkgs/commit/781572b236e0de7ff96e0f41dbe60a5f81a50e2e) | `` python312Packages.mypy-boto3-sqs: 1.39.0 -> 1.39.14 ``                                           |
| [`c6de65ca`](https://github.com/NixOS/nixpkgs/commit/c6de65ca1f947866059c15a7e1a139a2f8f602ec) | `` python312Packages.mypy-boto3-omics: 1.39.0 -> 1.39.13 ``                                         |
| [`39097907`](https://github.com/NixOS/nixpkgs/commit/390979072be4e686268e01cedc3323f58708a82a) | `` python312Packages.mypy-boto3-mediapackagev2: 1.39.7 -> 1.39.14 ``                                |
| [`f1e3c237`](https://github.com/NixOS/nixpkgs/commit/f1e3c237136526c28e04082f66f0398844c0e761) | `` python312Packages.mypy-boto3-kms: 1.39.0 -> 1.39.14 ``                                           |
| [`0426824a`](https://github.com/NixOS/nixpkgs/commit/0426824ade486929889e9349a674505fecd3b6b4) | `` python312Packages.mypy-boto3-glue: 1.39.7 -> 1.39.12 ``                                          |
| [`5752f85a`](https://github.com/NixOS/nixpkgs/commit/5752f85aa4484fc9cacab7fabdb8fc3afb3b59b6) | `` python312Packages.mypy-boto3-ec2: 1.39.10 -> 1.39.14 ``                                          |
| [`1f000184`](https://github.com/NixOS/nixpkgs/commit/1f0001844c19766c7267c2a9da2eef4a44411d68) | `` python312Packages.mypy-boto3-config: 1.39.0 -> 1.39.14 ``                                        |
| [`949affc6`](https://github.com/NixOS/nixpkgs/commit/949affc63806f33145b950fdc365652168a8033c) | `` python312Packages.mypy-boto3-budgets: 1.39.0 -> 1.39.14 ``                                       |
| [`d86254d4`](https://github.com/NixOS/nixpkgs/commit/d86254d4683e628e74ecded8bcc18d3540d5327a) | `` python312Packages.mypy-boto3-appintegrations: 1.39.0 -> 1.39.14 ``                               |
| [`4ae348e2`](https://github.com/NixOS/nixpkgs/commit/4ae348e2d1bcead0263669bad85451fac22401ac) | `` tigerbeetle: 0.16.50 -> 0.16.51 ``                                                               |
| [`daa91693`](https://github.com/NixOS/nixpkgs/commit/daa91693b974ba3d24bdc35c5d1ddd56e540e51f) | `` python313Packages.publicsuffixlist: 1.0.2.20250719 -> 1.0.2.20250724 ``                          |
| [`80b0f466`](https://github.com/NixOS/nixpkgs/commit/80b0f466651634ee94292d7d5d8f7431f272bffb) | `` vscode-extensions.illixion.vscode-vibrancy-continued: 1.1.58 -> 1.1.59 ``                        |
| [`c2ac8b81`](https://github.com/NixOS/nixpkgs/commit/c2ac8b81112cc25d5b8cdcad84bde917f3153844) | `` stac-validator: 3.10.0 -> 3.10.1 ``                                                              |
| [`3a2fb07b`](https://github.com/NixOS/nixpkgs/commit/3a2fb07b0feae291679be336da4d6bb2ae06ba26) | `` chirp: 0.4.0-unstable-2025-07-17 -> 0.4.0-unstable-2025-07-25 ``                                 |
| [`9baa67c2`](https://github.com/NixOS/nixpkgs/commit/9baa67c2e2e48c87b3e71c950ad76d4388c5791a) | `` cfonts: 1.2.0 -> 1.3.0 ``                                                                        |
| [`57a143d2`](https://github.com/NixOS/nixpkgs/commit/57a143d29e8ab8043c0116c632e5a1f36f0dd5ff) | `` rustical: 0.6.0 -> 0.8.1 ``                                                                      |
| [`d7f8de90`](https://github.com/NixOS/nixpkgs/commit/d7f8de903939e0ffe2a969781db35863f6e42844) | `` git-cliff: 2.9.1 -> 2.10.0 ``                                                                    |
| [`5469534f`](https://github.com/NixOS/nixpkgs/commit/5469534f54dbf179256bda7061e8ceb05b26f2e2) | `` terraform-providers.digitalocean: 2.60.0 -> 2.61.0 ``                                            |
| [`a5bf5da8`](https://github.com/NixOS/nixpkgs/commit/a5bf5da8971c5714265bda5f92b55144027d34b8) | `` far2l: 2.6.3 -> 2.6.5, fix improper wrapping (#419004) ``                                        |
| [`b5ccf171`](https://github.com/NixOS/nixpkgs/commit/b5ccf171ae55c250f51ab063ca971806c5e493ec) | `` affine: 0.22.4 -> 0.23.2 ``                                                                      |
| [`18ca15c5`](https://github.com/NixOS/nixpkgs/commit/18ca15c57f778120c79be521b62bb6e0bd5bd0b1) | `` gnu-efi: 4.0.0 -> 4.0.2 ``                                                                       |
| [`274b8936`](https://github.com/NixOS/nixpkgs/commit/274b8936a78fd48958ec811071f743ae73e3778a) | `` steampipePackages.steampipe-plugin-github: 1.4.0 -> 1.5.0 ``                                     |
| [`2272a4cd`](https://github.com/NixOS/nixpkgs/commit/2272a4cda69b612f8b0a54e61b646012e9c38b62) | `` pretix: relax css-inline constraint ``                                                           |
| [`3c0ff7e4`](https://github.com/NixOS/nixpkgs/commit/3c0ff7e40f58f7d9766dcbfb41ff60b7e7857d6f) | `` treewide: add preConfigure and postConfigure for ``                                              |
| [`18941d32`](https://github.com/NixOS/nixpkgs/commit/18941d32957fb5ba48f80fa7ffb55b4dccd1c6d5) | `` python3Packages.css-inline: 0.15.0 -> 0.17.0 ``                                                  |
| [`8bdeb8c5`](https://github.com/NixOS/nixpkgs/commit/8bdeb8c5bcf441ce57d357aa7910c3bd832b2bd6) | `` auto-cpufreq: set pyproject and refactor ``                                                      |
| [`34eeec0f`](https://github.com/NixOS/nixpkgs/commit/34eeec0f374d0472595329a7c794d1ec411ade67) | `` just: 1.42.3 -> 1.42.4 ``                                                                        |
| [`14d6af58`](https://github.com/NixOS/nixpkgs/commit/14d6af58416b9f72d3ecda1aa010a919c150d4d4) | `` aritim-dark: fix typo in name ``                                                                 |
| [`961254af`](https://github.com/NixOS/nixpkgs/commit/961254af0386e4d13c7ea11a5166fd558b6e666a) | `` forgejo-runner: 7.0.0 -> 8.0.0 ``                                                                |
| [`dedf852c`](https://github.com/NixOS/nixpkgs/commit/dedf852ccd920c9ea2f8efc879d2fb504c19a325) | `` nixos/systemd-boot: refactor json.load() logic for better error message ``                       |
| [`e8fb58a7`](https://github.com/NixOS/nixpkgs/commit/e8fb58a774884370811f85a8d6b166c20da5f132) | `` rustfinity: 0.2.13 -> 0.2.14 ``                                                                  |
| [`8adae681`](https://github.com/NixOS/nixpkgs/commit/8adae681212c7d2e473493544468a9b0374f20ed) | `` vouch-proxy: 0.41.0 -> 0.45.1 ``                                                                 |
| [`9490dc0a`](https://github.com/NixOS/nixpkgs/commit/9490dc0ac1cb0c2a328f7589b8474fc6b1c88a36) | `` systemd-manager-tui: init at 1.1.0 ``                                                            |
| [`fa9dec15`](https://github.com/NixOS/nixpkgs/commit/fa9dec157bd27c810c31c311c89f35e024fc9833) | `` python3Packages.langchain-deepseek: 0.1.3 -> 0.1.4 ``                                            |
| [`b3d4d701`](https://github.com/NixOS/nixpkgs/commit/b3d4d7017021c4c52122d627a4257214405b1f83) | `` kopia-ui: 0.21.0 -> 0.21.1 ``                                                                    |
| [`0833dfa4`](https://github.com/NixOS/nixpkgs/commit/0833dfa4cab446e29b29284ee5630efa6c118567) | `` python3Packages.discord-webhook: init at 1.4.1 ``                                                |
| [`cc298902`](https://github.com/NixOS/nixpkgs/commit/cc29890289151099720eb769ae536d6f8fb7900f) | `` signal-export: 3.6.0 -> 3.7.0 ``                                                                 |
| [`4698a46f`](https://github.com/NixOS/nixpkgs/commit/4698a46f56d57bae0aba4f9b40c6e4e1570bc566) | `` ocamlPackages.ca-certs-nss: 3.113.1 -> 3.114 ``                                                  |