### PR TITLE
chore(flake/nixvim): `da7b983a` -> `e0f1e4ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1758834902,
-        "narHash": "sha256-Pt7YS5qKMdh6gU0NP6+7qfe/TFlgjo2gnOSmF9fLQ9A=",
+        "lastModified": 1758931855,
+        "narHash": "sha256-jTmbWlOxsy9dDP3UdCB6jEO63FtkM3dQG2FOq0b4foI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "da7b983a29ffb8a390a4be7dfd643467c63543bf",
+        "rev": "e0f1e4ae4bb8762b7c51c3a514ca19664fad9c3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`e0f1e4ae`](https://github.com/nix-community/nixvim/commit/e0f1e4ae4bb8762b7c51c3a514ca19664fad9c3b) | `` opencode: add module ``                                    |
| [`f68f9d14`](https://github.com/nix-community/nixvim/commit/f68f9d145a9bfe2bd56a29744d76d54ea5130595) | `` plugins/colorful-winsep: account for upstream changes ``   |
| [`01636ad1`](https://github.com/nix-community/nixvim/commit/01636ad1cd1ac59cc7cb40d21f84a6db21ef819b) | `` envrc: nix-direnv 2.3.0 → 3.1.0 ``                         |
| [`afbd9366`](https://github.com/nix-community/nixvim/commit/afbd93661d8e674b56d293401675f8bbf3cb1c88) | `` envrc: update watch_file ``                                |
| [`45cd2f58`](https://github.com/nix-community/nixvim/commit/45cd2f58e1efc3b08251242841ff4c67da0e7d3a) | `` tests/all-package-defaults: disable verilator on darwin `` |
| [`384ea7ae`](https://github.com/nix-community/nixvim/commit/384ea7aeaf53f66604b235cdef32178ad0952bca) | `` maintainers: remove santosh (already in nixpkgs) ``        |
| [`5e87658f`](https://github.com/nix-community/nixvim/commit/5e87658fab563ab2eae2ca7bbf3a6e6720b88a47) | `` flake/dev/flake.lock: Update ``                            |
| [`fe79d7b0`](https://github.com/nix-community/nixvim/commit/fe79d7b005a7cb121cb04ffa8b4212534d615af8) | `` flake.lock: Update ``                                      |