### PR TITLE
chore(flake/nixvim): `eb54f65d` -> `42d87fd4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -229,11 +229,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1759445396,
-        "narHash": "sha256-ofMqAEC6NcFSDGC6qMMG+XFtmlnOghuxh89SzN40+sc=",
+        "lastModified": 1759527752,
+        "narHash": "sha256-+sncyvy1dkwRBeq7vw/YpsKqB18UuaKuW2lKRRv6/EI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eb54f65d9b24310a55de000e62ff6053aa8874ed",
+        "rev": "42d87fd4d8f51ea8c591b0b72af76b0aba991f54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`42d87fd4`](https://github.com/nix-community/nixvim/commit/42d87fd4d8f51ea8c591b0b72af76b0aba991f54) | `` tests/all-package-defaults: disable atopile ``                       |
| [`1a845c80`](https://github.com/nix-community/nixvim/commit/1a845c801ed017946e6da810521b8df755384ba2) | `` tests/{lsp-servers,all-package-defaults}: disable roslyn_ls ``       |
| [`f6330444`](https://github.com/nix-community/nixvim/commit/f63304449cf27d5215f6db6671cd2f0b72750b22) | `` plugins/lsp/lsp-packages: add defaults for new LSPs ``               |
| [`b9c5a75c`](https://github.com/nix-community/nixvim/commit/b9c5a75cc63a351b5d92a8af5e72841fba0ee383) | `` ci/nvim-lspconfig: migrate to the new API ``                         |
| [`308e5b38`](https://github.com/nix-community/nixvim/commit/308e5b38436a41e8870c16c9fba82c675910bb60) | `` tests/generated: add a separate error for unsupported entries ``     |
| [`5c6ee418`](https://github.com/nix-community/nixvim/commit/5c6ee4186f0fc0b8de06583361d228b643eea3d7) | `` ci/nvim-lspconfig: do not extract servers' cmd (unused) ``           |
| [`74536f74`](https://github.com/nix-community/nixvim/commit/74536f7432328fefe946dec2587969e44567a1a9) | `` flake/dev/devshell: drop (effectively unused) locate-lsp-packages `` |
| [`96c9775a`](https://github.com/nix-community/nixvim/commit/96c9775a5f109565595d8f2995ade4d16eb64a42) | `` plugins/lsp/volar: handle null package with ts_ls integration ``     |
| [`4c99ccfe`](https://github.com/nix-community/nixvim/commit/4c99ccfe1e7b9aed5c3444a634eb3794b0c54742) | `` tests/lsp-servers: disable building unfree default packages ``       |
| [`1e7550e6`](https://github.com/nix-community/nixvim/commit/1e7550e6a1d66257b35b0af8e059d7008e477687) | `` flake/dev/flake.lock: Update ``                                      |
| [`b2a8e456`](https://github.com/nix-community/nixvim/commit/b2a8e45680c13df3de275faa641f1e4df9890e84) | `` flake.lock: Update ``                                                |
| [`8bcb4c4a`](https://github.com/nix-community/nixvim/commit/8bcb4c4a8cd083bff3e1d00100dc7a40affb3984) | `` plugins/neogen: migrate to mkNeovimPlugin ``                         |