### PR TITLE
chore(flake/nix-fast-build): `7f4fa3e6` -> `690b9c4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1754265999,
-        "narHash": "sha256-pqbAs68kREJU34/rhdmd1BH4ApOKg+aIMo6M+1/YtcY=",
+        "lastModified": 1754421903,
+        "narHash": "sha256-l5wfRpuHuz9hGfkaVYCsGQJrreTlHU/bdYJxhvi+AD8=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "7f4fa3e62282ec16066c6da65685113fe70416e0",
+        "rev": "690b9c4f56abc842b5e930e6eb54810c6c49f93f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`845e13f7`](https://github.com/Mic92/nix-fast-build/commit/845e13f7fb9b73150ffd34e43c0d939e25eafdbd) | `` chore(deps): update flake-parts digest to 7f38f25 `` |
| [`f9a6ec46`](https://github.com/Mic92/nix-fast-build/commit/f9a6ec462f06c61a0b1e6fbe6ffb57ca29f7f631) | `` chore(deps): update flake-parts digest to 67df8c6 `` |