### PR TITLE
chore(flake/nix-fast-build): `4d204b0e` -> `ca71de01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -155,11 +155,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1754933997,
-        "narHash": "sha256-TsBGGFo3ruhu1EbSuG0ZQR+KFtVg+lgQPQZEZV+zgpE=",
+        "lastModified": 1755111453,
+        "narHash": "sha256-TuBYORqiTbgUpUfVkcSQB2664SKDU5Fxfqb7uGpWY34=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "4d204b0e917587eb39dcdc48077e15bba88d9b80",
+        "rev": "ca71de01f4fa3a79409c2d02dddb495494de1d11",
         "type": "github"
       },
       "original": {
@@ -313,11 +313,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754492133,
-        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
+        "lastModified": 1754847726,
+        "narHash": "sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl+V/PsmIiJREG4rE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
+        "rev": "7d81f6fb2e19bf84f1c65135d1060d829fae2408",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`56aa9aed`](https://github.com/Mic92/nix-fast-build/commit/56aa9aed59c207821dbb751a2aea0a1119012680) | `` Update flake input: treefmt-nix ``                |
| [`869355fe`](https://github.com/Mic92/nix-fast-build/commit/869355fe640213b90f1bdcdeef782fe1e458fc8c) | `` Update flake input: nixpkgs ``                    |
| [`ce5f48f3`](https://github.com/Mic92/nix-fast-build/commit/ce5f48f323b80bb1d864f54640ffdbcf9e7a5661) | `` add update-flake-inputs github action ``          |
| [`95979522`](https://github.com/Mic92/nix-fast-build/commit/9597952254ec1f5abed0ee8d553f5de70c33c36f) | `` feat: add `--override-input` ``                   |
| [`735ac59e`](https://github.com/Mic92/nix-fast-build/commit/735ac59e8b3388f4206cca7b044d7676ff2f72d0) | `` fix --flake help text ``                          |
| [`0726fcd3`](https://github.com/Mic92/nix-fast-build/commit/0726fcd3ab9c416cd8052c5ab017e374e79ea7be) | `` Flush stdout after printing a progress message `` |