### PR TITLE
chore(flake/nixpkgs): `dfb2f12e` -> `d7600c77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756386758,
-        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
+        "lastModified": 1756542300,
+        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
+        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`9dd0bee7`](https://github.com/NixOS/nixpkgs/commit/9dd0bee7269951ce70cc413f2b09817f33376eb0) | `` gamescope: 3.16.14.2 -> 3.16.15 ``                                         |
| [`de74f9ca`](https://github.com/NixOS/nixpkgs/commit/de74f9caf0854a9ee8c39774cf4521870fa1f44a) | `` Revert "stdenv: Add CPE fields to meta" ``                                 |
| [`50b5e742`](https://github.com/NixOS/nixpkgs/commit/50b5e742ef70c00b1424db25a212fa2286ec5256) | `` copier: 9.9.0 -> 9.10.1 ``                                                 |
| [`27fdf1c4`](https://github.com/NixOS/nixpkgs/commit/27fdf1c411495ca39ac2cb365c23b3009ee79371) | `` mieru: 3.19.0 -> 3.19.1 ``                                                 |
| [`ebdb272c`](https://github.com/NixOS/nixpkgs/commit/ebdb272cd4fa2220d0765a4f7c0ee91d7d1a91d6) | `` aliases: add trillium-next-* ``                                            |
| [`9dee9dfa`](https://github.com/NixOS/nixpkgs/commit/9dee9dfaa1b38c9e5792266f52a7fb3461d2c12a) | `` top-level/aliases: remove incorrect deprecation aliases ``                 |
| [`f7e6c0d5`](https://github.com/NixOS/nixpkgs/commit/f7e6c0d5d1f944bf553646cf61ac03b7e6f759a9) | `` boxflat: 1.34.2-1 -> 1.34.4 ``                                             |
| [`b3317164`](https://github.com/NixOS/nixpkgs/commit/b3317164c2bdac2bde9f591c8ec0cb3b79a6f4fd) | `` terraform-providers.google-beta: 6.48.0 -> 7.0.1 ``                        |
| [`db04d3c1`](https://github.com/NixOS/nixpkgs/commit/db04d3c1ff759c06d5b8e2a28e9587399c35b698) | `` terraform-providers.harbor: 3.10.23 -> 3.11.0 ``                           |
| [`abf12729`](https://github.com/NixOS/nixpkgs/commit/abf1272900d63a737428b605e14f0913ff1b9205) | `` terraform-providers.spotinst: 1.225.0 -> 1.225.1 ``                        |
| [`38d564ea`](https://github.com/NixOS/nixpkgs/commit/38d564eaf0b02c26fac6abdbdf05fa1582bfd20c) | `` terraform-providers.yandex: 0.150.0 -> 0.152.0 ``                          |
| [`ae8a7d32`](https://github.com/NixOS/nixpkgs/commit/ae8a7d325e5e5f826056297e7f0185ee822a47e0) | `` terraform-providers.mongodbatlas: 1.39.0 -> 1.40.0 ``                      |
| [`5a19a94d`](https://github.com/NixOS/nixpkgs/commit/5a19a94d523bb26129896c38e8aac0501fe5ddca) | `` terraform-providers.alicloud: 1.257.0 -> 1.258.0 ``                        |
| [`7348937b`](https://github.com/NixOS/nixpkgs/commit/7348937bb3b9f029f29092a10a8c2db01ffeae43) | `` terraform-providers.temporalcloud: 0.9.2 -> 1.0.0 ``                       |
| [`d3522a5d`](https://github.com/NixOS/nixpkgs/commit/d3522a5d5882e49e8d4f0fc67e6cd34c95384ec1) | `` terraform-providers.digitalocean: 2.65.0 -> 2.66.0 ``                      |
| [`b4db7711`](https://github.com/NixOS/nixpkgs/commit/b4db7711a7918f2f3366cbeb7a1d9cf8b419fda6) | `` terraform-providers.tencentcloud: 1.82.17 -> 1.82.18 ``                    |
| [`d5d19e82`](https://github.com/NixOS/nixpkgs/commit/d5d19e823177c1976a72d6fe11f9cc6bbc144015) | `` terraform-providers.google: 6.48.0 -> 6.49.2 ``                            |
| [`ea8a4d84`](https://github.com/NixOS/nixpkgs/commit/ea8a4d842d9db1c4d017d98064b9cb99ad613059) | `` terraform-providers.exoscale: 0.65.0 -> 0.65.1 ``                          |
| [`41b16482`](https://github.com/NixOS/nixpkgs/commit/41b164827ff5948b7a5e51fb1ebac0535accfb55) | `` yq-go: generate and install man page ``                                    |
| [`b474b7cb`](https://github.com/NixOS/nixpkgs/commit/b474b7cb3e2488705f8d82e96966bd7c42219a1c) | `` python3Packages.essentials: avoid with lib; ``                             |
| [`48564416`](https://github.com/NixOS/nixpkgs/commit/485644162524d2b6e0c93bc774ce1750d342a6d6) | `` python3Packages.essentials: fix build ``                                   |
| [`7285fc2f`](https://github.com/NixOS/nixpkgs/commit/7285fc2f9a59da8cb8b1ab49c4b3782c794980bc) | `` top-level/aliases: add filtering ``                                        |
| [`064cb56b`](https://github.com/NixOS/nixpkgs/commit/064cb56bd6a6c40867007914f82ef82cdb624b17) | `` proxify: 0.0.15 -> 0.0.16 ``                                               |
| [`faab5343`](https://github.com/NixOS/nixpkgs/commit/faab53431d3d3a7ab7e9bd35319edc98372bcc5b) | `` managarr: 0.5.1 -> 0.6.0 ``                                                |
| [`604f22e0`](https://github.com/NixOS/nixpkgs/commit/604f22e0304b679e96edd9f47cbbfc4d513a3751) | `` zed-editor: 0.201.6 -> 0.201.8 ``                                          |
| [`b2774b3b`](https://github.com/NixOS/nixpkgs/commit/b2774b3bd684209f0ef10a74b31ec3a745720c94) | `` dnscontrol: 4.23.0 -> 4.24.0 ``                                            |
| [`fff977b9`](https://github.com/NixOS/nixpkgs/commit/fff977b945d817c19ed41d1529eb5fe65e4be4dc) | `` python313Packages.reqif: fix runtime dependency, minor cleanup ``          |
| [`4afcb464`](https://github.com/NixOS/nixpkgs/commit/4afcb464ccddc5ae9ffccd17d10a8be77c538244) | `` gatekeeper: 3.20.0 -> 3.20.1 ``                                            |
| [`99bfc6e9`](https://github.com/NixOS/nixpkgs/commit/99bfc6e945094431e8bdb3689b1bf305b94af74d) | `` gemini-cli: drop node-tty doesn't build on darwin ``                       |
| [`2513b4f3`](https://github.com/NixOS/nixpkgs/commit/2513b4f3878c0701442a7eef54befcf3b455a903) | `` python3Packages.millheater: 012.2 -> 0.12.5 ``                             |
| [`d43a3b9a`](https://github.com/NixOS/nixpkgs/commit/d43a3b9a47c64d0d2dc2aff06077e99a76fcf5d5) | `` python313Packages.fints: fix build with sandbox ``                         |
| [`24212ab7`](https://github.com/NixOS/nixpkgs/commit/24212ab73ea725eae604cdec8f10bede24cb5ccd) | `` simplex-chat-desktop: 6.4.3.1 -> 6.4.4 ``                                  |
| [`e9e0a098`](https://github.com/NixOS/nixpkgs/commit/e9e0a0984f12a44238ed7e8f21ab6ac5107078fd) | `` nixos/plymouth: dedupe theme check ``                                      |
| [`9732672e`](https://github.com/NixOS/nixpkgs/commit/9732672e3e92e96f8f4a294023e5b3257d192fd8) | `` bilibili: 1.17.1-1 -> 1.17.1-2 ``                                          |
| [`d7a76925`](https://github.com/NixOS/nixpkgs/commit/d7a76925c1a909d3f7b0f1e2160d693f256cd5fd) | `` python3Packages.spdx-tools: fix tests ``                                   |
| [`a86781fa`](https://github.com/NixOS/nixpkgs/commit/a86781facc172c491fc7d16a6da7cb433cbf2aae) | `` python3Packages.plastexdepgraph: 0.0.4 -> 0.0.5 ``                         |
| [`b1dd43c0`](https://github.com/NixOS/nixpkgs/commit/b1dd43c020f5ff11a93c230ff8cd5229c26c9c3e) | `` python3Packages.django-scim2: unbreak ``                                   |
| [`66c18758`](https://github.com/NixOS/nixpkgs/commit/66c187580393c803979548ee328b5e9a24974044) | `` saldo: 0.6.0 -> 0.8.0 ``                                                   |
| [`17d0d352`](https://github.com/NixOS/nixpkgs/commit/17d0d352991095f70411c5d3633ade4f40dbebac) | `` saldo: rename from banking ``                                              |
| [`593320db`](https://github.com/NixOS/nixpkgs/commit/593320dbd154b081a2d22cc25432fb1d91a3aa1a) | `` zulip: 5.12.0 → 5.12.1 ``                                                  |
| [`c7c502a5`](https://github.com/NixOS/nixpkgs/commit/c7c502a5fc719dda78f07678aa49139dc4870b0f) | `` nixos/plymouth: list available themes if the current one does not exist `` |
| [`7dbd5083`](https://github.com/NixOS/nixpkgs/commit/7dbd50832a197f205dcdb2cecdfe2b8f9e84ab2d) | `` nixos/plymouth: fix theme == "breeze" breakage after removing Plasma 5 ``  |
| [`4ea249fc`](https://github.com/NixOS/nixpkgs/commit/4ea249fcc309a209092e9ed34cb46c458a75ff19) | `` python3Packages.duckduckgo-search: 9.5.1 -> 9.5.4 ``                       |
| [`b65fdfb3`](https://github.com/NixOS/nixpkgs/commit/b65fdfb36adae111c323c5844b0378882ab9906f) | `` hassil: 3.1.0 -> 3.2.0 ``                                                  |
| [`ee02dcf8`](https://github.com/NixOS/nixpkgs/commit/ee02dcf8d72a4acbeb3f2e7b5c9638c6de9282e5) | `` rclip: fix build ``                                                        |
| [`4c870bc5`](https://github.com/NixOS/nixpkgs/commit/4c870bc517b51c65aafc0e43f5c16adcd4fbdec1) | `` python3Packages.python-aodhclient: 3.7.1 -> 3.9.1 ``                       |
| [`0546ff00`](https://github.com/NixOS/nixpkgs/commit/0546ff0050765cb3730b3e8496d707359c221c93) | `` otel-desktop-viewer: 0.2.2 -> 0.2.5 ``                                     |
| [`c926c344`](https://github.com/NixOS/nixpkgs/commit/c926c344aa0d42abb734cf8471dde2eac2cc1138) | `` guile-goblins: remove offsetcyan from maintainers ``                       |
| [`7b8285f0`](https://github.com/NixOS/nixpkgs/commit/7b8285f0c515ece16bf7ee692203fed0d17fe618) | `` incus: 6.15.0 -> 6.16.0 ``                                                 |
| [`912d3338`](https://github.com/NixOS/nixpkgs/commit/912d3338ebca245f1abac7ae76aeb50d5151d46a) | `` albyhub: disable nixpkgs-update ``                                         |
| [`3459a9be`](https://github.com/NixOS/nixpkgs/commit/3459a9becbb8e6c6eaee2ae2ec5ab21998a617c6) | `` ipxe: 1.21.1-unstable-2025-08-13 -> 1.21.1-unstable-2025-08-29 ``          |
| [`6514e0d8`](https://github.com/NixOS/nixpkgs/commit/6514e0d864b5e0ecf26e171d1d846811d8ec05f4) | `` age-plugin-openpgp-card: init at 0.1.1 ``                                  |
| [`b5dee533`](https://github.com/NixOS/nixpkgs/commit/b5dee53399e985f074d579dc439c1282ee9cb033) | `` ci/github-script/labels: auto close package request issues ``              |
| [`e2ad57d4`](https://github.com/NixOS/nixpkgs/commit/e2ad57d487acab81377249ec17e389623aa0e6bd) | `` qolibri: move to by-name, switch to Qt6 ``                                 |
| [`57cf2183`](https://github.com/NixOS/nixpkgs/commit/57cf2183572a58d55048d63bea00a0a0c46ea1ea) | `` ISSUE_TEMPLATE: revert one-sentence-per-line for package_request ``        |
| [`75563f8f`](https://github.com/NixOS/nixpkgs/commit/75563f8f5237c44ed7b8a51fd870ed3d6a11eb82) | `` steam-unwrapped: 1.0.0.83 -> 1.0.0.84 ``                                   |
| [`df32f9e1`](https://github.com/NixOS/nixpkgs/commit/df32f9e1d58a42233d9a8ca15377bf97ef7ec529) | `` albyhub: 1.18.5 -> 1.19.2 ``                                               |
| [`d753792a`](https://github.com/NixOS/nixpkgs/commit/d753792abf7f6efb889bf00f841bbd7c21f5219e) | `` gh-classroom: 0.1.14 -> 0.1.15 ``                                          |
| [`44104d0f`](https://github.com/NixOS/nixpkgs/commit/44104d0ffefa5a3dcc6516f2f29918c874b7c6ae) | `` linuxPackages.system76-io: install thelio-io ko file ``                    |
| [`ad7c0cb8`](https://github.com/NixOS/nixpkgs/commit/ad7c0cb81f12936b6b9c46253df5426a248ce01a) | `` python3.pkgs.webargs: fix tests with newer pytest-asyncio ``               |
| [`81d4426b`](https://github.com/NixOS/nixpkgs/commit/81d4426bcf0feaff34c300f66523d8018bcfcdab) | `` python3Packages.datrie: 0.8.2 -> 0.8.3 ``                                  |
| [`98f40965`](https://github.com/NixOS/nixpkgs/commit/98f4096564532fd6bd845e9b6cab47c324df60ce) | `` windsurf: 1.12.2 -> 1.12.3 ``                                              |
| [`fcdbc73c`](https://github.com/NixOS/nixpkgs/commit/fcdbc73c8c333430c62ab7d1b88a80cca95a1457) | `` ghorg: 1.11.3 -> 1.11.4 ``                                                 |
| [`5cb90775`](https://github.com/NixOS/nixpkgs/commit/5cb90775d9685ef510ee434e2deca2e982ede9c7) | `` gh-dash: 4.16.1 -> 4.16.2 ``                                               |
| [`3632ad8d`](https://github.com/NixOS/nixpkgs/commit/3632ad8d50d07dad87b3e2e12736fa158b0016f6) | `` git-toolbelt: 1.9.3 -> 1.9.4 ``                                            |
| [`2c6eb485`](https://github.com/NixOS/nixpkgs/commit/2c6eb485710624c8da2ef3846100d3c6d8d4dd6c) | `` jay: 1.11.0 -> 1.11.1 ``                                                   |
| [`fa398135`](https://github.com/NixOS/nixpkgs/commit/fa39813571ac8fe1f26a8653238903c8be3ba48b) | `` home-assistant-custom-components.alarmo: 1.10.9 -> 1.10.10 ``              |
| [`c587281c`](https://github.com/NixOS/nixpkgs/commit/c587281c974424fa38d4d573e109a73813c51dcc) | `` kubescape: 3.0.38 -> 3.0.39 ``                                             |
| [`3c49a68b`](https://github.com/NixOS/nixpkgs/commit/3c49a68bb312de449b5c91032a5bf053dd9fd3f2) | `` nfpm: 2.43.0 -> 2.43.1 ``                                                  |
| [`df2eee12`](https://github.com/NixOS/nixpkgs/commit/df2eee1267ab29c43db07404c37c53c18a3e0b7c) | `` _1password-cli: 2.31.1 -> 2.32.0 ``                                        |
| [`9d1f0b22`](https://github.com/NixOS/nixpkgs/commit/9d1f0b224a4407783975cf658acc35e56d550946) | `` pinniped: 0.40.0 -> 0.41.0 ``                                              |
| [`15e89518`](https://github.com/NixOS/nixpkgs/commit/15e895181bc06d58268e265500b3aeb5c8444374) | `` win-pvdrivers: drop ``                                                     |
| [`37ebb291`](https://github.com/NixOS/nixpkgs/commit/37ebb291eeaa078e90df16c0eb72be329f43d5b1) | `` python3Packages.llguidance: 0.7.19 -> 1.2.0 ``                             |
| [`02c2cf51`](https://github.com/NixOS/nixpkgs/commit/02c2cf51eed159847e5d661d465a336291ae4854) | `` python3Packages.pyfunctional: 1.5.0 -> 1.4.3 ``                            |
| [`e4bbbe7c`](https://github.com/NixOS/nixpkgs/commit/e4bbbe7c77a228e3a05f22b558fa0c52f300547d) | `` stackit-cli: 0.39.1 -> 0.40.1 ``                                           |
| [`8f9d51f0`](https://github.com/NixOS/nixpkgs/commit/8f9d51f0b1c23ab924599abcf0f3fe403febece1) | `` esphome: 2025.8.1 -> 2025.8.2 ``                                           |
| [`d0c34e32`](https://github.com/NixOS/nixpkgs/commit/d0c34e3286568700c51723e82673e48134945171) | `` python3Packages.mscerts: 2025.6.27 -> 2025.8.29 ``                         |
| [`2a8555fd`](https://github.com/NixOS/nixpkgs/commit/2a8555fd042855642ed80072e614c6107a3861b6) | `` lidarr: 2.12.4.4658 -> 2.13.3.4711 ``                                      |
| [`98ed16e0`](https://github.com/NixOS/nixpkgs/commit/98ed16e0b254502ad1e720999920fe7e56575361) | `` lidarr: fix update script ``                                               |
| [`80f00ea0`](https://github.com/NixOS/nixpkgs/commit/80f00ea0c963bc7d789dc8b90d119786d1b228f7) | `` vimPlugins: update on 2025-08-29 ``                                        |
| [`a5917ce0`](https://github.com/NixOS/nixpkgs/commit/a5917ce0d7c790eb7276b1680b72fb293099db60) | `` python3Packages.pygitguardian: 1.24.0 -> 1.25.0 ``                         |
| [`28961511`](https://github.com/NixOS/nixpkgs/commit/289615112fe70270a5ba738399ced4da45ce4b9e) | `` python3Packages.aioswitcher: 6.0.1 -> 6.0.2 ``                             |
| [`13214a85`](https://github.com/NixOS/nixpkgs/commit/13214a8564bab6a5d662ded606fabb4577ca7ca6) | `` fyne: 1.26.1 -> 1.6.2 ``                                                   |
| [`ed9a505d`](https://github.com/NixOS/nixpkgs/commit/ed9a505d36ce67403fe90683e36f98ad184c0b80) | `` python3Packages.python-mpv-jsonipc: 1.2.0 -> 1.2.1 ``                      |