### PR TITLE
chore(flake/nixvim): `e1e4bb83` -> `1bd91097`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1755541228,
-        "narHash": "sha256-3PsCEAfZLk3shQNgEH67P6KvhV6bXziewl3HwJ/iaV4=",
+        "lastModified": 1755717891,
+        "narHash": "sha256-MbuYOji6oxqk2nawrfjnKkAoXnVqrXAp1vQPdjtb/Q4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e1e4bb83f1b1193c99971dfde6928e1f60ed4296",
+        "rev": "1bd91097c381aafec012babcfcd1d90821a0782e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`1bd91097`](https://github.com/nix-community/nixvim/commit/1bd91097c381aafec012babcfcd1d90821a0782e) | `` tests/lspsaga: update test ``                                  |
| [`1c999d4c`](https://github.com/nix-community/nixvim/commit/1c999d4c1539198bb3b1baeab0e4fc27b2526059) | `` plugins/lspsaga: migrate to mkNeovimPlugin ``                  |
| [`94386cdc`](https://github.com/nix-community/nixvim/commit/94386cdc4cdb42e90685274066805685d53afa37) | `` plugins/cmp: fix "nixivm" typo in docs ``                      |
| [`cfdbf726`](https://github.com/nix-community/nixvim/commit/cfdbf72664b3e3f91c0e8d4c247df7e37f53a679) | `` ci: added treefmt workflow to gha and removed from buildbot `` |