### PR TITLE
chore(flake/nixvim): `18a1b512` -> `91f51aed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1755900473,
-        "narHash": "sha256-UxpKQvD3dTT4/ueJBDccmHeHfnuUD+864Mzu8GPJZig=",
+        "lastModified": 1755924483,
+        "narHash": "sha256-wNqpEXZuAwPjW8hYKIYzmN+fgEZT/Qx+sUIWXg3EIWU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "18a1b5126f917fbcd65397b9ee429387fdbd51a6",
+        "rev": "91f51aede7c9c769c19f74ba9042b8fdb4ed2989",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`91f51aed`](https://github.com/nix-community/nixvim/commit/91f51aede7c9c769c19f74ba9042b8fdb4ed2989) | `` plugins/contextfiles: init ``                       |
| [`e03ede71`](https://github.com/nix-community/nixvim/commit/e03ede713896777f35a9ce4a981a2413eb6dde37) | `` plugins/lsp: fix volar tsls integration location `` |
| [`4a7aac69`](https://github.com/nix-community/nixvim/commit/4a7aac699b9b98c1450eb4fd1bebe91c5d3f2e47) | `` plugins/neotest-ctest: add neotest-ctest adapter `` |