### PR TITLE
chore(flake/nixvim): `91f51aed` -> `dae0629a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1755924483,
-        "narHash": "sha256-wNqpEXZuAwPjW8hYKIYzmN+fgEZT/Qx+sUIWXg3EIWU=",
+        "lastModified": 1756078164,
+        "narHash": "sha256-juX4p56mWrcq8UVfppUC7hl1nsc5JW8GeurkW+bDpX8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "91f51aede7c9c769c19f74ba9042b8fdb4ed2989",
+        "rev": "dae0629af952d108cda37e8f9140f572d63f5e5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`dae0629a`](https://github.com/nix-community/nixvim/commit/dae0629af952d108cda37e8f9140f572d63f5e5b) | `` flake/dev/flake.lock: Update `` |
| [`7b8fdbcd`](https://github.com/nix-community/nixvim/commit/7b8fdbcd7db1ba48acdb4eca315bcf2f0d68273c) | `` flake.lock: Update ``           |