### PR TITLE
chore(flake/nixvim): `1bd91097` -> `d96069b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,16 +130,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1748294338,
-        "narHash": "sha256-FVO01jdmUNArzBS7NmaktLdGA5qA3lUMJ4B7a05Iynw=",
+        "lastModified": 1754860581,
+        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "cc5f390f7caf265461d4aab37e98d2292ebbdb85",
+        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.0.8",
+        "ref": "v0.1.1",
         "repo": "ixx",
         "type": "github"
       }
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1755717891,
-        "narHash": "sha256-MbuYOji6oxqk2nawrfjnKkAoXnVqrXAp1vQPdjtb/Q4=",
+        "lastModified": 1755814403,
+        "narHash": "sha256-2iULLpTIzhRF+7ppTlfAfTGqFJknKOPjjUHlm2lqFMs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1bd91097c381aafec012babcfcd1d90821a0782e",
+        "rev": "d96069b1e14c7d9b756cc7c1dcf59f04ef35756b",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754301638,
-        "narHash": "sha256-aRgzcPDd2axHFOuMlPLuzmDptUM2JU8mUL3jfgbBeyc=",
+        "lastModified": 1755555503,
+        "narHash": "sha256-WiOO7GUOsJ4/DoMy2IC5InnqRDSo2U11la48vCCIjjY=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "a60091045273484c040a91f5c229ba298f8ecc27",
+        "rev": "6f3efef888b92e6520f10eae15b86ff537e1d2ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`d96069b1`](https://github.com/nix-community/nixvim/commit/d96069b1e14c7d9b756cc7c1dcf59f04ef35756b) | `` flake/dev/flake.lock: Update ``                          |
| [`2fe2e74c`](https://github.com/nix-community/nixvim/commit/2fe2e74cc90ec72d244c66b9fc71be233aa0e9db) | `` flake.lock: Update ``                                    |
| [`037b1d31`](https://github.com/nix-community/nixvim/commit/037b1d31348ea34ad35c9fbfa26e36c8e110288f) | `` user-configs: remove HeitorAugustoLN's configuration ``  |
| [`91a38e66`](https://github.com/nix-community/nixvim/commit/91a38e66240c338e683421a4ee3f525d329fc4ad) | `` tests/plugins/dap-view: add example test case ``         |
| [`3427b615`](https://github.com/nix-community/nixvim/commit/3427b61539dc424dbe28ed512dd86ddfa34bf15e) | `` tests/plugins/dap-view: update defaults ``               |
| [`d597c9cb`](https://github.com/nix-community/nixvim/commit/d597c9cbcaab2b9cd308b97e55534d41451568ad) | `` plugins/none-ls: add package mapping for meson_format `` |
| [`581e5cc1`](https://github.com/nix-community/nixvim/commit/581e5cc128cd1a5b65f62e4262ff40410d529649) | `` plugins/none-ls: add package mapping for kube_linter ``  |
| [`6cb956f1`](https://github.com/nix-community/nixvim/commit/6cb956f10b0b732ddbc2dcf6160b849394266464) | `` tests/plugins/crates: remove deprecated settings ``      |
| [`ea59072e`](https://github.com/nix-community/nixvim/commit/ea59072ef86b4b93e9fdff81e76b38b729dd3c83) | `` generated: Update ``                                     |
| [`ea664338`](https://github.com/nix-community/nixvim/commit/ea664338d07690a877de51ad62063be902eb5322) | `` flake/dev/flake.lock: Update ``                          |
| [`d32230ac`](https://github.com/nix-community/nixvim/commit/d32230ac2b972478ea23e5c8ed61828cce80ee9c) | `` flake.lock: Update ``                                    |