### PR TITLE
chore(flake/nixvim): `dae0629a` -> `8e3ca3fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1756078164,
-        "narHash": "sha256-juX4p56mWrcq8UVfppUC7hl1nsc5JW8GeurkW+bDpX8=",
+        "lastModified": 1756148061,
+        "narHash": "sha256-9QlWBvwDlizUa7YwlBnrmdXvh5pjaVGLG7u1N68VX5k=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "dae0629af952d108cda37e8f9140f572d63f5e5b",
+        "rev": "8e3ca3fc1f3ae23dee0e6d35dd4a70ea8ef7164c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`8e3ca3fc`](https://github.com/nix-community/nixvim/commit/8e3ca3fc1f3ae23dee0e6d35dd4a70ea8ef7164c) | `` plugins/blink-cmp-latex: init ``    |
| [`9f036a41`](https://github.com/nix-community/nixvim/commit/9f036a41d3cd2be5ebc5cd24786299ee974f66e2) | `` plugins/comfy-line-numbers: init `` |