### PR TITLE
chore(flake/nixpkgs): `20075955` -> `3b9f00d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1756125398,
+        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`68c2b33e`](https://github.com/NixOS/nixpkgs/commit/68c2b33eadd4971f59231b83a3858cd30094bf76) | `` nixos/tests: better handling of SDDM xauth files ``                                        |
| [`baa3367e`](https://github.com/NixOS/nixpkgs/commit/baa3367ea6e7f220e8fdda07445878d9a33525cd) | `` cvc4: fix build on darwin ``                                                               |
| [`0491e7e3`](https://github.com/NixOS/nixpkgs/commit/0491e7e3eb4d756a5865cfe8d0a9fb8695037e8a) | `` glab: 1.62.0 -> 1.65.0 ``                                                                  |
| [`c345de07`](https://github.com/NixOS/nixpkgs/commit/c345de079f121663798e5ffed6f8e415a33cf350) | `` nixos/tests/retroarch: modernize ``                                                        |
| [`35a5dfbf`](https://github.com/NixOS/nixpkgs/commit/35a5dfbfa3c3a5efb0547e8d4c96819ca65e75ca) | `` nixos/tests: fix tests that use SDDM ``                                                    |
| [`f9a31f46`](https://github.com/NixOS/nixpkgs/commit/f9a31f4687b18c8327d1c251f9270d1a520a487a) | `` keep-sorted: 0.7.0 -> 0.7.1 ``                                                             |
| [`636d8f84`](https://github.com/NixOS/nixpkgs/commit/636d8f84870a72791b550396f4679807a46bad11) | `` fractal: add missing `libwebp` runtime dependency (#436623) ``                             |
| [`cc1251b6`](https://github.com/NixOS/nixpkgs/commit/cc1251b631e8041547e6b63115bbb14c008626fa) | `` nixos/iwd: fix DriverQuirks.DefaultInterface config option ``                              |
| [`1651cb11`](https://github.com/NixOS/nixpkgs/commit/1651cb11aa10a92a3a9106753045d4d588e6741b) | `` grafanactl: 0.1.1 -> 0.1.3 ``                                                              |
| [`723fc4c9`](https://github.com/NixOS/nixpkgs/commit/723fc4c94b802dd25de308f467a5435966d7b4d2) | `` postgresqlPackages.omnigres: 0-unstable-2025-08-15 -> 0-unstable-2025-08-24 ``             |
| [`8fc8c3e1`](https://github.com/NixOS/nixpkgs/commit/8fc8c3e12efaf15912089254c81d7478c142aa44) | `` nixos/qemu-vm: Default configuration for empty disk image qemu devices. ``                 |
| [`da82f162`](https://github.com/NixOS/nixpkgs/commit/da82f162fe39484b166a78e5e13ddfd49f341eb4) | `` claude-code: 1.0.89 -> 1.0.90 ``                                                           |
| [`8ffe6061`](https://github.com/NixOS/nixpkgs/commit/8ffe606188d68603fd6ac6d4a341c640832e99f5) | `` codex: 0.22.0 -> 0.23.0 ``                                                                 |
| [`6052b3ba`](https://github.com/NixOS/nixpkgs/commit/6052b3ba6d4f14b0a9c459c7186871ea9c369ffb) | `` python3Packages.albucore: set skipBulkUpdate so albumentations doesn't break ``            |
| [`0331ac1a`](https://github.com/NixOS/nixpkgs/commit/0331ac1a11ebc689b4328a482d97b757243d9f1a) | `` Revert "python3Packages.albucore: 0.0.24 -> 0.0.33" ``                                     |
| [`1127296f`](https://github.com/NixOS/nixpkgs/commit/1127296f57fdc251506c84137eef0e7c2a83cb55) | `` oo7: 0.4.3 -> 0.5.0 ``                                                                     |
| [`d4c8961f`](https://github.com/NixOS/nixpkgs/commit/d4c8961f72ec70a67e285b0dbccc3567cd52d61b) | `` python3Packages.pyssim: drop obsolete patch ``                                             |
| [`4e20c95a`](https://github.com/NixOS/nixpkgs/commit/4e20c95a7709a2e6cb6b65709e140e63dba9ebac) | `` libretro.play: 0-unstable-2025-08-04 -> 0-unstable-2025-08-20 ``                           |
| [`3fdaa0ba`](https://github.com/NixOS/nixpkgs/commit/3fdaa0ba4a7c5898d7151482fe2b7c5958a8bf5c) | `` firefly-iii: 6.2.21 -> 6.3.2 ``                                                            |
| [`945a6fc3`](https://github.com/NixOS/nixpkgs/commit/945a6fc37f4e26a4d8201b18e8c737be8de80f89) | `` jscoverage: drop ``                                                                        |
| [`12b4a6f3`](https://github.com/NixOS/nixpkgs/commit/12b4a6f3cae57f3639fdc03c3200437f4d0b746c) | `` evil-helix: 20250601 -> 20250823 ``                                                        |
| [`bd953fc1`](https://github.com/NixOS/nixpkgs/commit/bd953fc1a80da0e86a40f89a4d0bfdc99270dd3e) | `` python3Packages.vcver: drop ``                                                             |
| [`15fad33a`](https://github.com/NixOS/nixpkgs/commit/15fad33a2715884a3082ab277949b191571eeaa3) | `` mat2: use python312 ``                                                                     |
| [`f41518ce`](https://github.com/NixOS/nixpkgs/commit/f41518ce88b7e62e00e361ac07f07cb05f75f65c) | `` python3Packages.outlines: 1.2.1 -> 1.2.3 ``                                                |
| [`76612602`](https://github.com/NixOS/nixpkgs/commit/766126029de4041c119d1c04fcd1f5cc362cbc4b) | `` python3Packages.outlines-core: 0.1.26 -> 0.2.11 ``                                         |
| [`8ff9a363`](https://github.com/NixOS/nixpkgs/commit/8ff9a3635c4d848d9946de07e1521b1e5cfe8d1e) | `` python3Packages.xgrammar: mark as broken on aarch64-linux ``                               |
| [`4b08c4e4`](https://github.com/NixOS/nixpkgs/commit/4b08c4e4e25ccdc694fcbaae9e3c570e958b3563) | `` python3Packages.xgrammar: mark as broken on darwin ``                                      |
| [`7e861fb7`](https://github.com/NixOS/nixpkgs/commit/7e861fb7f29383385481a1806bb9179bb552f8ce) | `` upbound: 0.40.1 -> 0.40.3 ``                                                               |
| [`8d3634ee`](https://github.com/NixOS/nixpkgs/commit/8d3634eece8972dc51372ca70043fed68dae0157) | `` python3Packages.xgrammar: 0.1.22 -> 0.1.23 ``                                              |
| [`ea2c47f9`](https://github.com/NixOS/nixpkgs/commit/ea2c47f9faf65e08f6b50439b7fc3be2a4ee7b6c) | `` xenia-canary: 0-unstable-2025-08-15 -> 0-unstable-2025-08-22 ``                            |
| [`c7348c8e`](https://github.com/NixOS/nixpkgs/commit/c7348c8e35dedb8ab74229e88fbcf130cca46eba) | `` artichoke: 0-unstable-2025-08-03 -> 0-unstable-2025-08-18 ``                               |
| [`8a394a88`](https://github.com/NixOS/nixpkgs/commit/8a394a88fdecda0f3647da6c5fcef7fd888401d5) | `` gat: 0.25.0 -> 0.25.1 ``                                                                   |
| [`798b5a2f`](https://github.com/NixOS/nixpkgs/commit/798b5a2f801318c4be156f5be12eaa407b479acc) | `` ghstack: 0.9.4 -> 0.11.0 ``                                                                |
| [`c45e1c3a`](https://github.com/NixOS/nixpkgs/commit/c45e1c3ad0540a98512c748dedf0eb01921ff273) | `` python3Packages.scikit-base: 0.12.4 -> 0.12.5 ``                                           |
| [`e82d0ac2`](https://github.com/NixOS/nixpkgs/commit/e82d0ac21dd78d745f471c88f90d05a3809bcd58) | `` fosrl-pangolin: 1.8.0 -> 1.9.0 ``                                                          |
| [`ec44a39a`](https://github.com/NixOS/nixpkgs/commit/ec44a39a389cb2cb4f515060c307abdf29b9c4b0) | `` nixos/qemu-vm: Allow configuration of empty disk image qemu devices. ``                    |
| [`328b6d87`](https://github.com/NixOS/nixpkgs/commit/328b6d874bd3c7fb4b9a327e73b1af072a41de44) | `` nixos/tests/swap-file-btrfs: Use autoFormat ``                                             |
| [`bb51c2d8`](https://github.com/NixOS/nixpkgs/commit/bb51c2d8fe4ba70d5400932f625c1e828708a60c) | `` nixos/tests/snapper: Use autoFormat ``                                                     |
| [`e2e7ac25`](https://github.com/NixOS/nixpkgs/commit/e2e7ac25049773709e07f04003af7fdf8532f936) | `` nixos/tests/saunafs: Use autoFormat ``                                                     |
| [`e31cb258`](https://github.com/NixOS/nixpkgs/commit/e31cb2587707ac6dfeebc048083e11903541c2c5) | `` nixos/tests/orangefs: Use autoFormat ``                                                    |
| [`b9057606`](https://github.com/NixOS/nixpkgs/commit/b9057606a5334caca626dc22277e2b85df25c04b) | `` nixos/tests/moosefs: Use autoFormat ``                                                     |
| [`dc4a8f96`](https://github.com/NixOS/nixpkgs/commit/dc4a8f961ae3c9de85284d8d9a6850280d64f998) | `` nixos/tests/hardened: Use autoFormat ``                                                    |
| [`d22eef5c`](https://github.com/NixOS/nixpkgs/commit/d22eef5cfa0cd941529ce3ad4d9b5d91ea791043) | `` nixos/tests/glusterfs: Use autoFormat ``                                                   |
| [`35bbf241`](https://github.com/NixOS/nixpkgs/commit/35bbf24122dd03522dc281fef72309f206429c48) | `` nixos/tests/bees: Use autoFormat ``                                                        |
| [`078b5bba`](https://github.com/NixOS/nixpkgs/commit/078b5bba8345d56692d19a03a9f993933ee2a991) | `` lldap: lldap 0.6.1 -> 0.6.2 ``                                                             |
| [`42b6d626`](https://github.com/NixOS/nixpkgs/commit/42b6d626997c4ebe420da7ccd70352cc08681238) | `` lldap: add options to set important secrets ``                                             |
| [`e4688fcb`](https://github.com/NixOS/nixpkgs/commit/e4688fcbde0e3bbe50ab8ea5e04f5bf6c405058a) | `` tombi: 0.5.6 -> 0.5.18 ``                                                                  |
| [`8416afc1`](https://github.com/NixOS/nixpkgs/commit/8416afc141769df88bc3de92a875e333c4cdd030) | `` snx-rs: 4.5.0 -> 4.6.0 ``                                                                  |
| [`956d0a74`](https://github.com/NixOS/nixpkgs/commit/956d0a744d2fa17a392bb04b2a25d10aef642813) | `` workflows/check: allow owners to fail when ci/OWNERS is untouched ``                       |
| [`5ff32763`](https://github.com/NixOS/nixpkgs/commit/5ff32763b23369e3e1c06d3728e71a7bace4e0e3) | `` workflows/{merge-group,pr}: avoid posting "no PR failures" for pull_request trigger ``     |
| [`2c25cb08`](https://github.com/NixOS/nixpkgs/commit/2c25cb0891d23f052baac7db22004ec39e683921) | `` workflows/{merge-group,pr}: post "no PR failures" status manually ``                       |
| [`36b45289`](https://github.com/NixOS/nixpkgs/commit/36b4528952059d7df1a1ee1663cd8ce3b1e820f2) | `` linuxPackages.xone: 0.4.1 -> 0.4.3 ``                                                      |
| [`4c5513d3`](https://github.com/NixOS/nixpkgs/commit/4c5513d312bf139a3b51d06c81c0888b823feee7) | `` mopidy: remove upstreamed patch ``                                                         |
| [`9f15e04f`](https://github.com/NixOS/nixpkgs/commit/9f15e04f1884c9c560055a2e0266aaed0cae1d29) | `` maintainers: drop ertes ``                                                                 |
| [`ca683c6e`](https://github.com/NixOS/nixpkgs/commit/ca683c6eebd4475998a2cbe048fce0a15fe635f6) | `` pshash: 0.1.15.0 -> 0.1.15.1 (#436327) ``                                                  |
| [`40ab1553`](https://github.com/NixOS/nixpkgs/commit/40ab1553c4fac2dafb3ab18b4710670282cbaade) | `` gst_all_1.gst-plugins-rs: disable tests ``                                                 |
| [`89526e11`](https://github.com/NixOS/nixpkgs/commit/89526e117150b80fc5b57129be8ed363a7350a6c) | `` nixos/logind: migrate to settings option ``                                                |
| [`87d9b08f`](https://github.com/NixOS/nixpkgs/commit/87d9b08ffbb7d91109c159900809097d7e401524) | `` ci/github-script/prepare: identify real base branch ``                                     |
| [`0601cf6f`](https://github.com/NixOS/nixpkgs/commit/0601cf6fd0868b31429d3e1c90781fbba8b2b0c2) | `` ci/github-script/prepare: avoid running CI when targeting channel branches ``              |
| [`15f1903f`](https://github.com/NixOS/nixpkgs/commit/15f1903fc773094b070701637632eff32ba3d133) | `` weblate: 5.12.2 -> 5.13 ``                                                                 |
| [`79701ac7`](https://github.com/NixOS/nixpkgs/commit/79701ac7e98aef7ff676267d1276f81abaf41d83) | `` python3Packages.weblate-schemas: 2025.2 -> 2025.5 ``                                       |
| [`759dcc69`](https://github.com/NixOS/nixpkgs/commit/759dcc6981cd4aa222d36069f78fe7064d563305) | `` python3Packages.jq: 1.8.0 -> 1.10.0 (#436059) ``                                           |
| [`47562bbe`](https://github.com/NixOS/nixpkgs/commit/47562bbe456884e79603a5ff7e38e2d9f5d9874e) | `` hashcat: 7.1.1 -> 7.1.2 ``                                                                 |
| [`98a41b36`](https://github.com/NixOS/nixpkgs/commit/98a41b36697896a9d67dc9e72d01aba8b0747877) | `` angelscript: 2.37.0 -> 2.38.0 ``                                                           |
| [`b6c6fab8`](https://github.com/NixOS/nixpkgs/commit/b6c6fab8ceea024d8331cc44e4956c9ba210681b) | `` swagger-typescript-api: 13.2.7 -> 13.2.8 ``                                                |
| [`c8954842`](https://github.com/NixOS/nixpkgs/commit/c895484283cae1c2faa5904dfa9d354f26512d43) | `` _86Box-with-roms: 4.2.1 -> 5.0 ``                                                          |
| [`16b49dfc`](https://github.com/NixOS/nixpkgs/commit/16b49dfcf0a6737dde6dba74906bb7661c279d26) | `` radicale: 3.5.4 -> 3.5.5 ``                                                                |
| [`2af0f196`](https://github.com/NixOS/nixpkgs/commit/2af0f196e49270ef65b773284cce2af6b049b390) | `` home-assistant-custom-lovelace-modules.advanced-camera-card: 7.14.3 -> 7.15.0 (#436341) `` |
| [`56426e1a`](https://github.com/NixOS/nixpkgs/commit/56426e1a0c1a8eb246aca9a89fd173a47ba248b0) | `` lnd: 0.19.2-beta -> 0.19.3-beta ``                                                         |
| [`240d6b4d`](https://github.com/NixOS/nixpkgs/commit/240d6b4d6685d8ab8f115a30fea9859bd6f5d6c7) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.6.8 -> 4.6.11 ``           |
| [`51ea4a3d`](https://github.com/NixOS/nixpkgs/commit/51ea4a3d0eaabb3ebeab8c0c47a9164f4f5e0cab) | `` euphonica: 0.96.1-beta -> 0.96.3-beta ``                                                   |
| [`ad662d85`](https://github.com/NixOS/nixpkgs/commit/ad662d85a7a446089add7404131865c93afe5e36) | `` euphonica: build release profile ``                                                        |
| [`6d516d5d`](https://github.com/NixOS/nixpkgs/commit/6d516d5d9bfc03559c9c445a6f5b9e1d277aebbe) | `` euphonica: add updateScript ``                                                             |
| [`e83a6c64`](https://github.com/NixOS/nixpkgs/commit/e83a6c6443ae91f108292a9a306a4e76d16baf4d) | `` ipv6calc: 4.3.2 -> 4.3.3 ``                                                                |
| [`91202448`](https://github.com/NixOS/nixpkgs/commit/91202448f8d8361e1c7c862ab74b82e6e0f523af) | `` kodiPackages.netflix: 1.23.4 -> 1.23.5 ``                                                  |
| [`f7ea7cb0`](https://github.com/NixOS/nixpkgs/commit/f7ea7cb07ebff722a19c3c2fe21cc08ca0fea342) | `` minijinja: 2.11.0 -> 2.12.0 ``                                                             |
| [`0e35e768`](https://github.com/NixOS/nixpkgs/commit/0e35e768a2e997841e8a427e70422656793cb827) | `` jai: 0.2.012 -> 0.2.017 ``                                                                 |
| [`d8775897`](https://github.com/NixOS/nixpkgs/commit/d877589762b895661e73e8616f4d60be85fb6121) | `` video-compare: 20250420 -> 20250824 ``                                                     |
| [`62dda3ae`](https://github.com/NixOS/nixpkgs/commit/62dda3ae411f497e2982dc34406a73f63162dbae) | `` xpipe: 17.4 -> 18.0.1 ``                                                                   |
| [`c5914302`](https://github.com/NixOS/nixpkgs/commit/c5914302a0f349c722856b05033874ee769fcedd) | `` python3Packages.temporalio: 1.15.0 → 1.16.0 ``                                             |
| [`b8a35d1d`](https://github.com/NixOS/nixpkgs/commit/b8a35d1d1534f2cbbb3c757613c8599dbef0d9b3) | `` npins: remove explicit dependency on nix ``                                                |
| [`a0c53ddf`](https://github.com/NixOS/nixpkgs/commit/a0c53ddfb2e1104c3c81fa95b7bba0b3c121e61c) | `` rmfuse: unstable-2021-06-06 -> 0.2.3 ``                                                    |
| [`48f3c9e4`](https://github.com/NixOS/nixpkgs/commit/48f3c9e441d2080fde07537e2f6ded26ddba4baa) | `` vscode-extensions.tekumara.typos-vscode: 0.1.40 -> 0.1.41 ``                               |
| [`9aca6057`](https://github.com/NixOS/nixpkgs/commit/9aca6057ebbdc81a0c4e57b1264d23065a7a2386) | `` typos-lsp: 0.1.40 -> 0.1.41 ``                                                             |
| [`d8fae059`](https://github.com/NixOS/nixpkgs/commit/d8fae0591af082a1bc6366a4b63d643ad4c0ea97) | `` cent: 1.3.4 -> 2.0.0 ``                                                                    |