### PR TITLE
chore(flake/nixvim): `e0f1e4ae` -> `4cec6765`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1758931855,
-        "narHash": "sha256-jTmbWlOxsy9dDP3UdCB6jEO63FtkM3dQG2FOq0b4foI=",
+        "lastModified": 1759016999,
+        "narHash": "sha256-UhQmUPSWYpKJQutTzy9TKiRBMg/qVJn6AoNsFR+5Zmc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e0f1e4ae4bb8762b7c51c3a514ca19664fad9c3b",
+        "rev": "4cec67651a6dfdab9a79e68741282e3be8231a61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`4cec6765`](https://github.com/nix-community/nixvim/commit/4cec67651a6dfdab9a79e68741282e3be8231a61) | `` lib/plugins: infer packPathName ``                           |
| [`c4b27080`](https://github.com/nix-community/nixvim/commit/c4b27080a643253e0425db0455c3bd4cd9852356) | `` treewide: infer packPathName menial work ``                  |
| [`3cd56fce`](https://github.com/nix-community/nixvim/commit/3cd56fced459934a67905a4712e6ea7f92569593) | `` plugins/nvim-bqf: migrate to mkNeovimPlugin ``               |
| [`efa43aa8`](https://github.com/nix-community/nixvim/commit/efa43aa8668a7441c1a3c4e7e20d9761c127a943) | `` docs/contributing: change maintainers to a required field `` |