### PR TITLE
chore(flake/nixvim): `fd0c4235` -> `92ba37a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1758405527,
-        "narHash": "sha256-3OMGX/chlzLpL7OMjXUfcI+xGu5GMeldCnBQ5kM9lZE=",
+        "lastModified": 1758459270,
+        "narHash": "sha256-r2VA33WYfxDJyWmJeo0TmPPrk9yGS9WWb/kld0e7X+I=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "fd0c42355026185678e93bca152cbdb3b1a67563",
+        "rev": "92ba37a3e8c25d470f9affe8d5f36f2cfb21e5dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`92ba37a3`](https://github.com/nix-community/nixvim/commit/92ba37a3e8c25d470f9affe8d5f36f2cfb21e5dd) | `` flake/dev/flake.lock: Update `` |
| [`02db5abd`](https://github.com/nix-community/nixvim/commit/02db5abdc8be22a937f59eeb391a556c9df23c89) | `` flake.lock: Update ``           |