### PR TITLE
chore(flake/nixvim): `0c15f88f` -> `da7b983a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1758665797,
-        "narHash": "sha256-RIN05AhWIFCXL2OOXGoFdF/k8Q6OBhi/WcRtsYuTF5Q=",
+        "lastModified": 1758834902,
+        "narHash": "sha256-Pt7YS5qKMdh6gU0NP6+7qfe/TFlgjo2gnOSmF9fLQ9A=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0c15f88f1fc01c8799c5ce2a432fadc47f20e307",
+        "rev": "da7b983a29ffb8a390a4be7dfd643467c63543bf",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758272005,
-        "narHash": "sha256-1u3xTH+3kaHhztPmWtLAD8LF5pTYLR2CpsPFWTFnVtQ=",
+        "lastModified": 1758662783,
+        "narHash": "sha256-igrxT+/MnmcftPOHEb+XDwAMq3Xg1Xy7kVYQaHhPlAg=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "aa975a3757f28ce862812466c5848787b868e116",
+        "rev": "7d4c0fc4ffe3bd64e5630417162e9e04e64b27a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                    |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`da7b983a`](https://github.com/nix-community/nixvim/commit/da7b983a29ffb8a390a4be7dfd643467c63543bf) | `` flake/devshell/list-plugins: update EXCLUDES to fix the script ``                       |
| [`ce7fddd1`](https://github.com/nix-community/nixvim/commit/ce7fddd1ec5d0c72b856fc30a8799272cacb9cf8) | `` plugins/chadtree: account for initially wrong declaration for the 'ignore.*' options `` |
| [`ffc4d738`](https://github.com/nix-community/nixvim/commit/ffc4d73814ff06f06bfb9ee14ffde722aec494aa) | `` plugins/chadtree: migrate to mkNeovimPlugin ``                                          |
| [`ea14727f`](https://github.com/nix-community/nixvim/commit/ea14727f4cc2f648d7506c60aa60bcf08ea91581) | `` plugins/chadtree: remove web-devicons automatic activation ``                           |
| [`a8a3a37c`](https://github.com/nix-community/nixvim/commit/a8a3a37c9e565ea1929788efe530289fae2ef1e6) | `` flake/dev/flake.lock: Update ``                                                         |
| [`f7d357bb`](https://github.com/nix-community/nixvim/commit/f7d357bbfdab55e949e87d5c40f12ead289c632d) | `` flake.lock: Update ``                                                                   |
| [`97167168`](https://github.com/nix-community/nixvim/commit/9716716838993371fdc6f2448973ab1f6c9d3eed) | `` maintainers: update generated/all-maintainers.nix ``                                    |
| [`6dbe8877`](https://github.com/nix-community/nixvim/commit/6dbe8877e5bddb418c6b6ca2fee3b8f03fec36d3) | `` plugins/lsp/packages: make ansiblels unpackaged ``                                      |
| [`47b2ce06`](https://github.com/nix-community/nixvim/commit/47b2ce062aadabbb6a0bded6e02386a1ba08bb19) | `` rhubarb: init ``                                                                        |
| [`80cdf28d`](https://github.com/nix-community/nixvim/commit/80cdf28db411d3cfaf450ab62b086f415581a794) | `` maintainers: add santosh ``                                                             |
| [`fd835f3d`](https://github.com/nix-community/nixvim/commit/fd835f3dd13872841ef394e97be71276f75957b9) | `` flake/dev/flake.lock: Update ``                                                         |
| [`aabad55a`](https://github.com/nix-community/nixvim/commit/aabad55a74092c550d3aff007a72ff5ad374d07b) | `` flake.lock: Update ``                                                                   |