### PR TITLE
chore(flake/nixvim): `5b0a6eb3` -> `43c6f729`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1757539853,
-        "narHash": "sha256-KjDtDYGe6DqcCPZVPwRdpwpc/KCNmE3upQnjvFUiIXw=",
+        "lastModified": 1757619215,
+        "narHash": "sha256-AAg3S94zMF4BtByF2k9/K/tbC0awNHCc50GxCjccUhw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5b0a6eb34b94fe54c0759974962acc22d9c96d7b",
+        "rev": "43c6f7293eba3fa5ff699e339e55270305e51cab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`43c6f729`](https://github.com/nix-community/nixvim/commit/43c6f7293eba3fa5ff699e339e55270305e51cab) | `` plugins/colorschemes: add warning to gruvbox-material `` |
| [`e7140f96`](https://github.com/nix-community/nixvim/commit/e7140f963edf7d90499563d56cf48c7d87c76214) | `` flake/dev/flake.lock: Update ``                          |