### PR TITLE
chore(flake/nixvim): `7f45eae6` -> `0c867f9e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1758061611,
-        "narHash": "sha256-WJJDjNu80dWMSlpexhgRybPsvwl8C2tPwT6yM918Tsg=",
+        "lastModified": 1758134550,
+        "narHash": "sha256-Rj0v5VZuljxG4trz3IHJedEKghNDd1HsK6yVwTNPyJ0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7f45eae65baa38d77d09e0fcf5bfeab6c0f733c0",
+        "rev": "0c867f9e635ce70e829a562b20851cfc17a94196",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                    |
| ----------------------------------------------------------------------------------------------------- | -------------------------- |
| [`0c867f9e`](https://github.com/nix-community/nixvim/commit/0c867f9e635ce70e829a562b20851cfc17a94196) | `` patterns: add module `` |
| [`e6958a96`](https://github.com/nix-community/nixvim/commit/e6958a9699c209ce5b4b329f65a95b4a5d68b1f4) | `` lensline: add module `` |
| [`3e8c4c80`](https://github.com/nix-community/nixvim/commit/3e8c4c802cdb54367e64661e89abc703f3cc75c5) | `` unified: add module ``  |