### PR TITLE
chore(flake/nixvim): `92ba37a3` -> `0c15f88f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1758459270,
-        "narHash": "sha256-r2VA33WYfxDJyWmJeo0TmPPrk9yGS9WWb/kld0e7X+I=",
+        "lastModified": 1758665797,
+        "narHash": "sha256-RIN05AhWIFCXL2OOXGoFdF/k8Q6OBhi/WcRtsYuTF5Q=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "92ba37a3e8c25d470f9affe8d5f36f2cfb21e5dd",
+        "rev": "0c15f88f1fc01c8799c5ce2a432fadc47f20e307",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`0c15f88f`](https://github.com/nix-community/nixvim/commit/0c15f88f1fc01c8799c5ce2a432fadc47f20e307) | `` flake/dev/flake.lock: Update ``                                                                |
| [`f828dead`](https://github.com/nix-community/nixvim/commit/f828dead7723e7680b09929b9886225389d0370b) | `` Revert "tests/all-package-defaults: disable aider.nvim on aarch64-linux (hm build failure)" `` |
| [`e7cae3c3`](https://github.com/nix-community/nixvim/commit/e7cae3c3c1bcdb1fec0a3f718259e83056391fb8) | `` flake/dev/flake.lock: Update ``                                                                |
| [`bc9b0107`](https://github.com/nix-community/nixvim/commit/bc9b01070c78b8de1756792c7fb974a23961ff36) | `` flake.lock: Update ``                                                                          |