### PR TITLE
chore(flake/git-hooks): `e891a93b` -> `ab82ab08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755960406,
-        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "lastModified": 1757239681,
+        "narHash": "sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "rev": "ab82ab08d6bf74085bd328de2a8722c12d97bd9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`57e70dd1`](https://github.com/cachix/git-hooks.nix/commit/57e70dd1e97d57fdb2bcf16add926628272a716c) | `` modules/pre-commit: make `rawConfig` option type recursively updatable `` |