### PR TITLE
chore(flake/nixpkgs): `d7600c77` -> `b599843b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,11 +190,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756542300,
-        "narHash": "sha256-tlOn88coG5fzdyqz6R93SQL5Gpq+m/DsWpekNFhqPQk=",
+        "lastModified": 1757347588,
+        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7600c775f877cd87b4f5a831c28aa94137377aa",
+        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`8df7ffa9`](https://github.com/NixOS/nixpkgs/commit/8df7ffa95306f788f36e1923cae90c25e76d0541) | `` ktailctl: 0.21.0 -> 0.21.1 ``                                                            |
| [`b9b0a40e`](https://github.com/NixOS/nixpkgs/commit/b9b0a40ec483e825a51e5c54b717f711fc71d4d2) | `` limine: 9.6.5 -> 9.6.6 ``                                                                |
| [`edcb8078`](https://github.com/NixOS/nixpkgs/commit/edcb807891c714e254cd3440d9579f80972060ff) | `` kiwix: update qt5 to qt6 ``                                                              |
| [`82198476`](https://github.com/NixOS/nixpkgs/commit/82198476da543a1ce0e5cff8a0f570cd91bdabfa) | `` buck2: fix by disabling autoPatchelfHook on darwin ``                                    |
| [`227ac4d9`](https://github.com/NixOS/nixpkgs/commit/227ac4d95ab24e20b05d44a31ff424b4f57009ba) | `` buildRustCrate: fix wasm bins with hyphenated names ``                                   |
| [`09df8797`](https://github.com/NixOS/nixpkgs/commit/09df879764d6827c4ae1e6e60a35e3cddda9c230) | `` coqPackages.coq-record-update: 0.3.5 -> 0.3.6 ``                                         |
| [`f1571542`](https://github.com/NixOS/nixpkgs/commit/f1571542a00de5f3a7fe707689de80284404af4a) | `` agdaPackages.agda-categories: 0.2.0 -> 0.3.0 ``                                          |
| [`930dd217`](https://github.com/NixOS/nixpkgs/commit/930dd217a54a55084b06c2770b7be7167e6102b4) | `` gnomeExtensions.systemd-manager: 18 -> 19 ``                                             |
| [`b5d3a07d`](https://github.com/NixOS/nixpkgs/commit/b5d3a07d593c821c264bb6738ac933e9fd7486ea) | `` postgresqlPackages.timescaledb-apache: 2.21.3 -> 2.22.0 ``                               |
| [`07916fc3`](https://github.com/NixOS/nixpkgs/commit/07916fc3fd84832119cbc6cd0d70ad9a0fe7c347) | `` ci: have `eval.full` return the report as displayed in CI ``                             |
| [`3a93aa2d`](https://github.com/NixOS/nixpkgs/commit/3a93aa2d233d9e921db296bddf7c80c210ca0c02) | `` home-assistant-custom-components.samsungtv-smart: 0.14.4 -> 0.14.5 (#441133) ``          |
| [`f810cac5`](https://github.com/NixOS/nixpkgs/commit/f810cac510048d7284237fef6c497e34c737c215) | `` python3Packages.python-octaviaclient: 3.11.1 -> 3.12.0 ``                                |
| [`8f59f44d`](https://github.com/NixOS/nixpkgs/commit/8f59f44d003d6d3b2d3533b3ea2ac3261612c62c) | `` python3Packages.brother: 5.0.1 -> 5.1.0 (#441116) ``                                     |
| [`339bd06f`](https://github.com/NixOS/nixpkgs/commit/339bd06f2ddaffd13ffe9c61bb9006907dfae6af) | `` python3Packages.ffmpeg-progress-yield: fix build on Darwin by disabling failing tests `` |
| [`b791e74e`](https://github.com/NixOS/nixpkgs/commit/b791e74ea92078017afb0cdf77a3a794a02a2d7a) | `` h2o: 2.3.0-rolling-2025-08-22 → 2.3.0-rolling-2025-09-05 (#437033) ``                    |
| [`25753208`](https://github.com/NixOS/nixpkgs/commit/2575320814712d95bca23a4fff8f33ea1a8fe4af) | `` nixosTests.libresprite: improve test consistency ``                                      |
| [`aaa2d76d`](https://github.com/NixOS/nixpkgs/commit/aaa2d76de95a7b139df91c4004618c6a167c9959) | `` nixosTests.varnish60: fix failing test ``                                                |
| [`c8317779`](https://github.com/NixOS/nixpkgs/commit/c83177793e569fd1cb58db09f1fd9a7e22106f77) | `` postgresqlPackages.pg_cron: 1.6.6 -> 1.6.7 ``                                            |
| [`90a49d00`](https://github.com/NixOS/nixpkgs/commit/90a49d004a4d94f505e72debf4ff13af45f57044) | `` krename: re-init at 5.0.60 ``                                                            |
| [`4ea82165`](https://github.com/NixOS/nixpkgs/commit/4ea8216576dc974b1735ba184ba35471e968b3cd) | `` build(deps): bump actions/github-script from 7.0.1 to 8.0.0 ``                           |
| [`d64ece98`](https://github.com/NixOS/nixpkgs/commit/d64ece988b56b8083abeba807d5b69a1795e6ad2) | `` build(deps): bump actions/labeler from 5.0.0 to 6.0.1 ``                                 |
| [`c4fd1f65`](https://github.com/NixOS/nixpkgs/commit/c4fd1f6500e842cc7bdf3d57671fa414ae961cb4) | `` build(deps): bump cachix/install-nix-action from 31.6.0 to 31.6.1 ``                     |
| [`b3bcb65d`](https://github.com/NixOS/nixpkgs/commit/b3bcb65d4f5d723c2b0ae92fe03ae5da324be195) | `` maintainers: update sugar700 ``                                                          |
| [`dc23cb7e`](https://github.com/NixOS/nixpkgs/commit/dc23cb7ee3e538463ea9530e56981d489bc98776) | `` tailwindcss_4: 4.1.12 -> 4.1.13 ``                                                       |
| [`bd5c2075`](https://github.com/NixOS/nixpkgs/commit/bd5c2075cf5f9f7da46bddd8912660fb93e41e28) | `` cargo-expand: 1.0.115 -> 1.0.116 ``                                                      |
| [`93368343`](https://github.com/NixOS/nixpkgs/commit/933683438426eb1f2e0d7552883c5112896d071e) | `` python3Packages.bytecode: 0.16.2 -> 0.17.0 ``                                            |
| [`728a45f0`](https://github.com/NixOS/nixpkgs/commit/728a45f0f7c0206e9dae1802c04b87c59dbb6253) | `` batman-adv: 2025.2 -> 2025.3 ``                                                          |
| [`a034c0d3`](https://github.com/NixOS/nixpkgs/commit/a034c0d3b83e05d2181a9713abc89c3bf840cd99) | `` linuxKernel.kernels.linux_zen: 6.16.3 -> 6.16.5 ``                                       |
| [`dece6131`](https://github.com/NixOS/nixpkgs/commit/dece6131f790f63fdac918da0b5bae2005456e70) | `` ledger-live-desktop: 2.126.0 -> 2.126.2 ``                                               |
| [`f98d5c5f`](https://github.com/NixOS/nixpkgs/commit/f98d5c5f15ab3aca74aa1322be84c559c4bc350c) | `` python3Packages.pinecone-plugin-assistant: 1.7.0 -> 1.8.0 ``                             |
| [`71bec93d`](https://github.com/NixOS/nixpkgs/commit/71bec93d309daedf375d7580cf387548a7c2e8dd) | `` piliplus: 1.1.4.1 -> 1.1.4.3 ``                                                          |
| [`3379f636`](https://github.com/NixOS/nixpkgs/commit/3379f6362429b1429036cc9f3037f4ce8c481da3) | `` feh: 3.11 -> 3.11.1 ``                                                                   |
| [`bd06585b`](https://github.com/NixOS/nixpkgs/commit/bd06585b7f5ac054cb5311b8161c39d1600bddde) | `` nom: 2.13.0 -> 2.14.0 ``                                                                 |
| [`a7357445`](https://github.com/NixOS/nixpkgs/commit/a73574453d7743978dbaaade1f22b1617d5d62a2) | `` python3Packages.skops: 0.12.0 -> 0.13.0 ``                                               |
| [`f221aaf6`](https://github.com/NixOS/nixpkgs/commit/f221aaf60f02505a735896d58d9986518c0bf0df) | `` OWNERS: remove redundant owners from LLVM files ``                                       |
| [`e47d4f03`](https://github.com/NixOS/nixpkgs/commit/e47d4f032e00a4680050d42315e5cd19f43e363c) | `` maintainers/team-list: add emily to LLVM ``                                              |
| [`67e8b880`](https://github.com/NixOS/nixpkgs/commit/67e8b88035fe6b74edd97bf7e7e6da72f46381d4) | `` distribution: exclude failing test after Go update ``                                    |
| [`28fc022c`](https://github.com/NixOS/nixpkgs/commit/28fc022c36c0671f329bcddf814a6c6bb41a253b) | `` mkuimage: 0-unstable-2024-02-28 -> 0-unstable-2025-09-05 ``                              |
| [`dd64e083`](https://github.com/NixOS/nixpkgs/commit/dd64e0830ef5d7592e6402a2f0684bc239b36dd9) | `` gobusybox: pin buildGoModule to 1.24 ``                                                  |
| [`cb2698f9`](https://github.com/NixOS/nixpkgs/commit/cb2698f9331598cb5d974e0accef463bce5d1303) | `` u-root: 0.14.0-unstable-2024-09-26 -> 0.15.0 ``                                          |
| [`fc2e2eeb`](https://github.com/NixOS/nixpkgs/commit/fc2e2eeb82edd98b038c2841ebf7016d3a9ccfe4) | `` maintainers: rename 'rewine' to 'wineee' ``                                              |
| [`a734133d`](https://github.com/NixOS/nixpkgs/commit/a734133db932b89dcb97ef74a22a8fe1f83ff4c9) | `` models-dev: 0-unstable-2025-08-27 -> 0-unstable-2025-09-06 ``                            |
| [`403640aa`](https://github.com/NixOS/nixpkgs/commit/403640aa9ee256acdaebe931036ac9ce6842d86d) | `` rocqPackages.rocq-elpi: 3.0.0 -> 3.1.0 ``                                                |
| [`cb3e1ee4`](https://github.com/NixOS/nixpkgs/commit/cb3e1ee48162dc50032b6a66b5634aa72626336d) | `` python3Packages.tree-sitter-markdown: remove update script override ``                   |
| [`ff8d186d`](https://github.com/NixOS/nixpkgs/commit/ff8d186d8600116332a6bef91ad7813544e170ed) | `` databricks-cli: 0.266.0 -> 0.267.0 ``                                                    |
| [`0efa842a`](https://github.com/NixOS/nixpkgs/commit/0efa842a7648dc80f6e743edc0f6c4989ff07fc5) | `` texsurgery: init at 0.6.3 ``                                                             |
| [`56273064`](https://github.com/NixOS/nixpkgs/commit/562730648e9741e72900b88bce8e310154c617b3) | `` wit-bindgen: 0.45.0 -> 0.45.1 ``                                                         |
| [`0829ce94`](https://github.com/NixOS/nixpkgs/commit/0829ce947cc45519bfa8bd3ad0cbb7a014a86554) | `` nixos/eval-config: Remove NIXOS_EXTRA_MODULE_PATH ``                                     |
| [`86d2369a`](https://github.com/NixOS/nixpkgs/commit/86d2369ac488490480dd806e256751e803589548) | `` forecast: 0-unstable-2025-08-22 -> 0-unstable-2025-09-04 ``                              |
| [`c9430de6`](https://github.com/NixOS/nixpkgs/commit/c9430de6455216cb7ed54b9e96f4cecefe83cd84) | `` txtpbfmt: 0-unstable-2025-06-27 -> 0-unstable-2025-09-03 ``                              |
| [`97bc451c`](https://github.com/NixOS/nixpkgs/commit/97bc451c17de36b5e6337311e6ecf1fb0e423df5) | `` veryl: 0.16.3 -> 0.16.4 ``                                                               |
| [`0d5e144f`](https://github.com/NixOS/nixpkgs/commit/0d5e144f35efcbb9a375021cdc5c60775ca27392) | `` tdf: 0.4.2 -> 0.4.3 ``                                                                   |
| [`c68b80bd`](https://github.com/NixOS/nixpkgs/commit/c68b80bdde16829f825e7a2c12786f845b094118) | `` basedpyright: 1.31.3 -> 1.31.4 ``                                                        |
| [`7588c4c3`](https://github.com/NixOS/nixpkgs/commit/7588c4c341fd86a5d9f3bd204322e46c380bd8e2) | `` rclip: 2.0.5 -> 2.0.7 ``                                                                 |
| [`d16c59a0`](https://github.com/NixOS/nixpkgs/commit/d16c59a06f8c2b5dc03f6a98aa16175f3505dd80) | `` museum: 1.2.0 -> 1.2.4 ``                                                                |
| [`33dfc47d`](https://github.com/NixOS/nixpkgs/commit/33dfc47d5e3bd5f6aa5eb3180741fa4b31d50d8c) | `` nixos/timekpr: init at 0.5.8 ``                                                          |
| [`e06e5647`](https://github.com/NixOS/nixpkgs/commit/e06e56478509099358d299bbac5c5cd8d8f7f2e5) | `` duf: 0.8.1 -> 0.9.0 ``                                                                   |
| [`b52064b3`](https://github.com/NixOS/nixpkgs/commit/b52064b30972620345ee22170bb05403d2ab0450) | `` python3Packages.pyqt6: fix QtMultimediaWidgets ``                                        |
| [`b17f1938`](https://github.com/NixOS/nixpkgs/commit/b17f1938a1cdadacf54b0b5a35251c01c933bd52) | `` hdf5-threadsafe: fix cmake flag, disable c++ api. ``                                     |
| [`518b5ba8`](https://github.com/NixOS/nixpkgs/commit/518b5ba83d6234de804cd9a0e0f06c58edb1066f) | `` anytype: mark as broken on darwin ``                                                     |
| [`c9bd86e7`](https://github.com/NixOS/nixpkgs/commit/c9bd86e736b16d9519a32fcaf276937625bf54a6) | `` slint-lsp: 1.12.1 -> 1.13.0 ``                                                           |
| [`d1331163`](https://github.com/NixOS/nixpkgs/commit/d1331163ffde50e2d1188d0c592b215c5ac8dc9e) | `` thunderbird-140-unwrapped: 140.2.0esr -> 140.2.1esr ``                                   |
| [`4f342a1b`](https://github.com/NixOS/nixpkgs/commit/4f342a1bcc74fdcc70a669d3b6103358bca16b9d) | `` haskell.compiler.ghc{924,963,984}Binary: use `broken` for NCG check ``                   |
| [`9137f779`](https://github.com/NixOS/nixpkgs/commit/9137f77959a209b580bc6be3d5bab36deb717fb6) | `` git-annex: patch another test failure ``                                                 |
| [`02a37cad`](https://github.com/NixOS/nixpkgs/commit/02a37cadc8f6da01d4230aafcb5fbbf11f2ad62a) | `` tokyonight-gtk-theme: 0-unstable-2025-08-21 -> 0-unstable-2025-08-28 ``                  |
| [`66c4c625`](https://github.com/NixOS/nixpkgs/commit/66c4c6253a432cbddc49fbe5345beb94fe2588fa) | `` buf: 1.56.0 -> 1.57.0 ``                                                                 |
| [`2adb9c0f`](https://github.com/NixOS/nixpkgs/commit/2adb9c0f067635cd0e7b700fe6b5cfe54bd1329e) | `` cursor-cli: 0-unstable-2025-08-27 -> 0-unstable-2025-09-04 ``                            |
| [`514d7e01`](https://github.com/NixOS/nixpkgs/commit/514d7e017664f481d5334ad7c80dcaa77382be07) | `` python3Packages.weaviate-client: 4.16.5 -> 4.16.9 ``                                     |
| [`e7a609e8`](https://github.com/NixOS/nixpkgs/commit/e7a609e865e1cc8d2ca543574a2a2b9ca3386c04) | `` llvmPackages_git: 22.0.0-unstable-2025-08-31 -> 22.0.0-unstable-2025-09-07 ``            |
| [`83c7fc13`](https://github.com/NixOS/nixpkgs/commit/83c7fc132d0d4acc9c1269e3638dfa5b560c4941) | `` python3Packages.pynvim: 0.5.2 -> 0.6.0 ``                                                |
| [`98a17363`](https://github.com/NixOS/nixpkgs/commit/98a17363be02ae4f899c077336192a8a8a758d7a) | `` audacious: 4.5 -> 4.5.1 ``                                                               |
| [`c16bff86`](https://github.com/NixOS/nixpkgs/commit/c16bff862acaf4f3cae4a67fd69531caad4fbedc) | `` audacious-plugins: 4.5 -> 4.5.1 ``                                                       |
| [`1ed89cba`](https://github.com/NixOS/nixpkgs/commit/1ed89cba28e7e8bf9f78cb7cea873098b1755393) | `` python313Packages.checkdmarc: add importlib-resources ``                                 |
| [`89355918`](https://github.com/NixOS/nixpkgs/commit/89355918d4cecea4835e23026c28955ae0dde606) | `` aquamarine: 0.9.3 -> 0.9.4 ``                                                            |
| [`903c309a`](https://github.com/NixOS/nixpkgs/commit/903c309ab4ec535830f49a274b9916ced32bcb81) | `` maintainers: remove federicoschonborn ``                                                 |
| [`b30ba513`](https://github.com/NixOS/nixpkgs/commit/b30ba513b0afabb6127961e06f0f4313b0a9dbb8) | `` nixos/podman: use nftables as firewall when enabled ``                                   |
| [`4b24e003`](https://github.com/NixOS/nixpkgs/commit/4b24e00383ee5264815b09688c1b2d9750ac5c24) | `` kdePackages.dynamic-workspaces: remove federicoschonborn from maintainers ``             |
| [`57f735a1`](https://github.com/NixOS/nixpkgs/commit/57f735a19b2a24db459ea13fe79e0a372fe6d54e) | `` podman: move iptables to `virtualisation.podman.extraPackages` ``                        |
| [`b66f525c`](https://github.com/NixOS/nixpkgs/commit/b66f525c29ce502adeea217901b62a02f040114d) | `` systeroid: 0.4.5 -> 0.4.6 ``                                                             |
| [`d9cea0c9`](https://github.com/NixOS/nixpkgs/commit/d9cea0c9d4593a3f61824cb4202075b30596a471) | `` python3Packages.publicsuffixlist: 1.0.2.20250827 -> 1.0.2.20250906 ``                    |
| [`64a200f8`](https://github.com/NixOS/nixpkgs/commit/64a200f89f50a61d9e3be34fc797036d35aa1928) | `` python3Packages.pytenable: 1.8.3 -> 1.8.4 ``                                             |
| [`f68798a0`](https://github.com/NixOS/nixpkgs/commit/f68798a02e30b181515eceef1dc867fad7a12ced) | `` go_1_25: 1.25.0 -> 1.25.1 ``                                                             |
| [`fb5a523d`](https://github.com/NixOS/nixpkgs/commit/fb5a523d141f6406cd4d81962b1240a57fe71591) | `` haskell.compiler.ghc902Binary: bump LLVM by wrapping `opt(1)` ``                         |
| [`1bda5b19`](https://github.com/NixOS/nixpkgs/commit/1bda5b199d3bf976e9367ea3c51d854f6e8bcbde) | `` haskell.compiler.ghc{924,963,984}Binary: remove LLVM‐related dead code ``                |
| [`9940c1e6`](https://github.com/NixOS/nixpkgs/commit/9940c1e667ef3b96aa176eebaec2d10d413ac611) | `` vimPlugins.vim-textobj-line: init at 2021-09-27 ``                                       |
| [`3b7e7e36`](https://github.com/NixOS/nixpkgs/commit/3b7e7e362b58ceaba7274854b3af564d7cf87899) | `` haskell.compiler.ghc928: drop ``                                                         |
| [`c0243276`](https://github.com/NixOS/nixpkgs/commit/c0243276051bd319ee4176a5e69280f3de79be9c) | `` haskell.compiler.ghc8107{,Binary}: drop ``                                               |
| [`08129b69`](https://github.com/NixOS/nixpkgs/commit/08129b69e52e609ebee3c5985859f7a141da831d) | `` haskell.compiler.ghc{928,963,967,9101,9102,HEAD}: drop AArch32 bootstrap ``              |
| [`135bca15`](https://github.com/NixOS/nixpkgs/commit/135bca15a7e226b25cb7f0d9acf38983ffa0686c) | `` xdvdfs-cli: remove federicoschonborn from maintainers ``                                 |
| [`3e887590`](https://github.com/NixOS/nixpkgs/commit/3e88759063030071886b8775a09e18d7b81817a1) | `` surgescript: remove federicoschonborn from maintainers ``                                |
| [`2c5b8457`](https://github.com/NixOS/nixpkgs/commit/2c5b8457d2dd4d7d684d3a7e00eefc168e8cfaf5) | `` opensurge: remove federicoschonborn from maintainers ``                                  |
| [`0df17a71`](https://github.com/NixOS/nixpkgs/commit/0df17a71611a53898bfbfb68a10cbba9311ff845) | `` minesector: remove federicoschonborn from maintainers ``                                 |
| [`3b62ff91`](https://github.com/NixOS/nixpkgs/commit/3b62ff91df83af5f5cb6b2184ecc89dd3b999c76) | `` hugo: remove federicoschonborn from maintainers ``                                       |
| [`772e603a`](https://github.com/NixOS/nixpkgs/commit/772e603ae90a66fc8521f6fce8d7aa267a53b0d1) | `` hedgemodmanager: remove federicoschonborn from maintainers ``                            |
| [`fc7db8ff`](https://github.com/NixOS/nixpkgs/commit/fc7db8ff3e70090f3451e8e505db6557d931d167) | `` bluejay: remove federicoschonborn from maintainers ``                                    |
| [`9e2cbbfb`](https://github.com/NixOS/nixpkgs/commit/9e2cbbfbf7f6b37fd0ed6028e076a8e86d7382a5) | `` biplanes-revival: remove federicoschonborn from maintainers ``                           |
| [`996ba05a`](https://github.com/NixOS/nixpkgs/commit/996ba05a818f7fdfd0015aacec51b4629a8232aa) | `` s7: 11.5-unstable-2025-08-26 -> 11.5-unstable-2025-09-06 ``                              |
| [`7738ba0d`](https://github.com/NixOS/nixpkgs/commit/7738ba0de3cc6a4412b97488acb1176e90c4a99a) | `` vimPlugins.hlargs-nvim: init at 2025-06-16 ``                                            |
| [`0fbe24f8`](https://github.com/NixOS/nixpkgs/commit/0fbe24f8e5f0a07eb72fc47bb31828a9b07577c0) | `` pihole-ftl: Add patch to fix #435150 ``                                                  |
| [`82a3e70b`](https://github.com/NixOS/nixpkgs/commit/82a3e70b2db564a0df05e60cf3ec64370d84b566) | `` pihole-ftl: Add basic test ``                                                            |
| [`ec76ed9c`](https://github.com/NixOS/nixpkgs/commit/ec76ed9c4e0e0c80c678eff15c6ac71615853cc9) | `` haskell.compiler.ghc948: remove obsolete bootstrap hack ``                               |
| [`a25e8c52`](https://github.com/NixOS/nixpkgs/commit/a25e8c529139c160e6e3fe3b81db12985f89629a) | `` haskell.compiler.ghc902: add missing alias ``                                            |
| [`a120f523`](https://github.com/NixOS/nixpkgs/commit/a120f523bd67a372979842f9f77257b60cffd975) | `` clash-verge-rev: 2.4.1 -> 2.4.2 ``                                                       |
| [`1579b1f4`](https://github.com/NixOS/nixpkgs/commit/1579b1f4724825e54d4700c719dd5001b8965979) | `` versitygw: 1.0.16 -> 1.0.17 ``                                                           |