### PR TITLE
chore(flake/nixvim): `7afdd40b` -> `51edc33c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1757176284,
-        "narHash": "sha256-j4SBmYsARwNG0DHljZ1uzZlGqCIU5fzCMA2g+GjD0xw=",
+        "lastModified": 1757437784,
+        "narHash": "sha256-GFbRW1QCBNK/0di2Dj0WZJxdN+EZgTTn6gm7af4/r9s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7afdd40b96c9168aa4cb49b86fc67eccd441cae5",
+        "rev": "51edc33c9763e486beacf6a066ae41a3c18827fa",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755555503,
-        "narHash": "sha256-WiOO7GUOsJ4/DoMy2IC5InnqRDSo2U11la48vCCIjjY=",
+        "lastModified": 1756738487,
+        "narHash": "sha256-8QX7Ab5CcICp7zktL47VQVS+QeaU4YDNAjzty7l7TQE=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "6f3efef888b92e6520f10eae15b86ff537e1d2ea",
+        "rev": "5feeaeefb571e6ca2700888b944f436f7c05149b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`51edc33c`](https://github.com/nix-community/nixvim/commit/51edc33c9763e486beacf6a066ae41a3c18827fa) | `` modules/output: add `waylandSupport` option ``                                   |
| [`e3faa69c`](https://github.com/nix-community/nixvim/commit/e3faa69c0d094b94249225d4d98c29d73d26b87e) | `` flake/dev/flake.lock: Update ``                                                  |
| [`77eb9ea9`](https://github.com/nix-community/nixvim/commit/77eb9ea9cccd71a80d10b47d324ceb6390ba3c2b) | `` Removing old repo ``                                                             |
| [`d38eb947`](https://github.com/nix-community/nixvim/commit/d38eb947272dd4e6d138648b1b49360301db6859) | `` flake/dev/flake.lock: Update ``                                                  |
| [`d7b69bd0`](https://github.com/nix-community/nixvim/commit/d7b69bd0218d826edd031640e1347984e8557973) | `` flake.lock: Update ``                                                            |
| [`cf170ed6`](https://github.com/nix-community/nixvim/commit/cf170ed677fa595ec0370e83278c0d40c6c2638c) | `` tests/all-package-defaults: disable mint on darwin (build failure) ``            |
| [`8ef2d284`](https://github.com/nix-community/nixvim/commit/8ef2d2845169ccedbd0465faad13cfdafca9611f) | `` tests/all-package-defaults: disable texlive on aarch64-darwin too ``             |
| [`1500565d`](https://github.com/nix-community/nixvim/commit/1500565d53c3bde9956d7b486791b99f8d22a202) | `` tests/all-package-defaults: disable buck2 on darwin (build failure) ``           |
| [`3fe2a1f2`](https://github.com/nix-community/nixvim/commit/3fe2a1f253ab98283b8f1d3b735129ffae2e3f08) | `` tests/all-package-defaults: disable verible on aarch64-darwin (build failure) `` |
| [`6394d43f`](https://github.com/nix-community/nixvim/commit/6394d43f255ac596eecbafd2c1993da3b2b2bd3d) | `` plugins/codecompanion: adapt options ``                                          |
| [`f77a33e8`](https://github.com/nix-community/nixvim/commit/f77a33e8738ba0de5e1b5adde1349aad872fa198) | `` plugins/project-nvim: fix moduleName ``                                          |
| [`f329e8fa`](https://github.com/nix-community/nixvim/commit/f329e8faf211adbadc71b8e9b74639597a549d20) | `` flake/dev/flake.lock: Update ``                                                  |
| [`66c32ff5`](https://github.com/nix-community/nixvim/commit/66c32ff5068af61be504086f1bc842a5d3d727f9) | `` flake.lock: Update ``                                                            |
| [`2365afc0`](https://github.com/nix-community/nixvim/commit/2365afc0d51d71279b54ab702f8145f069664e2c) | `` ci: only build packages on x86_64-linux ``                                       |
| [`d241216e`](https://github.com/nix-community/nixvim/commit/d241216ede79a3938f764649a1b70c8758ba6c3d) | `` ci: only build "grouped" tests on x86_64-linux ``                                |
| [`3813f183`](https://github.com/nix-community/nixvim/commit/3813f183bc97100065554050b8b818b741a4e502) | `` ci/all-packages-defaults: disable broken packages on x86_64-darwin ``            |
| [`225e8c01`](https://github.com/nix-community/nixvim/commit/225e8c019836b23eeb7eefa1cbf5c0f2394cb76f) | `` ci: build all-packages-defaults on all platforms ``                              |
| [`1a7905ec`](https://github.com/nix-community/nixvim/commit/1a7905eced82dbfb21e9d7d1a8ee4fccdf608637) | `` colorschemes/gruvbox-material: init ``                                           |
| [`d5990763`](https://github.com/nix-community/nixvim/commit/d59907633aa0f233d367f1631e0814b271ec992a) | `` plugins/deprecation: remove gruvbox-material deprecation ``                      |