### PR TITLE
chore(flake/nixvim): `b7e96214` -> `8bad4d40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1756305488,
-        "narHash": "sha256-+6cgFdac+DN5PAZg3YtRXAEdk++r6msy7wfFMNMNsEY=",
+        "lastModified": 1756587208,
+        "narHash": "sha256-pATHF/7rZeEYxnkvLZgrLbCjG4xBJDJ4zkjUiu+hhiU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b7e96214e8e7244eceae73c606dcd243f6d180a3",
+        "rev": "8bad4d407dace583ebf6a41d32cab479788898fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`8bad4d40`](https://github.com/nix-community/nixvim/commit/8bad4d407dace583ebf6a41d32cab479788898fe) | `` plugins/tardis: add tardis-nvim `` |