### PR TITLE
chore(flake/nixvim): `fe059cd3` -> `eb54f65d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1759362264,
+        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1759279360,
-        "narHash": "sha256-0WavBzKMQ4Pn68fDHR1rigB+w5SlW36+Jxq/EuHmOhw=",
+        "lastModified": 1759445396,
+        "narHash": "sha256-ofMqAEC6NcFSDGC6qMMG+XFtmlnOghuxh89SzN40+sc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "fe059cd395575c00d475ab1c8200dcc3495724d9",
+        "rev": "eb54f65d9b24310a55de000e62ff6053aa8874ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`eb54f65d`](https://github.com/nix-community/nixvim/commit/eb54f65d9b24310a55de000e62ff6053aa8874ed) | `` plugins/ethersync: init ``                                                                 |
| [`18b8d53e`](https://github.com/nix-community/nixvim/commit/18b8d53e23eb2ab91744f5a66a74537bcd218560) | `` plugins/telescope/extensions/fzf-native: remove old renamed warnings ``                    |
| [`a19a0164`](https://github.com/nix-community/nixvim/commit/a19a0164584801d1d1b7cde863976f97d9ca155c) | `` plugins/copilot-lua: add copilot-lsp ``                                                    |
| [`dca0aa2d`](https://github.com/nix-community/nixvim/commit/dca0aa2defa89b02ed17d45e955af73be17e0178) | `` tests/all-package-defaults: disable superhtml on x86_64-darwin ``                          |
| [`5874f35f`](https://github.com/nix-community/nixvim/commit/5874f35f71dee6091bd23826f1f12ecb32085757) | `` flake/dev/flake.lock: Update ``                                                            |
| [`4f922f60`](https://github.com/nix-community/nixvim/commit/4f922f607a99530bfd6a9b3e8dd7f87078a8ebcc) | `` flake.lock: Update ``                                                                      |
| [`5c4a1009`](https://github.com/nix-community/nixvim/commit/5c4a10093d5367af740c04f2bbe3bab7310d9ad0) | `` plugins.lsp: automatically remove unsupported servers ``                                   |
| [`fc779c6e`](https://github.com/nix-community/nixvim/commit/fc779c6e8279226a128d3c0f06afebf08cfadc1b) | `` plugins/project-nvim: place config before telescope ``                                     |
| [`ba7e691a`](https://github.com/nix-community/nixvim/commit/ba7e691a31fd19e27b02aeae972c7115389209b1) | `` tests/plugins/lean: disable runNvim when LSP is enabed (using deprecated lspconfig API) `` |
| [`3607c2db`](https://github.com/nix-community/nixvim/commit/3607c2dbd2fac476d5098adb52a713e8029e122c) | `` tests/plugins/neogit: update defaults ``                                                   |
| [`c162a49c`](https://github.com/nix-community/nixvim/commit/c162a49c38f188812b19905d2d5aac4ebd44ec74) | `` tests/plugins/package-info: update defaults ``                                             |
| [`523444bf`](https://github.com/nix-community/nixvim/commit/523444bf996b5ad3463032fbcd1b2ec76c7d8498) | `` tests: disable test relying on the idris2 plugin (using deprecated lspconfig API) ``       |
| [`cf808765`](https://github.com/nix-community/nixvim/commit/cf808765c51d542469854c273008ecf2a961a6c7) | `` tests/all-package-defaults: disable open-policy-agent on darwin ``                         |
| [`d363851e`](https://github.com/nix-community/nixvim/commit/d363851efc8f187570672d9cbc09c8c611bb38c8) | `` flake/dev/flake.lock: Update ``                                                            |
| [`05dca882`](https://github.com/nix-community/nixvim/commit/05dca88231276a72014d374cd1ee995fcf51431a) | `` flake.lock: Update ``                                                                      |
| [`16302b08`](https://github.com/nix-community/nixvim/commit/16302b08f02b92a4db2baa6442cf730c0684a690) | `` plugins/kitty-scrollback: add settingsExample ``                                           |
| [`4ecc08df`](https://github.com/nix-community/nixvim/commit/4ecc08df4805432b66b054cc48d600e1125a0078) | `` plugins/kitty-scrollback: init ``                                                          |